### PR TITLE
fix: preserve client session pipeline

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -581,19 +581,24 @@ class HiveMindListenerProtocol:
 
         If a non-admin client attempts to use the "default" session ID, the client is disconnected. Otherwise, updates the client's session if the session ID matches and is not "default", then injects the message into the internal agent bus and invokes the agent bus callback if set.
         """
-        sess = Session.from_message(message.payload)
+        payload = message.payload
+        raw_session = payload.context.get("session") or {}
+        sent_pipeline = isinstance(raw_session, dict) and "pipeline" in raw_session
+        sess = Session.from_message(payload)
         if sess.session_id == "default" and not client.is_admin:
             LOG.warning("Client tried to inject 'default' session message, action only allowed for administrators!")
             client.disconnect()
             return
 
         if sess.session_id != "default" and client.sess.session_id == sess.session_id:
+            if not sent_pipeline:
+                sess.pipeline = client.sess.pipeline
             client.sess = sess
             LOG.debug(f"Client session updated from payload: {sess.serialize()}")
 
-        self.handle_inject_agent_msg(message.payload, client)
+        self.handle_inject_agent_msg(payload, client)
         if self.agent_bus_callback:
-            self.agent_bus_callback(message.payload)
+            self.agent_bus_callback(payload)
 
     def handle_broadcast_message(
             self, message: HiveMessage, client: HiveMindClientConnection
@@ -832,7 +837,11 @@ class HiveMindListenerProtocol:
     # HiveMind mycroft bus messages -  from slave -> master
     def _update_blacklist(self, message: Message, client: HiveMindClientConnection):
         LOG.debug("replacing message metadata with hivemind client session")
-        message.context["session"] = client.sess.serialize()
+        raw_session = message.context.get("session") or {}
+        session = client.sess.serialize()
+        if not isinstance(raw_session, dict) or "pipeline" not in raw_session:
+            session.pop("pipeline", None)
+        message.context["session"] = session
 
         # update blacklist from db, to account for changes without requiring a restart
         self.db.sync()

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -581,7 +581,16 @@ class HiveMindListenerProtocol:
 
         If a non-admin client attempts to use the "default" session ID, the client is disconnected. Otherwise, updates the client's session if the session ID matches and is not "default", then injects the message into the internal agent bus and invokes the agent bus callback if set.
         """
-        payload = message.payload
+        try:
+            payload = message.payload
+        except (AttributeError, KeyError, TypeError, ValueError):
+            LOG.warning("Ignoring BUS payload with invalid message/context shape")
+            return
+
+        if not isinstance(payload, Message) or not isinstance(payload.context, dict):
+            LOG.warning("Ignoring BUS payload with invalid message/context shape")
+            return
+
         raw_session = payload.context.get("session") or {}
         sent_pipeline = isinstance(raw_session, dict) and "pipeline" in raw_session
         sess = Session.from_message(payload)
@@ -599,8 +608,6 @@ class HiveMindListenerProtocol:
             LOG.debug(f"Client session updated from payload: {sess.serialize()}")
 
         self.handle_inject_agent_msg(payload, client)
-        if self.agent_bus_callback:
-            self.agent_bus_callback(payload)
 
     def handle_broadcast_message(
             self, message: HiveMessage, client: HiveMindClientConnection

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -585,6 +585,8 @@ class HiveMindListenerProtocol:
         raw_session = payload.context.get("session") or {}
         sent_pipeline = isinstance(raw_session, dict) and "pipeline" in raw_session
         sess = Session.from_message(payload)
+        if sent_pipeline:
+            sess.pipeline = raw_session.get("pipeline")
         if sess.session_id == "default" and not client.is_admin:
             LOG.warning("Client tried to inject 'default' session message, action only allowed for administrators!")
             client.disconnect()
@@ -840,6 +842,7 @@ class HiveMindListenerProtocol:
         raw_session = message.context.get("session") or {}
         session = client.sess.serialize()
         if not isinstance(raw_session, dict) or "pipeline" not in raw_session:
+            # Each bus message owns its outbound pipeline; do not reattach one from an earlier message.
             session.pop("pipeline", None)
         message.context["session"] = session
 

--- a/test/unittests/test_session_pipeline.py
+++ b/test/unittests/test_session_pipeline.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivemind_bus_client import HiveMessage, HiveMessageType
+from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
+
+
+def _make_protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.callbacks = MagicMock()
+
+    db_user = MagicMock()
+    db_user.skill_blacklist = []
+    db_user.intent_blacklist = []
+    db_user.message_blacklist = []
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db)
+
+
+def _make_client(protocol, pipeline):
+    client = HiveMindClientConnection(
+        key="test-key",
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+    )
+    client.name = "test-client"
+    client.allowed_types = ["recognizer_loop:utterance"]
+    client.sess = Session("session-1", site_id="client-site", pipeline=pipeline)
+    return client
+
+
+class TestSessionPipelineHandling(unittest.TestCase):
+    def test_missing_pipeline_is_not_invented_from_core_config(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, ["client-pipeline"])
+        raw_session = {"session_id": "session-1", "site_id": "client-site"}
+        bus_message = Message(
+            "recognizer_loop:utterance",
+            {"utterances": ["hello"]},
+            {"session": raw_session},
+        )
+
+        protocol.handle_bus_message(
+            HiveMessage(HiveMessageType.BUS, bus_message), client
+        )
+
+        emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
+        self.assertNotIn("pipeline", emitted.context["session"])
+        self.assertEqual(client.sess.pipeline, ["client-pipeline"])
+
+    def test_explicit_pipeline_is_kept(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, ["old-pipeline"])
+        raw_session = {
+            "session_id": "session-1",
+            "site_id": "client-site",
+            "pipeline": ["client-sent-pipeline"],
+        }
+        bus_message = Message(
+            "recognizer_loop:utterance",
+            {"utterances": ["hello"]},
+            {"session": raw_session},
+        )
+
+        protocol.handle_bus_message(
+            HiveMessage(HiveMessageType.BUS, bus_message), client
+        )
+
+        emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
+        self.assertEqual(
+            emitted.context["session"]["pipeline"], ["client-sent-pipeline"]
+        )
+        self.assertEqual(client.sess.pipeline, ["client-sent-pipeline"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_session_pipeline.py
+++ b/tests/e2e/test_session_pipeline.py
@@ -1,0 +1,256 @@
+"""End-to-end coverage for the session-pipeline preservation fix.
+
+Mirrors the unit tests in ``tests/test_session_pipeline.py`` but exercises
+the behaviour through the real master/satellite protocol stack via
+hivescope, so regressions in any layer (network, slave protocol, listener
+protocol) get caught.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivescope.scenarios import admin_satellite
+from hivescope.topology import TopologyBuilder
+
+
+def _non_admin_satellite():
+    """Non-admin counterpart to ``admin_satellite()``.
+
+    Needed for tests that probe the ``session_id == "default"`` rejection,
+    which only fires for non-admin peers. ``allowed_types`` is set
+    explicitly because ``recognizer_loop:utterance`` is not in the default
+    allowlist for non-admin satellites.
+    """
+    b = TopologyBuilder()
+    m = b.add_master("M0")
+    m.register_satellite(
+        "test-key",
+        password="test-password",
+        is_admin=False,
+        allowed_types=["recognizer_loop:utterance"],
+    )
+    b.add_satellite("S0", upstream=m)
+    return b
+
+
+def _wait_for(condition, timeout: float = 2.0, interval: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _send_bus(satellite, session_dict):
+    """Send ``recognizer_loop:utterance`` with an explicit session context.
+
+    ``SatelliteNode.send`` only injects a default session when ``"session"``
+    is missing entirely, so passing one here is enough to control what the
+    master sees on the wire.
+    """
+    msg = Message(
+        "recognizer_loop:utterance",
+        {"utterances": ["hello"]},
+        {"session": session_dict},
+    )
+    satellite.send(HiveMessage(HiveMessageType.BUS, payload=msg))
+
+
+def _emitted_session(master):
+    assert _wait_for(lambda: len(master.agent_protocol.injected) >= 1), (
+        f"no message was injected on master bus: {master.agent_protocol.injected}"
+    )
+    return master.agent_protocol.injected[-1].context.get("session", {})
+
+
+def test_no_pipeline_in_payload_is_not_invented_from_core_config():
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        ctx = sess.serialize()
+        ctx.pop("pipeline", None)
+        _send_bus(s, ctx)
+
+        emitted = _emitted_session(m)
+        assert "pipeline" not in emitted or emitted.get("pipeline") in (None, []), (
+            f"core invented a pipeline for a client that did not send one: {emitted}"
+        )
+    finally:
+        b.stop_all()
+
+
+def test_explicit_pipeline_list_is_preserved():
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        ctx = sess.serialize()
+        ctx["pipeline"] = ["client-sent-pipeline"]
+        _send_bus(s, ctx)
+
+        emitted = _emitted_session(m)
+        assert emitted.get("pipeline") == ["client-sent-pipeline"], emitted
+    finally:
+        b.stop_all()
+
+
+def test_explicit_none_pipeline_is_preserved():
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        ctx = sess.serialize()
+        ctx["pipeline"] = None
+        _send_bus(s, ctx)
+
+        emitted = _emitted_session(m)
+        assert emitted.get("pipeline") is None, emitted
+    finally:
+        b.stop_all()
+
+
+def test_agent_bus_callback_fires_exactly_once_per_bus_message():
+    """Regression guard for the duplicate-callback bug.
+
+    ``handle_inject_agent_msg`` already invokes ``agent_bus_callback``;
+    before the fix, ``handle_bus_message`` invoked it a second time.
+    """
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        callback = MagicMock()
+        m.hm_protocol.agent_bus_callback = callback
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        _send_bus(s, sess.serialize())
+
+        assert _wait_for(lambda: callback.call_count >= 1)
+        # Give any duplicate dispatch a chance to land before asserting count==1.
+        time.sleep(0.05)
+        assert callback.call_count == 1, (
+            f"agent_bus_callback fired {callback.call_count} times, expected 1"
+        )
+    finally:
+        b.stop_all()
+
+
+def test_non_admin_default_session_id_is_disconnected():
+    """Non-admin client may not use the reserved ``default`` session id."""
+    b = _non_admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        peer = next(iter(m.hm_protocol.clients))
+        client = m.hm_protocol.clients[peer]
+        client.disconnect = MagicMock()
+
+        _send_bus(s, {"session_id": "default", "site_id": "client-site"})
+
+        assert _wait_for(lambda: client.disconnect.called), (
+            "non-admin client using session_id='default' was not disconnected"
+        )
+        # And the message must not have reached the agent bus.
+        assert not any(
+            msg.msg_type == "recognizer_loop:utterance"
+            for msg in m.agent_protocol.injected
+        ), m.agent_protocol.injected
+    finally:
+        b.stop_all()
+
+
+def test_non_admin_payload_without_session_is_disconnected():
+    """Missing session in payload defaults to ``default`` and is rejected."""
+    b = _non_admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        peer = next(iter(m.hm_protocol.clients))
+        client = m.hm_protocol.clients[peer]
+        client.disconnect = MagicMock()
+
+        # Build the BUS message with NO session in context — Session.from_message
+        # will fall back to the reserved 'default' id, which a non-admin may not use.
+        msg = Message(
+            "recognizer_loop:utterance", {"utterances": ["hello"]}, {}
+        )
+        s.send(HiveMessage(HiveMessageType.BUS, payload=msg))
+
+        assert _wait_for(lambda: client.disconnect.called), (
+            "non-admin client whose payload had no session was not disconnected"
+        )
+    finally:
+        b.stop_all()
+
+
+def test_admin_default_session_id_is_allowed():
+    """Counterpart: admin clients may use ``default`` and the message lands."""
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        peer = next(iter(m.hm_protocol.clients))
+        client = m.hm_protocol.clients[peer]
+        client.disconnect = MagicMock()
+
+        _send_bus(s, {"session_id": "default", "site_id": "client-site"})
+
+        assert _wait_for(lambda: len(m.agent_protocol.injected) >= 1)
+        assert not client.disconnect.called, (
+            "admin client using session_id='default' was wrongly disconnected"
+        )
+    finally:
+        b.stop_all()
+
+
+def test_stale_master_side_pipeline_is_not_reattached():
+    """End-to-end exercise for the ``_update_blacklist`` fix.
+
+    If the master-side connection has a leftover pipeline from a prior
+    message, sending a new BUS payload without pipeline must not cause it
+    to be reattached on its way to the agent bus.
+    """
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        peer = next(iter(m.hm_protocol.clients))
+        m.hm_protocol.clients[peer].sess.pipeline = ["stale-pipeline"]
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        ctx = sess.serialize()
+        ctx.pop("pipeline", None)
+        _send_bus(s, ctx)
+
+        emitted = _emitted_session(m)
+        assert emitted.get("pipeline") in (None, [], ), (
+            f"stale master-side pipeline leaked into agent bus: {emitted}"
+        )
+        assert emitted.get("pipeline") != ["stale-pipeline"]
+    finally:
+        b.stop_all()

--- a/tests/test_session_pipeline.py
+++ b/tests/test_session_pipeline.py
@@ -37,16 +37,34 @@ def _make_client(protocol, pipeline):
     return client
 
 
+def _make_bus_message(context):
+    return Message(
+        "recognizer_loop:utterance",
+        {"utterances": ["hello"]},
+        context,
+    )
+
+
 class TestSessionPipelineHandling(unittest.TestCase):
     def test_missing_pipeline_is_not_invented_from_core_config(self):
         protocol = _make_protocol()
         client = _make_client(protocol, ["client-pipeline"])
         raw_session = {"session_id": "session-1", "site_id": "client-site"}
-        bus_message = Message(
-            "recognizer_loop:utterance",
-            {"utterances": ["hello"]},
-            {"session": raw_session},
+        bus_message = _make_bus_message({"session": raw_session})
+
+        protocol.handle_bus_message(
+            HiveMessage(HiveMessageType.BUS, bus_message), client
         )
+
+        emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
+        self.assertNotIn("pipeline", emitted.context["session"])
+        self.assertEqual(client.sess.pipeline, ["client-pipeline"])
+
+    def test_missing_session_key_is_not_given_pipeline(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, ["client-pipeline"])
+        client.is_admin = True
+        bus_message = _make_bus_message({})
 
         protocol.handle_bus_message(
             HiveMessage(HiveMessageType.BUS, bus_message), client
@@ -64,11 +82,7 @@ class TestSessionPipelineHandling(unittest.TestCase):
             "site_id": "client-site",
             "pipeline": ["client-sent-pipeline"],
         }
-        bus_message = Message(
-            "recognizer_loop:utterance",
-            {"utterances": ["hello"]},
-            {"session": raw_session},
-        )
+        bus_message = _make_bus_message({"session": raw_session})
 
         protocol.handle_bus_message(
             HiveMessage(HiveMessageType.BUS, bus_message), client
@@ -79,6 +93,24 @@ class TestSessionPipelineHandling(unittest.TestCase):
             emitted.context["session"]["pipeline"], ["client-sent-pipeline"]
         )
         self.assertEqual(client.sess.pipeline, ["client-sent-pipeline"])
+
+    def test_explicit_none_pipeline_is_kept(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, ["old-pipeline"])
+        raw_session = {
+            "session_id": "session-1",
+            "site_id": "client-site",
+            "pipeline": None,
+        }
+        bus_message = _make_bus_message({"session": raw_session})
+
+        protocol.handle_bus_message(
+            HiveMessage(HiveMessageType.BUS, bus_message), client
+        )
+
+        emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
+        self.assertIsNone(emitted.context["session"]["pipeline"])
+        self.assertIsNone(client.sess.pipeline)
 
 
 if __name__ == "__main__":

--- a/tests/test_session_pipeline.py
+++ b/tests/test_session_pipeline.py
@@ -112,6 +112,31 @@ class TestSessionPipelineHandling(unittest.TestCase):
         self.assertIsNone(emitted.context["session"]["pipeline"])
         self.assertIsNone(client.sess.pipeline)
 
+    def test_invalid_bus_payload_is_ignored(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, ["client-pipeline"])
+
+        protocol.handle_bus_message(
+            HiveMessage(HiveMessageType.BUS, {"context": {}}), client
+        )
+
+        protocol.agent_protocol.bus.emit.assert_not_called()
+        client.disconnect.assert_not_called()
+        self.assertEqual(client.sess.pipeline, ["client-pipeline"])
+
+    def test_agent_bus_callback_runs_once(self):
+        protocol = _make_protocol()
+        protocol.agent_bus_callback = MagicMock()
+        client = _make_client(protocol, ["client-pipeline"])
+        raw_session = {"session_id": "session-1", "site_id": "client-site"}
+        bus_message = _make_bus_message({"session": raw_session})
+
+        protocol.handle_bus_message(
+            HiveMessage(HiveMessageType.BUS, bus_message), client
+        )
+
+        protocol.agent_bus_callback.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes JarbasHiveMind/hivemind-websocket-client#104

Core was filling in `pipeline` from local config when the client did not send one. Keep it out unless the client explicitly includes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session pipeline is no longer invented or carried over when omitted; client-injected pipelines are only applied when explicitly provided
  * Non-admin clients are disconnected for forbidden default-session injection; admin clients remain allowed
  * Ensures injected messages forward the correct session context and avoid duplicate callback dispatches

* **Tests**
  * Added unit and end-to-end tests covering pipeline preservation, omission behavior, admin vs non-admin handling, and single callback invocation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/HiveMind-core/pull/79)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->