### PR TITLE
filter allowed_types

### DIFF
--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -9,7 +9,8 @@ from ovos_utils.log import LOG
 def cast_to_client_obj():
     valid_kwargs: Iterable[str] = ("client_id", "api_key", "name",
                                    "description", "is_admin", "last_seen",
-                                   "blacklist", "crypto_key", "password")
+                                   "blacklist", "allowed_types", "crypto_key",
+                                   "password")
 
     def _handler(func):
 
@@ -46,6 +47,7 @@ class Client:
                  is_admin: bool = False,
                  last_seen: float = -1,
                  blacklist: Optional[Dict[str, List[str]]] = None,
+                 allowed_types: Optional[List[str]] = None,
                  crypto_key: Optional[str] = None,
                  password: Optional[str] = None):
 
@@ -62,6 +64,9 @@ class Client:
             "skills": [],
             "intents": []
         }
+        self.allowed_types = allowed_types or ["recognizer_loop:utterance"]
+        if "recognizer_loop:utterance" not in self.allowed_types:
+            self.allowed_types.append("recognizer_loop:utterance")
 
     def __getitem__(self, item: str) -> Any:
         return self.__dict__.get(item)
@@ -179,6 +184,7 @@ class ClientDatabase(JsonDatabaseXDG):
                    key: str = "",
                    admin: bool = False,
                    blacklist: Optional[Dict[str, Any]] = None,
+                   allowed_types: Optional[List[str]] = None,
                    crypto_key: Optional[str] = None,
                    password: Optional[str] = None) -> Client:
 
@@ -191,6 +197,8 @@ class ClientDatabase(JsonDatabaseXDG):
                 user["name"] = name
             if blacklist:
                 user["blacklist"] = blacklist
+            if allowed_types:
+                user["allowed_types"] = allowed_types
             if admin is not None:
                 user["is_admin"] = admin
             if crypto_key:
@@ -202,7 +210,8 @@ class ClientDatabase(JsonDatabaseXDG):
             user = Client(api_key=key, name=name,
                           blacklist=blacklist, crypto_key=crypto_key,
                           client_id=self.total_clients() + 1,
-                          is_admin=admin, password=password)
+                          is_admin=admin, password=password,
+                          allowed_types=allowed_types)
             self.add_item(user)
         return user
 

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -137,11 +137,12 @@ class MessageBusEventHandler(WebSocketHandler):
                 self.close()
                 return
 
-            self.client.crypto_key = users.get_crypto_key(key)
-            pswd = users.get_password(key)
-            if pswd:
+            self.client.crypto_key = user.crypto_key
+            self.client.blacklist = user.blacklist.get("messages", [])
+            self.client.allowed_types = user.allowed_types
+            if user.password:
                 # pre-shared password to derive aes_key
-                self.client.pswd_handshake = PasswordHandShake(pswd)
+                self.client.pswd_handshake = PasswordHandShake(user.password)
 
             self.client.node_type = HiveMindNodeType.NODE  # TODO . placeholder
 


### PR DESCRIPTION
Introduces `allowed_types`, a list of message types that get permitted to be sent to the master
Defaults to only "recognizer_loop:utterance" if no additional msg_type is added to the node client (db) configuration

new allowed types should be added per cli (not per config) to avoid overrides
<img width="475" alt="Screenshot 2023-06-21 173531" src="https://github.com/JarbasHiveMind/HiveMind-core/assets/25036977/754c3635-d16c-4e97-8203-fae973dbd722">

## changes
- blacklist: this filter was brought up to the `send` block as defined
> list of ovos message_type to never be sent to this client
- revert the factory/type annotation `clients: dict = field(default_factory=dict)` in `HiveMindListenerProtocol` as this interferes with
https://github.com/JarbasHiveMind/HiveMind-core/blob/4d367c8dfa94543f3724257240a978e0593e19a6/hivemind_core/protocol.py#L112-L113
This should be handled differently
