### PR TITLE
fix:binarization_protocol

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -5,6 +5,9 @@ from ovos_utils.xdg_utils import xdg_config_home, xdg_data_home
 
 
 _DEFAULT = {
+    # enable the hivemind binarization protocol
+    "binarize": False,  # default False because of a bug in old hivemind-bus-client versions
+
     # sort encodings by order of preference
     "allowed_encodings": ["JSON-Z85B", "JSON-B64", "JSON-HEX"],
     "allowed_ciphers": ["CHACHA20-POLY1305", 'AES-GCM'],


### PR DESCRIPTION
should default to True once https://github.com/JarbasHiveMind/hivemind-websocket-client/pull/53 has been widely adopted

further reduces message size even more #40 

```
# AES-GCM + JSON-B64
# 2025-01-03 02:34:16.164 - HiveMind - hivemind_core.protocol:send:129 - DEBUG - unencrypted binary payload size: 565 bytes
# 2025-01-03 02:34:16.165 - HiveMind - hivemind_core.protocol:send:138 - DEBUG - encrypted payload size: 597 bytes

# AES-GCM + JSON-Z85B
# 2025-01-03 02:39:10.707 - HiveMind - hivemind_core.protocol:send:129 - DEBUG - unencrypted binary payload size: 565 bytes
# 2025-01-03 02:39:10.708 - HiveMind - hivemind_core.protocol:send:138 - DEBUG - encrypted payload size: 597 bytes

# AES-GCM + JSON-HEX
# 2025-01-03 02:39:46.958 - HiveMind - hivemind_core.protocol:send:129 - DEBUG - unencrypted binary payload size: 566 bytes
# 2025-01-03 02:39:46.958 - HiveMind - hivemind_core.protocol:send:138 - DEBUG - encrypted payload size: 598 bytes

# CHACHA20-POLY1305 + JSON-B64
# 2025-01-03 02:37:37.400 - HiveMind - hivemind_core.protocol:send:129 - DEBUG - unencrypted binary payload size: 566 bytes
# 2025-01-03 02:37:37.401 - HiveMind - hivemind_core.protocol:send:138 - DEBUG - encrypted payload size: 594 bytes

# CHACHA20-POLY1305 + JSON-Z85B
# 2025-01-03 02:37:37.400 - HiveMind - hivemind_core.protocol:send:129 - DEBUG - unencrypted binary payload size: 564 bytes
# 2025-01-03 02:37:37.401 - HiveMind - hivemind_core.protocol:send:138 - DEBUG - encrypted payload size: 592 bytes

# CHACHA20-POLY1305 + JSON-HEX
# 2025-01-03 02:40:32.333 - HiveMind - hivemind_core.protocol:send:129 - DEBUG - unencrypted binary payload size: 564 bytes
# 2025-01-03 02:40:32.333 - HiveMind - hivemind_core.protocol:send:138 - DEBUG - encrypted payload size: 592 bytes
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added a new configuration option `binarize` with a default value of `False`
	- Enhanced protocol flexibility for binary data handling

- **Protocol Improvements**
	- Dynamically set binary data transmission settings based on server configuration
	- Allow more configurable client-server communication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->