### PR TITLE
refactor: allow "default" session for clients

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -7,11 +7,11 @@ jobs:
   build_tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install Build Tools

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -23,7 +23,7 @@ jobs:
     needs: publish_alpha
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Send message to Matrix bots channel
         id: matrix-chat-message
         uses: fadenb/matrix-chat-message@v0.0.6
@@ -39,12 +39,12 @@ jobs:
     if: success()  # Ensure this job only runs if the previous job succeeds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install Build Tools

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -541,29 +541,15 @@ class HiveMindListenerProtocol:
             LOG.warning(f"client did NOT send public key")
 
         LOG.debug(f"client site_id: {client.sess.site_id}")
-        if client.sess.session_id != "default":
-            LOG.debug(f"client session_id: {client.sess.session_id}")
-            self.clients[client.peer] = client
-        else:
-            LOG.warning("client did not send a session after it's handshake")
+        LOG.debug(f"client session_id: {client.sess.session_id}")
+        self.clients[client.peer] = client
 
     def handle_bus_message(
             self, message: HiveMessage, client: HiveMindClientConnection
     ):
         # track any Session updates from client side
         sess = Session.from_message(message.payload)
-        if client.sess.session_id == "default":
-            LOG.warning(f"{client.peer} did not send a Session via handshake")
-            if sess.session_id == "default":
-                client.sess.session_id = str(uuid.uuid4())
-                LOG.debug(f"Client session_id randomly generated: {client.sess.session_id}")
-            else:
-                client.sess.session_id = sess.session_id
-                LOG.debug(f"Client session_id assigned via client first message: {client.sess.session_id}")
-            self.clients[client.peer] = client
 
-        if sess.session_id == "default":
-            sess.session_id = client.sess.session_id
         if client.sess.session_id == sess.session_id:
             client.sess = sess
             LOG.debug(f"Client session updated from payload: {sess.serialize()}")

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -547,6 +547,7 @@ class HiveMindListenerProtocol:
 
         LOG.debug(f"client site_id: {client.sess.site_id}")
         LOG.debug(f"client session_id: {client.sess.session_id}")
+        LOG.debug(f"client is_admin: {client.is_admin}")
         if client.sess.session_id == "default" and not client.is_admin:
             LOG.warning("Client requested 'default' session, but is not an administrator")
             client.disconnect()

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -549,8 +549,12 @@ class HiveMindListenerProtocol:
     ):
         # track any Session updates from client side
         sess = Session.from_message(message.payload)
+        if sess.session_id == "default" and not client.is_admin:
+            LOG.warning("Client tried to inject 'default' session message, action only allowed for administrators!")
+            client.disconnect()
+            return
 
-        if client.sess.session_id == sess.session_id:
+        if sess.session_id != "default" and client.sess.session_id == sess.session_id:
             client.sess = sess
             LOG.debug(f"Client session updated from payload: {sess.serialize()}")
 

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -547,7 +547,11 @@ class HiveMindListenerProtocol:
 
         LOG.debug(f"client site_id: {client.sess.site_id}")
         LOG.debug(f"client session_id: {client.sess.session_id}")
-        self.clients[client.peer] = client
+        if client.sess.session_id == "default" and not client.is_admin:
+            LOG.warning("Client requested 'default' session, but is not an administrator")
+            client.disconnect()
+        else:
+            self.clients[client.peer] = client
 
     def handle_bus_message(
             self, message: HiveMessage, client: HiveMindClientConnection

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -554,11 +554,11 @@ class HiveMindListenerProtocol:
     ):
         # track any Session updates from client side
         """
-            Handles internal bus messages from a client, enforcing session restrictions and forwarding to the agent bus.
-            
-            If a non-admin client attempts to use the "default" session ID, the client is disconnected. Otherwise, updates the client's session if the session ID matches and is not "default", then injects the message into the internal agent bus and invokes the agent bus callback if set.
-            """
-            sess = Session.from_message(message.payload)
+        Handles internal bus messages from a client, enforcing session restrictions and forwarding to the agent bus.
+
+        If a non-admin client attempts to use the "default" session ID, the client is disconnected. Otherwise, updates the client's session if the session ID matches and is not "default", then injects the message into the internal agent bus and invokes the agent bus callback if set.
+        """
+        sess = Session.from_message(message.payload)
         if sess.session_id == "default" and not client.is_admin:
             LOG.warning("Client tried to inject 'default' session message, action only allowed for administrators!")
             client.disconnect()

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -145,6 +145,8 @@ def rename_client(node_id, name):
                 db.update_item(client)
                 print(f"Renamed '{old_name}' to {name}")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="Give administrator powers to a client in the database.", name="make-admin")
@@ -186,6 +188,8 @@ def revoke_admin(node_id):
                 db.update_item(client)
                 print(f"Revoked administrator powers for {client.name}")
                 break
+        else:
+           print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="Remove credentials for a client.", name="delete-client")
@@ -281,6 +285,8 @@ def allow_msg(msg_type, node_id):
                 db.update_item(client)
                 print(f"Allowed '{msg_type}' for {client.name}")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="Blacklist a message type from a client.", name="blacklist-msg")
@@ -304,6 +310,8 @@ def blacklist_msg(msg_type, node_id):
                     return
                 print(f"Client '{client.name}' message already blacklisted: '{msg_type}'")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="Allow 'ESCALATE' messages to be sent from a client.", name="allow-escalate")
@@ -321,6 +329,8 @@ def allow_escalate(node_id):
                 db.update_item(client)
                 print(f"Allowed 'ESCALATE' messages for {client.name}")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="blacklist 'ESCALATE' messages from being sent by a client", name="blacklist-escalate")
@@ -337,6 +347,8 @@ def blacklist_escalate(node_id):
                     return
                 print(f"Client '{client.name}' 'ESCALATE' messages already blacklisted")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="allow 'PROPAGATE' messages to be sent from a client", name="allow-propagate")
@@ -353,6 +365,8 @@ def allow_propagate(node_id):
                 db.update_item(client)
                 print(f"Allowed 'PROPAGATE' messages for {client.name}")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="blacklist 'PROPAGATE' messages from being sent by a client", name="blacklist-propagate")
@@ -369,6 +383,8 @@ def blacklist_propagate(node_id):
                     return
                 print(f"Client '{client.name}' 'PROPAGATE' messages already blacklisted")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 ##########################
@@ -390,6 +406,8 @@ def blacklist_skill(skill_id, node_id):
                 db.update_item(client)
                 print(f"Blacklisted '{skill_id}' for {client.name}")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="remove skills from a client blacklist", name="allow-skill")
@@ -407,6 +425,8 @@ def unblacklist_skill(skill_id, node_id):
                 db.update_item(client)
                 print(f"Blacklisted '{skill_id}' for {client.name}")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="blacklist intents from being triggered by a client", name="blacklist-intent")
@@ -424,6 +444,8 @@ def blacklist_intent(intent_id, node_id):
                 db.update_item(client)
                 print(f"Blacklisted '{intent_id}' for {client.name}")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 @hmcore_cmds.command(help="remove intents from a client blacklist", name="allow-intent")
@@ -441,6 +463,8 @@ def unblacklist_intent(intent_id, node_id):
                 db.update_item(client)
                 print(f"Unblacklisted '{intent_id}' for {client.name}")
                 break
+        else:
+            print("Invalid Node ID!")
 
 
 if __name__ == "__main__":

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -12,13 +12,16 @@ from hivemind_core.config import get_server_config
 
 
 def prompt_node_id(db: ClientDatabase) -> int:
-    """Prompt the user to select a client ID from the database.
-
+    """
+    Prompts the user to select a client ID from the database, displaying available clients in a table.
+    
+    If no clients are found, prints a message and exits. If multiple clients exist, presents a selection prompt; otherwise, selects the only available client.
+    
     Args:
-        db (ClientDatabase): The client database.
-
+        db: The client database to query.
+    
     Returns:
-        int: The selected client ID.
+        The selected client ID as an integer.
     """
     table = Table(title="HiveMind Clients")
     table.add_column("ID", justify="right", style="cyan", no_wrap=True)
@@ -55,13 +58,20 @@ def prompt_node_id(db: ClientDatabase) -> int:
 
 @click.group(help="HiveMind-core admin CLI.")
 def hmcore_cmds():
-    """Main command group for HiveMind admin tasks."""
+    """
+    Main command group for HiveMind-core server administration.
+    
+    This group organizes CLI commands for managing clients, permissions, and server
+    configuration in the HiveMind-core environment.
+    """
     pass
 
 
 @hmcore_cmds.command(help="Print HiveMind server configuration.")
 def print_config():
-    """Print the server's current configuration as JSON."""
+    """
+    Prints the current HiveMind server configuration as formatted JSON to the console.
+    """
     cfg = get_server_config()
     cfg = json.dumps(cfg, indent=2, ensure_ascii=False)
     console = Console()
@@ -70,7 +80,9 @@ def print_config():
 
 @hmcore_cmds.command(help="Start listening for HiveMind connections.", name="listen")
 def listen():
-    """Start the HiveMind service and begin accepting connections."""
+    """
+    Starts the HiveMind service and begins accepting client connections.
+    """
     service = HiveMindService()
     service.run()
 
@@ -82,7 +94,23 @@ def listen():
 @click.option("--crypto-key", required=False, type=str)
 @click.option("--admin", default=False, required=False, type=bool)
 def add_client(name, access_key, password, crypto_key, admin):
-    """Add a new client to the database, generating credentials if necessary."""
+    """
+    Adds a new client to the database, generating credentials if not provided.
+    
+    If a crypto key is supplied, validates its length and warns about deprecation.
+    Random credentials are generated for any missing values. Prints the new client's
+    credentials and admin status after successful addition.
+    
+    Args:
+        name: Optional friendly name for the client. If not provided, a default is generated.
+        access_key: Optional API access key. If not provided, a random key is generated.
+        password: Optional password. If not provided, a random password is generated.
+        crypto_key: Optional 16-character encryption key. If not provided, a random key is generated.
+        admin: Boolean indicating whether the client should have administrator privileges.
+    
+    Raises:
+        ValueError: If the crypto key is not exactly 16 characters, or if the client cannot be added.
+    """
     key = crypto_key
     if key:
         print(
@@ -130,11 +158,10 @@ def add_client(name, access_key, password, crypto_key, admin):
 @click.argument("node_id", required=False, type=int)
 @click.option("--name", required=False, type=str, help="The new friendly name for the client")
 def rename_client(node_id, name):
-    """Rename an existing client.
-
-    Args:
-        node_id (int): The ID of the client to rename.
-        name (str): The new name for the client.
+    """
+    Renames a client in the database to a new name.
+    
+    If node_id is not provided, prompts the user to select a client. Updates the client's name and prints a confirmation.
     """
     with ClientDatabase() as db:
         node_id = node_id or prompt_node_id(db)
@@ -152,10 +179,10 @@ def rename_client(node_id, name):
 @hmcore_cmds.command(help="Give administrator powers to a client in the database.", name="make-admin")
 @click.argument("node_id", required=False, type=int)
 def make_admin(node_id):
-    """Give administrator powers to an existing client.
-
-    Args:
-        node_id (int): The ID of the client to rename.
+    """
+    Grants administrator privileges to a client.
+    
+    If the client is already an administrator, notifies the user; otherwise, updates the client's admin status.
     """
     with ClientDatabase() as db:
         node_id = node_id or prompt_node_id(db)
@@ -172,10 +199,10 @@ def make_admin(node_id):
 @hmcore_cmds.command(help="Revoke administrator powers from a client in the database.", name="revoke-admin")
 @click.argument("node_id", required=False, type=int)
 def revoke_admin(node_id):
-    """Revoke administrator powers from an existing client.
-
-    Args:
-        node_id (int): The ID of the client to rename.
+    """
+    Revokes administrator privileges from a client.
+    
+    If the client is currently an administrator, their admin status is removed. If the client is not an administrator, a message is printed indicating no change.
     """
     with ClientDatabase() as db:
         node_id = node_id or prompt_node_id(db)
@@ -195,10 +222,10 @@ def revoke_admin(node_id):
 @hmcore_cmds.command(help="Remove credentials for a client.", name="delete-client")
 @click.argument("node_id", required=False, type=int)
 def delete_client(node_id):
-    """Delete a client's credentials from the database.
-
-    Args:
-        node_id (int): The ID of the client to delete.
+    """
+    Deletes a client's credentials from the database by node ID.
+    
+    If no node ID is provided, prompts the user to select a client. Prints the revoked credentials upon successful deletion, or an error message if the node ID is invalid.
     """
     with ClientDatabase() as db:
         node_id = node_id or prompt_node_id(db)
@@ -218,7 +245,11 @@ def delete_client(node_id):
 
 @hmcore_cmds.command(help="List all clients and their credentials.", name="list-clients")
 def list_clients():
-    """List all clients currently stored in the database."""
+    """
+    Displays a formatted table of all clients and their credentials stored in the database.
+    
+    Excludes clients with a client ID of -1 from the listing. The table includes each client's ID, name, access key, password, and crypto key.
+    """
     console = Console()
     table = Table(title="HiveMind Credentials:")
     table.add_column("ID", justify="center")
@@ -244,10 +275,13 @@ def list_clients():
 @hmcore_cmds.command(help="Export clients and credentials to a CSV file.", name="export-clients")
 @click.option("--path", required=False, type=str)
 def export_clients(path):
-    """Export client credentials to a CSV file.
-
+    """
+    Exports all client credentials to a CSV file or prints them to stdout.
+    
+    If a directory path is provided, the CSV will be saved as 'hivemind_clients.csv' in that directory. If a file path is provided, the CSV will be saved to that file. If no path is given, the CSV content is printed to stdout. Excludes clients with client_id == -1.
+    
     Args:
-        path (str): Optional path where the CSV will be saved. If not set will print to stdout
+        path: Optional file or directory path for the CSV output.
     """
     if path and os.path.isdir(path):
         path = os.path.join(path, "hivemind_clients.csv")
@@ -268,11 +302,14 @@ def export_clients(path):
 @click.argument("msg_type", required=True, type=str)
 @click.argument("node_id", required=False, type=int)
 def allow_msg(msg_type, node_id):
-    """Allow a specific message type for a client.
-
+    """
+    Allows a specific message type for a client.
+    
+    If the client does not already have the message type in their allowed list, it is added and the change is saved. If the message type is already allowed, a notice is printed and the operation exits.
+    
     Args:
-        msg_type (str): The message type to allow.
-        node_id (int): The ID of the client.
+        msg_type: The message type to allow for the client.
+        node_id: The ID of the client to update. If not provided, prompts for selection.
     """
     with ClientDatabase() as db:
         node_id = node_id or prompt_node_id(db)
@@ -293,11 +330,10 @@ def allow_msg(msg_type, node_id):
 @click.argument("msg_type", required=True, type=str)
 @click.argument("node_id", required=False, type=int)
 def blacklist_msg(msg_type, node_id):
-    """Blacklist a specific message type from a client.
-
-    Args:
-        msg_type (str): The message type to blacklist.
-        node_id (int): The ID of the client.
+    """
+    Removes a specific message type from a client's allowed list, effectively blacklisting it.
+    
+    If the client does not currently allow the specified message type, a notice is printed.
     """
     with ClientDatabase() as db:
         node_id = node_id or prompt_node_id(db)
@@ -317,7 +353,11 @@ def blacklist_msg(msg_type, node_id):
 @hmcore_cmds.command(help="Allow 'ESCALATE' messages to be sent from a client.", name="allow-escalate")
 @click.argument("node_id", required=False, type=int)
 def allow_escalate(node_id):
-    """Allow a client to send 'ESCALATE' messages."""
+    """
+    Grants a client permission to send 'ESCALATE' messages.
+    
+    If the client is already allowed, notifies the user and exits. Otherwise, updates the client's permissions to allow 'ESCALATE' messages and confirms the change.
+    """
     with ClientDatabase() as db:
         node_id = node_id or prompt_node_id(db)
         for client in db:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pybase64
 hivemind-plugin-manager>=0.3.0,<1.0.0
 ovos-bus-client>=1.3.1,<2.0.0
 json-database>=0.9.1,<1.0.0
-hivemind-websocket-protocol>=0.0.2,<1.0.0
+hivemind-websocket-protocol>=0.0.3,<1.0.0
 setuptools


### PR DESCRIPTION
dont force reassign one, clients like HomeAssistant want to query info from "default" and can't otherwise

eg. OCP media player in music assistant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined session handling by enforcing stricter validation of session IDs and simplifying client registration during connections.  
- **New Features**
  - Added administrator privileges management commands to the CLI, including granting and revoking admin rights.  
  - Introduced client export functionality to output client credentials as CSV.  
- **Documentation**
  - Enhanced CLI commands with detailed descriptions and improved help text for better usability.  
- **Chores**
  - Updated GitHub Actions workflows to use newer versions of checkout and Python setup actions for improved compatibility.  
  - Bumped version constraint for a key package in requirements for better dependency management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->