### PR TITLE
feat:multiple_net_protos

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -9,7 +9,10 @@ _DEFAULT = {
     "binarize": False,  # default False because of a bug in old hivemind-bus-client versions
 
     # sort encodings by order of preference
-    "allowed_encodings": ["JSON-Z85B", "JSON-B64", "JSON-HEX"],
+    "allowed_encodings": ["JSON-B64", "JSON-URLSAFE-B64",
+                          "JSON-B91",
+                          "JSON-Z85B", "JSON-Z85P",
+                          "JSON-B32", "JSON-HEX"],
     "allowed_ciphers": ["CHACHA20-POLY1305", 'AES-GCM'],
 
     # configure various plugins
@@ -19,10 +22,16 @@ _DEFAULT = {
                            "port": 8181
                        }},
     "binary_protocol": {"module": None},
-    "network_protocol": {"module": "hivemind-websocket-plugin",
-                         "hivemind-websocket-plugin": {
+    "network_protocol": {"hivemind-websocket-plugin": {
                              "host": "0.0.0.0",
                              "port": 5678,
+                             "ssl": False,
+                             "cert_dir": f"{xdg_data_home()}/hivemind",
+                             "cert_name": "hivemind"
+                         },
+                         "hivemind-http-plugin": {
+                             "host": "0.0.0.0",
+                             "port": 5679,
                              "ssl": False,
                              "cert_dir": f"{xdg_data_home()}/hivemind",
                              "cert_name": "hivemind"
@@ -41,6 +50,7 @@ def get_server_config() -> JsonStorageXDG:
     if not os.path.isfile(db.path):
         db.merge(_DEFAULT)
         db.store()
+    # ensure all top level keys are present
     for k, v in _DEFAULT.items():
         if k not in db:
             db[k] = v

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -126,6 +126,11 @@ class HiveMindService:
             except:
                 LOG.exception(f"Failed to load plugin '{plug_name}'")
 
+        if not protos:
+            LOG.error("No network protocols were loaded. Exiting service.")
+            self._status.set_stopping()
+            return
+
         for network_protocol in protos:
             create_daemon(network_protocol.run)
 

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -1,6 +1,7 @@
 import dataclasses
 from typing import Callable, Optional, Type
 
+from ovos_utils import create_daemon, wait_for_exit_signal
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
 
@@ -15,12 +16,6 @@ def get_agent_protocol():
     config = get_server_config()["agent_protocol"]
     name = config["module"]
     return AgentProtocolFactory.get_class(name), config.get(name, {})
-
-
-def get_network_protocol():
-    config = get_server_config()["network_protocol"]
-    name = config["module"]
-    return NetworkProtocolFactory.get_class(name), config.get(name, {})
 
 
 def get_binary_protocol():
@@ -121,14 +116,21 @@ class HiveMindService:
                                        binary_data_protocol=bin_protocol,
                                        agent_protocol=agent_protocol)
 
-        # start network protocol that will deliver HiveMessages
-        network_class, net_config = get_network_protocol()
-        LOG.info(f"Network protocol: {network_class.__name__}")
+        # start network protocols that will carry HiveMessages
+        protos = []
+        for plug_name, plug_conf in get_server_config()["network_protocol"].items():
+            try:
+                network_class = NetworkProtocolFactory.get_class(plug_name)
+                LOG.info(f"Network protocol: {network_class.__name__}")
+                protos.append(network_class(hm_protocol=hm_protocol, config=plug_conf))
+            except:
+                LOG.exception(f"Failed to load plugin '{plug_name}'")
 
-        network_protocol = network_class(hm_protocol=hm_protocol, config=net_config)
+        for network_protocol in protos:
+            create_daemon(network_protocol.run)
 
         self._status.set_ready()
 
-        network_protocol.run()  # blocking
+        wait_for_exit_signal()  # block until ctrl+c
 
         self._status.set_stopping()


### PR DESCRIPTION
eg, allow http + websockets to be used at same time instead of requiring 2 hivemind-core processes

deprecates "module" and instead loads all protocols defined in config

```
    "network_protocol": {"module":  "hivemind-http-plugin",
                         "hivemind-http-plugin": {
                             "host": "0.0.0.0",
                             "port": 5679
                         }},
 ```
 becomes
```
    "network_protocol": {"hivemind-websocket-plugin": {
                             "host": "0.0.0.0",
                             "port": 5678
                         },
                         "hivemind-http-plugin": {
                             "host": "0.0.0.0",
                             "port": 5679
                         }},
 ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
	- Expanded encoding formats with new JSON-based encoding options
	- Added configuration support for HTTP plugin alongside existing WebSocket plugin
	- Enhanced network protocol configuration management

- **Service Improvements**
	- Implemented support for multiple network protocol configurations
	- Updated network protocol instantiation and thread management
	- Improved error handling for network protocol loading
<!-- end of auto-generated comment: release notes by coderabbit.ai -->