### PR TITLE
additional event handlers

### DIFF
--- a/jarbas_hive_mind/__init__.py
+++ b/jarbas_hive_mind/__init__.py
@@ -109,6 +109,8 @@ class HiveMindConnection:
 
 class HiveMindListener:
     _autorun = True
+    default_factory = HiveMind
+    default_protocol = HiveMindProtocol
 
     def __init__(self, port=DEFAULT_PORT, max_cons=-1, bus=None):
         self.host = "0.0.0.0"
@@ -189,8 +191,8 @@ class HiveMindListener:
         # SSL server context: load server key and certificate
         contextFactory = ssl.DefaultOpenSSLContextFactory(key, cert)
 
-        factory = factory or HiveMind(bus=self.bus)
-        factory.protocol = protocol or HiveMindProtocol
+        factory = factory or self.default_factory(bus=self.bus)
+        factory.protocol = protocol or self.default_protocol
         if self.max_cons >= 0:
             factory.setProtocolOptions(maxConnections=self.max_cons)
         factory.bind(self)
@@ -203,8 +205,8 @@ class HiveMindListener:
 
     def unsafe_listen(self, factory=None, protocol=None):
         self._use_ssl = False
-        factory = factory or HiveMind(bus=self.bus)
-        factory.protocol = protocol or HiveMindProtocol
+        factory = factory or self.default_factory(bus=self.bus)
+        factory.protocol = protocol or self.default_protocol
         if self.max_cons >= 0:
             factory.setProtocolOptions(maxConnections=self.max_cons)
         factory.bind(self)

--- a/jarbas_hive_mind/master/__init__.py
+++ b/jarbas_hive_mind/master/__init__.py
@@ -255,10 +255,10 @@ class HiveMind(WebSocketServerFactory):
             #  if not whitelisted kick
             self.unregister_client(client, reason="Unknown ip")
             return
-        self.handle_register(client, platform)
         self.clients[client.peer] = {"instance": client,
                                      "status": "connected",
                                      "platform": platform}
+        self.handle_register(client, platform)
 
     def handle_unregister(self, client, code, reason, context):
         """ called before unregistering a client, subclasses can take

--- a/jarbas_hive_mind/master/__init__.py
+++ b/jarbas_hive_mind/master/__init__.py
@@ -73,7 +73,7 @@ class HiveMindProtocol(WebSocketServerProtocol):
         self.factory.mycroft_send("hive.client.connect", data, context)
         # return a pair with WS protocol spoken (or None for any) and
         # custom headers to send in initial WS opening handshake HTTP response
-        headers = {"server": platform}
+        headers = {"server": self.platform}
         return (None, headers)
 
     def onOpen(self):

--- a/jarbas_hive_mind/master/__init__.py
+++ b/jarbas_hive_mind/master/__init__.py
@@ -287,6 +287,13 @@ class HiveMind(WebSocketServerFactory):
     def handle_binary_message(self, client, payload):
         """ binary data handler, can be for example an audio stream """
 
+    def handle_message(self, data, client):
+        """ message handler for non default message types, subclasses can
+        handle their own types here
+
+        data contains payload, msg_type, source_peer, route
+        """
+
     def on_message(self, client, payload, isBinary):
         """
        Process message from client, decide what to do internally here
@@ -319,6 +326,8 @@ class HiveMind(WebSocketServerFactory):
                 self.handle_broadcast_message(data, client)
             elif msg_type == "escalate":
                 self.handle_escalate_message(data, client)
+            else:
+                self.handle_message(data, client)
 
     # HiveMind protocol messages -  from DOWNstream
     def handle_bus_message(self, payload, client):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='jarbas_hive_mind',
-    version='0.10.6',
+    version='0.10.7',
     packages=['jarbas_hive_mind',
               'jarbas_hive_mind.master',
               'jarbas_hive_mind.slave',
@@ -18,6 +18,7 @@ setup(
                       "ovos_utils>=0.0.1",
                       "json_database>=0.2.6",
                       "pycryptodome",
+                      "zeroconf>=0.1.6",
                       "upnpclient>=0.0.8"],
     url='https://github.com/JarbasAl/hive_mind',
     license='MIT',


### PR DESCRIPTION
add new event handlers for subclasses to override

see usage here https://github.com/JarbasHiveMind/HiveMind-speech-master/blob/master/hivemind_speech_master/__init__.py

- client register
- client unregister
- binary data received
- message received (non standard, default messages are handled automatically)

make platform a class property
add missing requirement from setup.py
bump version