### PR TITLE
launcher scripts / deprecate mail param / increase RSA key size

### DIFF
--- a/examples/add_keys.py
+++ b/examples/add_keys.py
@@ -3,8 +3,7 @@ from jarbas_hive_mind.database import ClientDatabase
 name = "JarbasCliTerminal"
 key = "RESISTENCEisFUTILE"
 crypto_key = "resistanceISfutile"
-mail = "jarbasaai@mailfence.com"
 
 
 with ClientDatabase() as db:
-    db.add_client(name, mail, key, crypto_key=crypto_key)
+    db.add_client(name, key, crypto_key=crypto_key)

--- a/jarbas_hive_mind/__main__.py
+++ b/jarbas_hive_mind/__main__.py
@@ -1,0 +1,27 @@
+from jarbas_hive_mind import get_listener
+from jarbas_hive_mind.configuration import CONFIGURATION
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description='Start HiveMind as a server')
+    parser.add_argument("--name", help="human readable name")
+    parser.add_argument("--access_key", help="access key")
+    parser.add_argument("--crypto_key", help="payload encryption key")
+    parser.add_argument("--mail", help="human readable mail")
+    parser.add_argument("--port", help="HiveMind port number")
+    args = parser.parse_args()
+    # Check if a user was defined
+    if args.name is not None:
+        from jarbas_hive_mind.database import ClientDatabase
+        with ClientDatabase() as db:
+            db.add_client(args.name, args.mail, args.key, crypto_key=args.crypto_key)
+    config = config or CONFIGURATION
+    listener = get_listener()
+    listener.load_config(config)
+    # Replace defined values
+    if args.port is not None:
+        listener.port = int(args.port)
+    listener.listen()
+
+if __name__ == '__main__':
+    main()

--- a/jarbas_hive_mind/__main__.py
+++ b/jarbas_hive_mind/__main__.py
@@ -14,7 +14,7 @@ def main():
     if args.name is not None:
         from jarbas_hive_mind.database import ClientDatabase
         with ClientDatabase() as db:
-            db.add_client(args.name, args.mail, args.key, crypto_key=args.crypto_key)
+            db.add_client(args.name, args.mail, args.access_key, crypto_key=args.crypto_key)
     config = config or CONFIGURATION
     listener = get_listener()
     listener.load_config(config)

--- a/jarbas_hive_mind/__main__.py
+++ b/jarbas_hive_mind/__main__.py
@@ -7,14 +7,13 @@ def main():
     parser.add_argument("--name", help="human readable name")
     parser.add_argument("--access_key", help="access key")
     parser.add_argument("--crypto_key", help="payload encryption key")
-    parser.add_argument("--mail", help="human readable mail")
     parser.add_argument("--port", help="HiveMind port number")
     args = parser.parse_args()
     # Check if a user was defined
     if args.name is not None:
         from jarbas_hive_mind.database import ClientDatabase
         with ClientDatabase() as db:
-            db.add_client(args.name, args.mail, args.access_key, crypto_key=args.crypto_key)
+            db.add_client(args.name, args.access_key, crypto_key=args.crypto_key)
     config = CONFIGURATION
     listener = get_listener()
     listener.load_config(config)

--- a/jarbas_hive_mind/__main__.py
+++ b/jarbas_hive_mind/__main__.py
@@ -15,7 +15,7 @@ def main():
         from jarbas_hive_mind.database import ClientDatabase
         with ClientDatabase() as db:
             db.add_client(args.name, args.mail, args.access_key, crypto_key=args.crypto_key)
-    config = config or CONFIGURATION
+    config = CONFIGURATION
     listener = get_listener()
     listener.load_config(config)
     # Replace defined values

--- a/jarbas_hive_mind/__main__.py
+++ b/jarbas_hive_mind/__main__.py
@@ -4,22 +4,14 @@ from jarbas_hive_mind.configuration import CONFIGURATION
 def main():
     import argparse
     parser = argparse.ArgumentParser(description='Start HiveMind as a server')
-    parser.add_argument("--name", help="human readable name")
-    parser.add_argument("--access_key", help="access key")
-    parser.add_argument("--crypto_key", help="payload encryption key")
-    parser.add_argument("--port", help="HiveMind port number")
+    parser.add_argument("--port", help="HiveMind port number", type=int)
     args = parser.parse_args()
-    # Check if a user was defined
-    if args.name is not None:
-        from jarbas_hive_mind.database import ClientDatabase
-        with ClientDatabase() as db:
-            db.add_client(args.name, args.access_key, crypto_key=args.crypto_key)
     config = CONFIGURATION
     listener = get_listener()
     listener.load_config(config)
     # Replace defined values
     if args.port is not None:
-        listener.port = int(args.port)
+        listener.port = args.port
     listener.listen()
 
 if __name__ == '__main__':

--- a/jarbas_hive_mind/database/__main__.py
+++ b/jarbas_hive_mind/database/__main__.py
@@ -1,0 +1,23 @@
+import argparse
+from jarbas_hive_mind.database import ClientDatabase
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Modify HiveMind's database")
+    parser.add_argument(
+        "action",
+        help="database action",
+        choices=['add'])
+    parser.add_argument("--name", help="human readable name")
+    parser.add_argument("--access_key", help="access key")
+    parser.add_argument("--crypto_key", help="payload encryption key")
+    args = parser.parse_args()
+    # Check if a user was defined
+    if args.action == 'add':
+        with ClientDatabase() as db:
+            db.add_client(
+                args.name, args.access_key, crypto_key=args.crypto_key)
+
+
+if __name__ == '__main__':
+    main()

--- a/jarbas_hive_mind/database/json_db.py
+++ b/jarbas_hive_mind/database/json_db.py
@@ -5,14 +5,13 @@ from ovos_utils.log import LOG
 
 
 class Client:
-    def __init__(self, client_id, api_key, name="", mail="",
+    def __init__(self, client_id, api_key, name="",
                  description="", is_admin=False, last_seen=-1,
                  blacklist=None, crypto_key=None):
         self.client_id = client_id
         self.description = description
         self.api_key = api_key
         self.name = name
-        self.mail = mail
         self.last_seen = last_seen
         self.is_admin = is_admin
         self.crypto_key = crypto_key
@@ -103,7 +102,7 @@ class JsonClientDatabase(JsonDatabase):
     def get_clients_by_name(self, name):
         return self.search_by_value("name", name)
 
-    def add_client(self, name=None, mail=None, key="",
+    def add_client(self, name=None, key="",
                    admin=None, blacklist=None, crypto_key=None):
 
         user = self.get_client_by_api_key(key)
@@ -113,8 +112,6 @@ class JsonClientDatabase(JsonDatabase):
         if item_id >= 0:
             if name:
                 user["name"] = name
-            if mail:
-                user["mail"] = mail
             if blacklist:
                 user["blacklist"] = blacklist
             if admin is not None:
@@ -123,7 +120,7 @@ class JsonClientDatabase(JsonDatabase):
 
             self.update_item(item_id, user)
         else:
-            user = Client(api_key=key, name=name, mail=mail,
+            user = Client(api_key=key, name=name,
                           blacklist=blacklist, crypto_key=crypto_key,
                           client_id=self.total_clients() + 1,
                           is_admin=admin)
@@ -142,4 +139,3 @@ class JsonClientDatabase(JsonDatabase):
             self.commit()
         except Exception as e:
             LOG.error(e)
-

--- a/jarbas_hive_mind/database/sql_db.py
+++ b/jarbas_hive_mind/database/sql_db.py
@@ -28,7 +28,6 @@ class Client(Base):
     api_key = Column(String)
     name = Column(String)
     crypto_key = Column(String)
-    mail = Column(String)
     last_seen = Column(Integer, default=0)
     is_admin = Column(Boolean, default=False)
     blacklist = Column(Text)  # json string
@@ -105,7 +104,7 @@ class SQLClientDatabase:
             return None
         return user.crypto_key
 
-    def add_client(self, name=None, mail=None, key="", admin=False,
+    def add_client(self, name=None, key="", admin=False,
                    blacklist="{}", crypto_key=None):
         if isinstance(blacklist, dict):
             blacklist = json.dumps(blacklist)
@@ -115,12 +114,11 @@ class SQLClientDatabase:
             crypto_key = crypto_key[:16]
         if user:
             user.name = name
-            user.mail = mail
             user.blacklist = blacklist
             user.is_admin = admin
             user.crypto_key = crypto_key if crypto_key else user.crypto_key
         else:
-            user = Client(api_key=key, name=name, mail=mail,
+            user = Client(api_key=key, name=name,
                           blacklist=blacklist, crypto_key=crypto_key,
                           client_id=self.total_clients() + 1,
                           is_admin=admin)
@@ -152,4 +150,3 @@ class SQLClientDatabase:
             LOG.error(e)
         finally:
             self.close()
-

--- a/jarbas_hive_mind/utils/__init__.py
+++ b/jarbas_hive_mind/utils/__init__.py
@@ -38,7 +38,7 @@ def create_self_signed_cert(cert_dir=CERTS_PATH, name="jarbas_hivemind"):
             or not exists(join(cert_dir, KEY_FILE)):
         # create a key pair
         k = crypto.PKey()
-        k.generate_key(crypto.TYPE_RSA, 1024)
+        k.generate_key(crypto.TYPE_RSA, 2048)
 
         # create a self-signed cert
         cert = crypto.X509()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     license='MIT',
     author='jarbasAI',
     author_email='jarbasai@mailfence.com',
-    description='Mesh Networking utilities for mycroft core'
+    description='Mesh Networking utilities for mycroft core',
     entry_points={
         'console_scripts': [
             'HiveMind-server=jarbas_hive_mind.__main__:main'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='jarbas_hive_mind',
-    version='0.10.8',
+    version='0.10.9',
     packages=['jarbas_hive_mind',
               'jarbas_hive_mind.nodes',
               'jarbas_hive_mind.configuration',
@@ -28,4 +28,9 @@ setup(
     author='jarbasAI',
     author_email='jarbasai@mailfence.com',
     description='Mesh Networking utilities for mycroft core'
+    entry_points={
+        'console_scripts': [
+            'HiveMind-server=jarbas_hive_mind.__main__:main'
+        ]
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     description='Mesh Networking utilities for mycroft core',
     entry_points={
         'console_scripts': [
-            'HiveMind-server=jarbas_hive_mind.__main__:main'
+            'HiveMind-server=jarbas_hive_mind.__main__:main',
+            'HiveMind-database=jarbas_hive_mind.database.__main__:main'
         ]
     }
 )


### PR DESCRIPTION
RSA key length set to 2048 to avoid "low security" error messages in some devices such as Raspberry Pi's.
Also included __main__.py to launch a HiveMind server.
Can be called like: ```HiveMind-server``` and accepts the flags ```--port PORT``` to define the listening port and ```--name NAME --access_key ACCESS_KEY --crypto_key CRYPTO_KEY --mail MAIL``` to define a new user in the users database before running the server.
When defining a new user, only ```--name``` and ```--access_key``` are required.