### PR TITLE
fix: bind hm_protocol to agent_protocol

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -365,6 +365,7 @@ class HiveMindListenerProtocol:
     ):
         assert message.msg_type == HiveMessageType.BINARY
         bin_data = message.payload
+        # TODO - split binary handlers protocol too
         if message.bin_type == HiveMindBinaryPayloadType.RAW_AUDIO:
             sr = message.metadata.get("sample_rate", 16000)
             sw = message.metadata.get("sample_width", 2)

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -125,6 +125,9 @@ class HiveMindService:
         hm_protocol = self.hm_protocol(identity=self.identity,
                                        db=self.db,
                                        agent_protocol=agent_protocol)
+        agent_protocol.hm_protocol = hm_protocol # allow it to reference clients/database/identity
+
+        # start network protocol that will deliver HiveMessages
         network_protocol = self.network_protocol(hm_protocol=hm_protocol,
                                                  config=self.network_config)
 
@@ -133,7 +136,6 @@ class HiveMindService:
         self._presence.start()
         self._status.set_ready()
 
-        # start network protocol that will deliver HiveMessages
         network_protocol.run()  # blocking
 
         self._status.set_stopping()


### PR DESCRIPTION
allow subclasses to reference clients/db/identity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced interaction between the agent protocol and the HiveMind protocol by establishing a direct link.
- **Documentation**
	- Added a comment to clarify the future refactoring of binary message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->