### PR TITLE
fix:allow b64 by default

### DIFF
--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -79,6 +79,8 @@ class Client:
                                                "recognizer_loop:record_end", 
                                                "recognizer_loop:audio_output_start", 
                                                "recognizer_loop:audio_output_end",
+                                               'recognizer_loop:b64_transcribe',
+                                               'speak:b64_audio',
                                                "ovos.common_play.SEI.get.response"]
         if "recognizer_loop:utterance" not in self.allowed_types:
             self.allowed_types.append("recognizer_loop:utterance")

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -15,10 +15,10 @@ def hmcore_cmds():
 
 
 @hmcore_cmds.command(help="add credentials for a client", name="add-client")
-@click.argument("name", required=False, type=str)
-@click.argument("access_key", required=False, type=str)
-@click.argument("password", required=False, type=str)
-@click.argument("crypto_key", required=False, type=str)
+@click.option("--name", required=False, type=str)
+@click.option("--access-key", required=False, type=str)
+@click.option("--password", required=False, type=str)
+@click.option("--crypto-key", required=False, type=str)
 def add_client(name, access_key, password, crypto_key):
     key = crypto_key
     if key:


### PR DESCRIPTION
skip the need for running `$ hivemind-core allow-msg "speak:b64_audio" ` in hivemind-core

companion to https://github.com/OpenVoiceOS/ovos-dinkum-listener/pull/152 and https://github.com/OpenVoiceOS/ovos-audio/pull/107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded client interaction types to include `'recognizer_loop:b64_transcribe'` and `'speak:b64_audio'`.
	- Enhanced command-line interface for the `add-client` command by transitioning from positional arguments to named options, improving usability.

- **Bug Fixes**
	- Implemented a constraint on the `crypto_key` length during client addition to a maximum of 16 characters.

- **Documentation**
	- Updated command options in the CLI to provide clearer instructions and deprecation warnings for `crypto_key`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->