### PR TITLE
fix/allow_audio_state_messages_for_session

### DIFF
--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -74,7 +74,11 @@ class Client:
         self.crypto_key = crypto_key
         self.password = password
         self.blacklist = blacklist or {"messages": [], "skills": [], "intents": []}
-        self.allowed_types = allowed_types or ["recognizer_loop:utterance"]
+        self.allowed_types = allowed_types or ["recognizer_loop:utterance", 
+                                               "recognizer_loop:record_begin", 
+                                               "recognizer_loop:record_end", 
+                                               "recognizer_loop:audio_output_start", 
+                                               "recognizer_loop:audio_output_end"]
         if "recognizer_loop:utterance" not in self.allowed_types:
             self.allowed_types.append("recognizer_loop:utterance")
         self.can_broadcast = can_broadcast


### PR DESCRIPTION
companion to https://github.com/OpenVoiceOS/ovos-bus-client/pull/93

by default allows voice sats to report if they are recording/playing audio, exposing that info to Session

avoids the need of configuring devices individually by default
```
$hivemind-core allow-msg "recognizer_loop:record_begin"
$hivemind-core allow-msg "recognizer_loop:record_end"
$hivemind-core allow-msg "recognizer_loop:audio_output_start"
$hivemind-core allow-msg "recognizer_loop:audio_output_end"
```