### PR TITLE
test(e2e): pin session-pipeline fix with hivescope (stacked on #79)

### DIFF
--- a/tests/e2e/test_session_pipeline.py
+++ b/tests/e2e/test_session_pipeline.py
@@ -14,6 +14,27 @@ from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
 
 from hivescope.scenarios import admin_satellite
+from hivescope.topology import TopologyBuilder
+
+
+def _non_admin_satellite():
+    """Non-admin counterpart to ``admin_satellite()``.
+
+    Needed for tests that probe the ``session_id == "default"`` rejection,
+    which only fires for non-admin peers. ``allowed_types`` is set
+    explicitly because ``recognizer_loop:utterance`` is not in the default
+    allowlist for non-admin satellites.
+    """
+    b = TopologyBuilder()
+    m = b.add_master("M0")
+    m.register_satellite(
+        "test-key",
+        password="test-password",
+        is_admin=False,
+        allowed_types=["recognizer_loop:utterance"],
+    )
+    b.add_satellite("S0", upstream=m)
+    return b
 
 
 def _wait_for(condition, timeout: float = 2.0, interval: float = 0.02) -> bool:
@@ -126,6 +147,80 @@ def test_agent_bus_callback_fires_exactly_once_per_bus_message():
         time.sleep(0.05)
         assert callback.call_count == 1, (
             f"agent_bus_callback fired {callback.call_count} times, expected 1"
+        )
+    finally:
+        b.stop_all()
+
+
+def test_non_admin_default_session_id_is_disconnected():
+    """Non-admin client may not use the reserved ``default`` session id."""
+    b = _non_admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        peer = next(iter(m.hm_protocol.clients))
+        client = m.hm_protocol.clients[peer]
+        client.disconnect = MagicMock()
+
+        _send_bus(s, {"session_id": "default", "site_id": "client-site"})
+
+        assert _wait_for(lambda: client.disconnect.called), (
+            "non-admin client using session_id='default' was not disconnected"
+        )
+        # And the message must not have reached the agent bus.
+        assert not any(
+            msg.msg_type == "recognizer_loop:utterance"
+            for msg in m.agent_protocol.injected
+        ), m.agent_protocol.injected
+    finally:
+        b.stop_all()
+
+
+def test_non_admin_payload_without_session_is_disconnected():
+    """Missing session in payload defaults to ``default`` and is rejected."""
+    b = _non_admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        peer = next(iter(m.hm_protocol.clients))
+        client = m.hm_protocol.clients[peer]
+        client.disconnect = MagicMock()
+
+        # Build the BUS message with NO session in context — Session.from_message
+        # will fall back to the reserved 'default' id, which a non-admin may not use.
+        msg = Message(
+            "recognizer_loop:utterance", {"utterances": ["hello"]}, {}
+        )
+        s.send(HiveMessage(HiveMessageType.BUS, payload=msg))
+
+        assert _wait_for(lambda: client.disconnect.called), (
+            "non-admin client whose payload had no session was not disconnected"
+        )
+    finally:
+        b.stop_all()
+
+
+def test_admin_default_session_id_is_allowed():
+    """Counterpart: admin clients may use ``default`` and the message lands."""
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        peer = next(iter(m.hm_protocol.clients))
+        client = m.hm_protocol.clients[peer]
+        client.disconnect = MagicMock()
+
+        _send_bus(s, {"session_id": "default", "site_id": "client-site"})
+
+        assert _wait_for(lambda: len(m.agent_protocol.injected) >= 1)
+        assert not client.disconnect.called, (
+            "admin client using session_id='default' was wrongly disconnected"
         )
     finally:
         b.stop_all()

--- a/tests/e2e/test_session_pipeline.py
+++ b/tests/e2e/test_session_pipeline.py
@@ -1,0 +1,161 @@
+"""End-to-end coverage for the session-pipeline preservation fix.
+
+Mirrors the unit tests in ``tests/test_session_pipeline.py`` but exercises
+the behaviour through the real master/satellite protocol stack via
+hivescope, so regressions in any layer (network, slave protocol, listener
+protocol) get caught.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivescope.scenarios import admin_satellite
+
+
+def _wait_for(condition, timeout: float = 2.0, interval: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _send_bus(satellite, session_dict):
+    """Send ``recognizer_loop:utterance`` with an explicit session context.
+
+    ``SatelliteNode.send`` only injects a default session when ``"session"``
+    is missing entirely, so passing one here is enough to control what the
+    master sees on the wire.
+    """
+    msg = Message(
+        "recognizer_loop:utterance",
+        {"utterances": ["hello"]},
+        {"session": session_dict},
+    )
+    satellite.send(HiveMessage(HiveMessageType.BUS, payload=msg))
+
+
+def _emitted_session(master):
+    assert _wait_for(lambda: len(master.agent_protocol.injected) >= 1), (
+        f"no message was injected on master bus: {master.agent_protocol.injected}"
+    )
+    return master.agent_protocol.injected[-1].context.get("session", {})
+
+
+def test_no_pipeline_in_payload_is_not_invented_from_core_config():
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        ctx = sess.serialize()
+        ctx.pop("pipeline", None)
+        _send_bus(s, ctx)
+
+        emitted = _emitted_session(m)
+        assert "pipeline" not in emitted or emitted.get("pipeline") in (None, []), (
+            f"core invented a pipeline for a client that did not send one: {emitted}"
+        )
+    finally:
+        b.stop_all()
+
+
+def test_explicit_pipeline_list_is_preserved():
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        ctx = sess.serialize()
+        ctx["pipeline"] = ["client-sent-pipeline"]
+        _send_bus(s, ctx)
+
+        emitted = _emitted_session(m)
+        assert emitted.get("pipeline") == ["client-sent-pipeline"], emitted
+    finally:
+        b.stop_all()
+
+
+def test_explicit_none_pipeline_is_preserved():
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        ctx = sess.serialize()
+        ctx["pipeline"] = None
+        _send_bus(s, ctx)
+
+        emitted = _emitted_session(m)
+        assert emitted.get("pipeline") is None, emitted
+    finally:
+        b.stop_all()
+
+
+def test_agent_bus_callback_fires_exactly_once_per_bus_message():
+    """Regression guard for the duplicate-callback bug.
+
+    ``handle_inject_agent_msg`` already invokes ``agent_bus_callback``;
+    before the fix, ``handle_bus_message`` invoked it a second time.
+    """
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        callback = MagicMock()
+        m.hm_protocol.agent_bus_callback = callback
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        _send_bus(s, sess.serialize())
+
+        assert _wait_for(lambda: callback.call_count >= 1)
+        # Give any duplicate dispatch a chance to land before asserting count==1.
+        time.sleep(0.05)
+        assert callback.call_count == 1, (
+            f"agent_bus_callback fired {callback.call_count} times, expected 1"
+        )
+    finally:
+        b.stop_all()
+
+
+def test_stale_master_side_pipeline_is_not_reattached():
+    """End-to-end exercise for the ``_update_blacklist`` fix.
+
+    If the master-side connection has a leftover pipeline from a prior
+    message, sending a new BUS payload without pipeline must not cause it
+    to be reattached on its way to the agent bus.
+    """
+    b = admin_satellite()
+    try:
+        b.start_all()
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+
+        peer = next(iter(m.hm_protocol.clients))
+        m.hm_protocol.clients[peer].sess.pipeline = ["stale-pipeline"]
+
+        sess = Session(session_id=s.shim.session_id, site_id="client-site")
+        ctx = sess.serialize()
+        ctx.pop("pipeline", None)
+        _send_bus(s, ctx)
+
+        emitted = _emitted_session(m)
+        assert emitted.get("pipeline") in (None, [], ), (
+            f"stale master-side pipeline leaked into agent bus: {emitted}"
+        )
+        assert emitted.get("pipeline") != ["stale-pipeline"]
+    finally:
+        b.stop_all()


### PR DESCRIPTION
Stacked on #79. Adds end-to-end tests through the real master/satellite stack via hivescope, mirroring the unit tests in `tests/test_session_pipeline.py`.

## Coverage

- no pipeline in payload is not invented from core config
- explicit pipeline list is preserved
- explicit `None` pipeline is preserved
- `agent_bus_callback` fires exactly once per BUS message — regression guard for the duplicate dispatch removed in #79 (`handle_inject_agent_msg` already invokes the callback at `protocol.py:906–907`)
- stale master-side pipeline is not reattached by `_update_blacklist`

## Verification

Run on this branch:
```
PYTHONPATH=. pytest tests/e2e/test_session_pipeline.py -v
```
→ 5/5 pass.

Same tests against `origin/dev` (pre-fix) → 4/5 fail (the explicit-list case incidentally passes there too), confirming each test pins a real behaviour change rather than just shadowing the unit tests.

## Notes

- Branch is `codex/...` to keep the stack visually grouped with the parent PR.
- Re-target to `dev` once #79 lands.