### PR TITLE
[requirements] Add missing pyOpenSSL

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ poorman_handshake>=0.1.0
 click
 click_default_group
 rich
+pyOpenSSL


### PR DESCRIPTION
Fix this error:

```
(hivemind) pi@rpi4b01:~ $ hivemind-core listen 
Traceback (most recent call last):
  File "/home/pi/.venv/hivemind/bin/hivemind-core", line 11, in <module>
    load_entry_point('jarbas-hive-mind==0.13.0a1', 'console_scripts', 'hivemind-core')()
  File "/home/pi/.venv/hivemind/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/pi/.venv/hivemind/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/pi/.venv/hivemind/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/pi/.venv/hivemind/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/pi/.venv/hivemind/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/pi/.venv/hivemind/lib/python3.9/site-packages/hivemind_core/scripts.py", line 103, in listen
    from hivemind_core.service import HiveMindService
  File "/home/pi/.venv/hivemind/lib/python3.9/site-packages/hivemind_core/service.py", line 12, in <module>
    from OpenSSL import crypto
ModuleNotFoundError: No module named 'OpenSSL'
```