### PR TITLE
Wire policy plugins into HiveMind core

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ $ hivemind-core add-client --name "satellite_1" --access-key "mykey123" --passwo
 - **When to use**:  
   Use this command when setting up a new HiveMind client (e.g., Raspberry Pi, IoT device). Provide credentials for
   secure communication with the server.
+- **Optional metadata**:
+  Admins can attach plugin-specific client context with `--metadata`:
+
+```bash
+hivemind-core add-client --name "satellite_1" --metadata '{"account_id":"acct_123","device_type":"satellite"}'
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ HiveMind is designed to be modular, allowing you to customize its behavior throu
 - **Payload Handling** 🤖 : The protocol does not dictate **who** handles the messages; this is implemebted via **agent protocol plugins** (e.g., OVOS, Persona).
 - **Message Format** 📦: The protocol supports **JSON data** modeled after the `Message` [structure from OVOS](https://jarbashivemind.github.io/HiveMind-community-docs/13_mycroft/) and **binary** data; what happens to the received binary data is implemented via **binary data protocol plugins** (e.g., process incoming audio).
 - **Database**: 🗃️ how client credentials are stored is implemented via **database plugins** (e.g., JSON, SQLite, Redis).
+- **Policy**: optional dynamic ACL checks can be implemented via **policy plugins** before client messages are forwarded to the bus.
 
 ---
 
@@ -91,6 +92,8 @@ The default configuration
   "binary_protocol": {
     "module": null
   },
+  "policy": {},
+  "policy_fail_closed": true,
   "network_protocol": {
     "hivemind-websocket-plugin": {
       "host": "0.0.0.0",
@@ -110,6 +113,21 @@ The default configuration
   }
 }
 ```
+
+A policy plugin can be enabled by entry point name:
+
+```json
+{
+  "policy": {
+    "example-utterance-limit": {
+      "limit": 100
+    }
+  },
+  "policy_fail_closed": true
+}
+```
+
+Policy plugins do not change HiveMind identity. Clients are still identified by `api_key`; the policy receives the authenticated client/database record from core. If a policy denies a message, the message is not emitted to the agent bus and the client receives a `hive.policy.denied` bus message with the policy code/reason.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ A policy plugin can be enabled by entry point name:
 
 Policy plugins do not change HiveMind identity. Clients are still identified by `api_key`; the policy receives the authenticated client/database record from core. If a policy denies a message, the message is not emitted to the agent bus and the client receives a `hive.policy.denied` bus message with the policy code/reason.
 
+Existing installs keep working without policy plugins configured. Enabling `policy` requires a HiveMind Plugin Manager version that provides the `hivemind.policy` entry point.
+
 
 ---
 

--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -37,6 +37,8 @@ _DEFAULT = {
                            "port": 8181
                        }},
     "binary_protocol": {"module": None},
+    "policy": {},
+    "policy_fail_closed": True,
     "network_protocol": {"hivemind-websocket-plugin": {
                              "host": "0.0.0.0",
                              "port": 5678,

--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -13,13 +13,26 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from typing import List, Optional, Iterable
+from dataclasses import fields
+from typing import Any, Dict, List, Optional, Iterable
 
 from ovos_utils.log import LOG
 
 from hivemind_core.config import get_server_config
 from hivemind_plugin_manager import DatabaseFactory
 from hivemind_plugin_manager.database import Client
+
+
+def _client_supports_metadata() -> bool:
+    try:
+        return any(field.name == "metadata" for field in fields(Client))
+    except TypeError:
+        annotations = getattr(Client, "__annotations__", {})
+        return "metadata" in annotations or hasattr(Client, "metadata")
+
+
+CLIENT_SUPPORTS_METADATA = _client_supports_metadata()
+METADATA_SUPPORT_REQUIRED = "Client.metadata requires hivemind-plugin-manager metadata support"
 
 
 class ClientDatabase:
@@ -62,9 +75,12 @@ class ClientDatabase:
                    message_blacklist: Optional[List[str]] = None,
                    allowed_types: Optional[List[str]] = None,
                    crypto_key: Optional[str] = None,
-                   password: Optional[str] = None) -> bool:
+                   password: Optional[str] = None,
+                   metadata: Optional[Dict[str, Any]] = None) -> bool:
         if crypto_key is not None:
             crypto_key = crypto_key[:16]
+        if metadata is not None and not CLIENT_SUPPORTS_METADATA:
+            raise RuntimeError(METADATA_SUPPORT_REQUIRED)
 
         user = self.get_client_by_api_key(key)
         if user:
@@ -85,20 +101,25 @@ class ClientDatabase:
                 user.crypto_key = crypto_key
             if password:
                 user.password = password
+            if metadata is not None:
+                user.metadata = dict(metadata)
             return self.db.update_item(user)
 
-        user = Client(
-            api_key=key,
-            name=name,
-            intent_blacklist=intent_blacklist,
-            skill_blacklist=skill_blacklist,
-            message_blacklist=message_blacklist,
-            crypto_key=crypto_key,
-            client_id=self.total_clients() + 1,
-            is_admin=admin,
-            password=password,
-            allowed_types=allowed_types,
-        )
+        client_data = {
+            "api_key": key,
+            "name": name,
+            "intent_blacklist": intent_blacklist,
+            "skill_blacklist": skill_blacklist,
+            "message_blacklist": message_blacklist,
+            "crypto_key": crypto_key,
+            "client_id": self.total_clients() + 1,
+            "is_admin": admin,
+            "password": password,
+            "allowed_types": allowed_types,
+        }
+        if metadata is not None:
+            client_data["metadata"] = dict(metadata)
+        user = Client(**client_data)
         return self.db.add_item(user)
 
     def update_item(self, client: Client):

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -39,10 +39,15 @@ from hivemind_core.database import ClientDatabase
 from hivemind_bus_client.hive_map import HiveMapper
 from hivemind_plugin_manager.protocols import (AgentProtocol,
                                                BinaryDataHandlerProtocol,
-                                               ClientCallbacks,
-                                               PolicyContext,
-                                               PolicyDecision,
-                                               PolicyProtocol)
+                                               ClientCallbacks)
+try:
+    from hivemind_plugin_manager.protocols import (PolicyContext,
+                                                   PolicyDecision,
+                                                   PolicyProtocol)
+except ImportError:
+    PolicyContext = None
+    PolicyDecision = None
+    PolicyProtocol = Any
 from poorman_handshake import HandShake, PasswordHandShake
 from poorman_handshake.asymmetric.utils import decrypt_RSA, load_RSA_key
 
@@ -261,6 +266,8 @@ class HiveMindListenerProtocol:
                 target[key] = value
 
     def _make_policy_context(self, client: HiveMindClientConnection, user=None) -> PolicyContext:
+        if PolicyContext is None:
+            raise RuntimeError("Policy support requires hivemind-plugin-manager with hivemind.policy support")
         user = user or self._get_client_user(client)
         return PolicyContext(
             client=client,
@@ -270,6 +277,8 @@ class HiveMindListenerProtocol:
     def _policy_exception_decision(self, policy: PolicyProtocol, hook_name: str) -> PolicyDecision:
         LOG.exception(f"Policy '{policy.__class__.__name__}' failed in {hook_name}")
         if get_server_config().get("policy_fail_closed", True):
+            if PolicyDecision is None:
+                raise RuntimeError("Policy support requires hivemind-plugin-manager with hivemind.policy support")
             return PolicyDecision(
                 allowed=False,
                 reason="policy check failed",

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -19,7 +19,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
-from typing import Union, List, Optional, Callable, Literal
+from typing import Any, Dict, Union, List, Optional, Callable, Literal
 
 import pybase64
 from ovos_bus_client import MessageBusClient
@@ -37,7 +37,12 @@ from hivemind_bus_client.encryption import (SupportedEncodings, SupportedCiphers
                                             _norm_encoding, _norm_cipher)
 from hivemind_core.database import ClientDatabase
 from hivemind_bus_client.hive_map import HiveMapper
-from hivemind_plugin_manager.protocols import AgentProtocol, BinaryDataHandlerProtocol, ClientCallbacks
+from hivemind_plugin_manager.protocols import (AgentProtocol,
+                                               BinaryDataHandlerProtocol,
+                                               ClientCallbacks,
+                                               PolicyContext,
+                                               PolicyDecision,
+                                               PolicyProtocol)
 from poorman_handshake import HandShake, PasswordHandShake
 from poorman_handshake.asymmetric.utils import decrypt_RSA, load_RSA_key
 
@@ -206,6 +211,7 @@ class HiveMindListenerProtocol:
     identity: NodeIdentity = dataclasses.field(default_factory=NodeIdentity)
     db: ClientDatabase = dataclasses.field(default_factory=ClientDatabase)
     callbacks: ClientCallbacks = dataclasses.field(default_factory=ClientCallbacks)
+    policy_protocols: List[PolicyProtocol] = dataclasses.field(default_factory=list)
 
     hive_mapper: HiveMapper = dataclasses.field(default_factory=HiveMapper)
 
@@ -228,10 +234,159 @@ class HiveMindListenerProtocol:
                                                                   agent_protocol=self.agent_protocol)
         else:
             self.binary_data_protocol.hm_protocol = self
+        for policy in self.policy_protocols:
+            policy.hm_protocol = self
 
     def get_bus(self, client: HiveMindClientConnection) -> Union[FakeBus, MessageBusClient]:
         # allow subclasses to use dedicated bus per client
         return self.agent_protocol.bus
+
+    def _get_client_user(self, client: HiveMindClientConnection):
+        self.db.sync()
+        user = self.db.get_client_by_api_key(client.key)
+        if user is None:
+            LOG.warning(f"No database user found for connected client: {client.peer}")
+        return user
+
+    @staticmethod
+    def _merge_policy_patch(target: Dict[str, Any], patch: Dict[str, Any]):
+        for key, value in patch.items():
+            if isinstance(value, dict) and isinstance(target.get(key), dict):
+                HiveMindListenerProtocol._merge_policy_patch(target[key], value)
+            elif isinstance(value, list) and isinstance(target.get(key), list):
+                for item in value:
+                    if item not in target[key]:
+                        target[key].append(item)
+            else:
+                target[key] = value
+
+    def _make_policy_context(self, client: HiveMindClientConnection, user=None) -> PolicyContext:
+        user = user or self._get_client_user(client)
+        return PolicyContext(
+            client=client,
+            user=user,
+        )
+
+    def _policy_exception_decision(self, policy: PolicyProtocol, hook_name: str) -> PolicyDecision:
+        LOG.exception(f"Policy '{policy.__class__.__name__}' failed in {hook_name}")
+        if get_server_config().get("policy_fail_closed", True):
+            return PolicyDecision(
+                allowed=False,
+                reason="policy check failed",
+                code="policy_error",
+                data={"policy": policy.__class__.__name__, "hook": hook_name},
+            )
+        return PolicyDecision()
+
+    def _send_policy_denied(self,
+                            client: HiveMindClientConnection,
+                            decision: PolicyDecision,
+                            request: Optional[Message] = None):
+        data = dict(decision.data or {})
+        if decision.reason:
+            data.setdefault("reason", decision.reason)
+        if decision.code:
+            data.setdefault("code", decision.code)
+        data.setdefault("peer", client.peer)
+        if request is not None:
+            data.setdefault("request_type", request.msg_type)
+
+        response = Message(
+            decision.message_type or "hive.policy.denied",
+            data,
+            {
+                "source": self.peer,
+                "destination": client.peer,
+                "session": client.sess.serialize(),
+            },
+        )
+        client.send(HiveMessage(HiveMessageType.BUS, response))
+
+    def _apply_policy_decision(self,
+                               decision: Optional[PolicyDecision],
+                               client: HiveMindClientConnection,
+                               message: Optional[Message] = None) -> bool:
+        if decision is None:
+            return True
+        if message is not None and decision.context_patch:
+            if not isinstance(message.context, dict):
+                message.context = {}
+            self._merge_policy_patch(message.context, decision.context_patch)
+        if decision.allowed:
+            return True
+
+        LOG.warning(f"{client.peer} denied by policy: {decision.reason or decision.code}")
+        self._send_policy_denied(client, decision, message)
+        return False
+
+    def _authorize_hive_message_policies(self,
+                                         message: HiveMessage,
+                                         client: HiveMindClientConnection,
+                                         user=None) -> bool:
+        if not self.policy_protocols:
+            return True
+        context = self._make_policy_context(client, user)
+        request = message.payload if isinstance(message.payload, Message) else None
+        for policy in self.policy_protocols:
+            try:
+                decision = policy.authorize_hive_message(message, context)
+            except Exception:
+                decision = self._policy_exception_decision(policy, "authorize_hive_message")
+            if not self._apply_policy_decision(decision, client, request):
+                return False
+            if decision and decision.stop_processing:
+                break
+        return True
+
+    def _authorize_binary_payload_policies(self,
+                                           message: HiveMessage,
+                                           client: HiveMindClientConnection,
+                                           user=None) -> bool:
+        if not self.policy_protocols:
+            return True
+        context = self._make_policy_context(client, user)
+        for policy in self.policy_protocols:
+            try:
+                decision = policy.authorize_binary_payload(message, context)
+            except Exception:
+                decision = self._policy_exception_decision(policy, "authorize_binary_payload")
+            if not self._apply_policy_decision(decision, client):
+                return False
+            if decision and decision.stop_processing:
+                break
+        return True
+
+    def _authorize_bus_message_policies(self,
+                                        message: Message,
+                                        client: HiveMindClientConnection,
+                                        user=None) -> bool:
+        if not self.policy_protocols:
+            return True
+        context = self._make_policy_context(client, user)
+        for policy in self.policy_protocols:
+            try:
+                decision = policy.authorize_bus_message(message, context)
+            except Exception:
+                decision = self._policy_exception_decision(policy, "authorize_bus_message")
+            if not self._apply_policy_decision(decision, client, message):
+                return False
+            if decision and decision.stop_processing:
+                break
+        return True
+
+    def _record_bus_message_policies(self,
+                                     message: Message,
+                                     client: HiveMindClientConnection,
+                                     user=None,
+                                     result: Optional[Any] = None):
+        if not self.policy_protocols:
+            return
+        context = self._make_policy_context(client, user)
+        for policy in self.policy_protocols:
+            try:
+                policy.record_bus_message(message, context, result=result)
+            except Exception:
+                LOG.exception(f"Policy '{policy.__class__.__name__}' failed in record_bus_message")
 
     def handle_new_client(self, client: HiveMindClientConnection):
         try:
@@ -401,6 +556,11 @@ class HiveMindListenerProtocol:
         message.update_source_peer(client.peer)
 
         message.update_hop_data()
+        user = None
+        if message.msg_type not in [HiveMessageType.HANDSHAKE, HiveMessageType.HELLO]:
+            user = self._get_client_user(client)
+            if not self._authorize_hive_message_policies(message, client, user):
+                return
 
         if message.msg_type == HiveMessageType.HANDSHAKE:
             self.handle_handshake_message(message, client)
@@ -443,6 +603,9 @@ class HiveMindListenerProtocol:
             self, message: HiveMessage, client: HiveMindClientConnection
     ):
         assert message.msg_type == HiveMessageType.BINARY
+        user = self._get_client_user(client)
+        if not self._authorize_binary_payload_policies(message, client, user):
+            return
         bin_data = message.payload
         if message.bin_type == HiveMindBinaryPayloadType.RAW_AUDIO:
             sr = message.metadata.get("sample_rate", 16000)
@@ -844,7 +1007,7 @@ class HiveMindListenerProtocol:
         return False
 
     # HiveMind mycroft bus messages -  from slave -> master
-    def _update_blacklist(self, message: Message, client: HiveMindClientConnection):
+    def _update_blacklist(self, message: Message, client: HiveMindClientConnection, user=None):
         LOG.debug("replacing message metadata with hivemind client session")
         raw_session = message.context.get("session") or {}
         session = client.sess.serialize()
@@ -854,8 +1017,9 @@ class HiveMindListenerProtocol:
         message.context["session"] = session
 
         # update blacklist from db, to account for changes without requiring a restart
-        self.db.sync()
-        user = self.db.get_client_by_api_key(client.key)
+        user = user or self._get_client_user(client)
+        if user is None:
+            return message
         client.skill_blacklist = user.skill_blacklist or []
         client.intent_blacklist = user.intent_blacklist or []
         client.msg_blacklist = user.message_blacklist or []
@@ -889,7 +1053,10 @@ class HiveMindListenerProtocol:
             return
 
         # ensure client specific session data is injected in query to ovos
-        message = self._update_blacklist(message, client)
+        user = self._get_client_user(client)
+        message = self._update_blacklist(message, client, user=user)
+        if not self._authorize_bus_message_policies(message, client, user):
+            return
         if message.msg_type == "speak":
             message.context["destination"] = ["audio"]  # make audible, this is injected "speak" command
         elif message.context.get("destination") is None:
@@ -902,6 +1069,7 @@ class HiveMindListenerProtocol:
 
         bus = self.get_bus(client)
         bus.emit(message)
+        self._record_bus_message_policies(message, client, user)
 
         if self.agent_bus_callback:
             self.agent_bus_callback(message)

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -566,7 +566,7 @@ class HiveMindListenerProtocol:
 
         message.update_hop_data()
         user = None
-        if message.msg_type not in [HiveMessageType.HANDSHAKE, HiveMessageType.HELLO]:
+        if self.policy_protocols and message.msg_type not in [HiveMessageType.HANDSHAKE, HiveMessageType.HELLO]:
             user = self._get_client_user(client)
             if not self._authorize_hive_message_policies(message, client, user):
                 return
@@ -612,9 +612,10 @@ class HiveMindListenerProtocol:
             self, message: HiveMessage, client: HiveMindClientConnection
     ):
         assert message.msg_type == HiveMessageType.BINARY
-        user = self._get_client_user(client)
-        if not self._authorize_binary_payload_policies(message, client, user):
-            return
+        if self.policy_protocols:
+            user = self._get_client_user(client)
+            if not self._authorize_binary_payload_policies(message, client, user):
+                return
         bin_data = message.payload
         if message.bin_type == HiveMindBinaryPayloadType.RAW_AUDIO:
             sr = message.metadata.get("sample_rate", 16000)

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -26,6 +26,19 @@ from hivemind_core.service import HiveMindService
 from hivemind_core.config import get_server_config
 
 
+def parse_client_metadata(metadata):
+    """Parse client metadata from a JSON object string."""
+    if metadata is None:
+        return None
+    try:
+        parsed = json.loads(metadata)
+    except json.JSONDecodeError as e:
+        raise click.BadParameter("must be valid JSON") from e
+    if not isinstance(parsed, dict):
+        raise click.BadParameter("must be a JSON object")
+    return parsed
+
+
 def prompt_node_id(db: ClientDatabase) -> int:
     """
     Prompts the user to select a client ID from the database, displaying available clients in a table.
@@ -108,7 +121,8 @@ def listen():
 @click.option("--password", required=False, type=str)
 @click.option("--crypto-key", required=False, type=str)
 @click.option("--admin", default=False, required=False, type=bool)
-def add_client(name, access_key, password, crypto_key, admin):
+@click.option("--metadata", required=False, type=str, help="Client metadata as a JSON object.")
+def add_client(name, access_key, password, crypto_key, admin, metadata):
     """
     Adds a new client to the database, generating credentials if not provided.
     
@@ -122,6 +136,7 @@ def add_client(name, access_key, password, crypto_key, admin):
         password: Optional password. If not provided, a random password is generated.
         crypto_key: Optional 16-character encryption key. If not provided, a random key is generated.
         admin: Boolean indicating whether the client should have administrator privileges.
+        metadata: Optional JSON object with admin-defined client metadata.
     
     Raises:
         ValueError: If the crypto key is not exactly 16 characters, or if the client cannot be added.
@@ -143,11 +158,13 @@ def add_client(name, access_key, password, crypto_key, admin):
 
     password = password or os.urandom(16).hex()
     access_key = access_key or os.urandom(16).hex()
+    client_metadata = parse_client_metadata(metadata)
 
     with ClientDatabase() as db:
         name = name or f"HiveMind-Node-{db.total_clients()}"
         print(f"Database backend: {db.db.__class__.__name__}")
-        success = db.add_client(name, access_key, crypto_key=key, password=password, admin=admin)
+        success = db.add_client(name, access_key, crypto_key=key, password=password,
+                                admin=admin, metadata=client_metadata)
         if not success:
             raise ValueError(f"Error adding User to database: {name}")
 
@@ -161,8 +178,10 @@ def add_client(name, access_key, password, crypto_key, admin):
         print("Admin Privileges:", admin)
         print("Friendly Name:", name)
         print("Access Key:", access_key)
-        print("Password:", password)
+        click.echo(f"Password: {password}")
         print("Encryption Key:", key)
+        if client_metadata is not None:
+            print("Metadata:", json.dumps(user.metadata, sort_keys=True, ensure_ascii=False))
 
         print(
             "WARNING: Encryption Key is deprecated, only use if your client does not support password"
@@ -247,11 +266,11 @@ def delete_client(node_id):
         for client in db:
             if client.client_id == int(node_id):
                 db.delete_client(client.api_key)
-                print(f"Revoked credentials!\n")
+                print("Revoked credentials!\n")
                 print("Node ID:", client.client_id)
                 print("Friendly Name:", client.name)
                 print("Access Key:", client.api_key)
-                print("Password:", client.password)
+                click.echo(f"Password: {client.password}")
                 print("Encryption Key:", client.crypto_key)
                 break
         else:

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import dataclasses
-from typing import Callable, Optional, Type
+from typing import Callable, List, Optional, Type
 
 from ovos_utils import create_daemon, wait_for_exit_signal
 from ovos_utils.log import LOG
@@ -24,8 +24,11 @@ from hivemind_bus_client.identity import NodeIdentity
 from hivemind_core.config import get_server_config
 from hivemind_core.database import ClientDatabase
 from hivemind_core.protocol import HiveMindListenerProtocol, ClientCallbacks
-from hivemind_plugin_manager import AgentProtocolFactory, NetworkProtocolFactory, BinaryDataHandlerProtocolFactory
-from hivemind_plugin_manager.protocols import BinaryDataHandlerProtocol
+from hivemind_plugin_manager import (AgentProtocolFactory,
+                                     NetworkProtocolFactory,
+                                     BinaryDataHandlerProtocolFactory,
+                                     PolicyProtocolFactory)
+from hivemind_plugin_manager.protocols import BinaryDataHandlerProtocol, PolicyProtocol
 
 def get_agent_protocol():
     config = get_server_config()["agent_protocol"]
@@ -40,6 +43,18 @@ def get_binary_protocol():
         # dummy by default
         return BinaryDataHandlerProtocol, {}
     return BinaryDataHandlerProtocolFactory.get_class(name), config.get(name, {})
+
+
+def get_policy_protocols() -> List[PolicyProtocol]:
+    policies = []
+    for plug_name, plug_conf in (get_server_config().get("policy") or {}).items():
+        plug_conf = plug_conf or {}
+        if plug_conf.get("enabled", True) is False:
+            continue
+        policy_class = PolicyProtocolFactory.get_class(plug_name)
+        LOG.info(f"Policy protocol: {policy_class.__name__}")
+        policies.append(policy_class(config=plug_conf))
+    return policies
 
 
 def on_ready():
@@ -123,13 +138,15 @@ class HiveMindService:
         LOG.info(f"BinaryData protocol: {bin_class.__name__}")
 
         bin_protocol = bin_class(agent_protocol=agent_protocol, config=bin_config)
+        policy_protocols = get_policy_protocols()
 
         # start hivemind protocol that will handle HiveMessages
         hm_protocol = self.hm_protocol(identity=self.identity,
                                        db=self.db,
                                        callbacks=self.callbacks,
                                        binary_data_protocol=bin_protocol,
-                                       agent_protocol=agent_protocol)
+                                       agent_protocol=agent_protocol,
+                                       policy_protocols=policy_protocols)
 
         # start network protocols that will carry HiveMessages
         protos = []

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import dataclasses
-from typing import Callable, List, Optional, Type
+from typing import Any, Callable, List, Optional, Type
 
 from ovos_utils import create_daemon, wait_for_exit_signal
 from ovos_utils.log import LOG
@@ -26,9 +26,14 @@ from hivemind_core.database import ClientDatabase
 from hivemind_core.protocol import HiveMindListenerProtocol, ClientCallbacks
 from hivemind_plugin_manager import (AgentProtocolFactory,
                                      NetworkProtocolFactory,
-                                     BinaryDataHandlerProtocolFactory,
-                                     PolicyProtocolFactory)
-from hivemind_plugin_manager.protocols import BinaryDataHandlerProtocol, PolicyProtocol
+                                     BinaryDataHandlerProtocolFactory)
+try:
+    from hivemind_plugin_manager import PolicyProtocolFactory
+    from hivemind_plugin_manager.protocols import PolicyProtocol
+except ImportError:
+    PolicyProtocolFactory = None
+    PolicyProtocol = Any
+from hivemind_plugin_manager.protocols import BinaryDataHandlerProtocol
 
 def get_agent_protocol():
     config = get_server_config()["agent_protocol"]
@@ -51,6 +56,8 @@ def get_policy_protocols() -> List[PolicyProtocol]:
         plug_conf = plug_conf or {}
         if plug_conf.get("enabled", True) is False:
             continue
+        if PolicyProtocolFactory is None:
+            raise RuntimeError("Policy plugins require hivemind-plugin-manager with hivemind.policy support")
         policy_class = PolicyProtocolFactory.get_class(plug_name)
         LOG.info(f"Policy protocol: {policy_class.__name__}")
         policies.append(policy_class(config=plug_conf))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "hivemind_bus_client>=0.7.0a2,<1.0.0",
     "ovos_utils>=0.0.33,<1.0.0",
     "pybase64",
-    "hivemind-plugin-manager>=0.3.0,<1.0.0",
+    "hivemind-plugin-manager>=0.4.1a1,<1.0.0",
     "ovos-bus-client>=1.3.1,<2.0.0",
     "json-database>=0.9.1,<1.0.0",
     "hivemind-websocket-protocol>=0.0.3,<1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "hivemind_bus_client>=0.7.0a2,<1.0.0",
     "ovos_utils>=0.0.33,<1.0.0",
     "pybase64",
-    "hivemind-plugin-manager>=0.4.1a1,<1.0.0",
+    "hivemind-plugin-manager>=0.4.0,<1.0.0",
     "ovos-bus-client>=1.3.1,<2.0.0",
     "json-database>=0.9.1,<1.0.0",
     "hivemind-websocket-protocol>=0.0.3,<1.0.0",

--- a/tests/e2e/test_policy_protocol.py
+++ b/tests/e2e/test_policy_protocol.py
@@ -1,0 +1,160 @@
+"""Policy hooks exercised through a hivescope master/satellite topology."""
+
+import dataclasses
+import time
+from typing import Any, Dict
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+
+from hivescope.scenarios import admin_satellite
+
+import hivemind_core.protocol as protocol_module
+
+
+try:
+    from hivemind_plugin_manager.protocols import PolicyContext, PolicyDecision
+except ImportError:
+    @dataclasses.dataclass
+    class PolicyContext:
+        client: Any = None
+        user: Any = None
+        source_ip: str = ""
+        metadata: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    @dataclasses.dataclass
+    class PolicyDecision:
+        allowed: bool = True
+        reason: str = ""
+        code: str = ""
+        message_type: str = "hive.policy.denied"
+        data: Dict[str, Any] = dataclasses.field(default_factory=dict)
+        context_patch: Dict[str, Any] = dataclasses.field(default_factory=dict)
+        stop_processing: bool = False
+
+
+class CapturePolicy:
+    def __init__(self, decision=None):
+        self.decision = decision or PolicyDecision()
+        self.contexts = []
+        self.recorded = []
+        self.hm_protocol = None
+
+    def authorize_hive_message(self, message, context):
+        self.contexts.append(("hive", context))
+        return PolicyDecision()
+
+    def authorize_bus_message(self, message, context):
+        self.contexts.append(("bus", context))
+        return self.decision
+
+    def authorize_binary_payload(self, message, context):
+        return PolicyDecision()
+
+    def record_bus_message(self, message, context, result=None):
+        self.recorded.append((message, context, result))
+
+
+def _wait_for(condition, timeout: float = 2.0, interval: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if condition():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _attach_policy(monkeypatch, master, policy):
+    monkeypatch.setattr(protocol_module, "PolicyContext", PolicyContext)
+    monkeypatch.setattr(protocol_module, "PolicyDecision", PolicyDecision)
+    policy.hm_protocol = master.hm_protocol
+    master.hm_protocol.policy_protocols = [policy]
+
+
+def _send_utterance(satellite, session_id=None):
+    session_id = session_id or satellite.shim.session_id
+    satellite.send(HiveMessage(
+        HiveMessageType.BUS,
+        payload=Message(
+            "recognizer_loop:utterance",
+            {"utterances": ["hello"]},
+            {
+                "session": {
+                    "session_id": session_id,
+                    "site_id": "client-site",
+                },
+                "api_key": "client-controlled",
+            },
+        ),
+    ))
+
+
+def test_policy_denial_blocks_bus_emit_and_notifies_satellite(monkeypatch):
+    policy = CapturePolicy(PolicyDecision(
+        allowed=False,
+        reason="quota exceeded",
+        code="quota_exceeded",
+        data={"period": "daily"},
+    ))
+    b = admin_satellite()
+    try:
+        m = b.get_master("M0")
+        _attach_policy(monkeypatch, m, policy)
+        b.start_all()
+        s = b.get_satellite("S0")
+
+        denied = []
+        s.shim.emitter.on(HiveMessageType.BUS, denied.append)
+
+        _send_utterance(s)
+
+        assert _wait_for(lambda: len(denied) >= 1), "policy denial was not sent downstream"
+        assert not any(
+            msg.msg_type == "recognizer_loop:utterance"
+            for msg in m.agent_protocol.injected
+        ), m.agent_protocol.injected
+        assert denied[0].payload.msg_type == "hive.policy.denied"
+        assert denied[0].payload.data["code"] == "quota_exceeded"
+        assert denied[0].payload.data["reason"] == "quota exceeded"
+        assert denied[0].payload.data["period"] == "daily"
+        assert policy.recorded == []
+    finally:
+        b.stop_all()
+
+
+def test_policy_context_patch_reaches_master_bus_with_server_user_context(monkeypatch):
+    policy = CapturePolicy(PolicyDecision(
+        context_patch={
+            "session": {
+                "blacklisted_intents": ["quota.intent"],
+                "blacklisted_skills": ["quota.skill"],
+            }
+        }
+    ))
+    b = admin_satellite()
+    try:
+        m = b.get_master("M0")
+        _attach_policy(monkeypatch, m, policy)
+        b.start_all()
+        s = b.get_satellite("S0")
+
+        _send_utterance(s)
+
+        assert _wait_for(lambda: any(
+            msg.msg_type == "recognizer_loop:utterance"
+            for msg in m.agent_protocol.injected
+        )), m.agent_protocol.injected
+
+        emitted = m.agent_protocol.last_injected("recognizer_loop:utterance")
+        session = emitted.context["session"]
+        assert "quota.intent" in session["blacklisted_intents"]
+        assert "quota.skill" in session["blacklisted_skills"]
+
+        bus_context = [ctx for hook, ctx in policy.contexts if hook == "bus"][-1]
+        assert bus_context.client.key == s.identity.access_key
+        assert bus_context.user.api_key == s.identity.access_key
+        assert bus_context.user.name == "test-satellite"
+        assert policy.recorded
+        assert policy.recorded[-1][0].msg_type == "recognizer_loop:utterance"
+    finally:
+        b.stop_all()

--- a/tests/test_client_metadata.py
+++ b/tests/test_client_metadata.py
@@ -1,0 +1,115 @@
+import pytest
+from click import BadParameter
+
+import hivemind_core.database as db_module
+from hivemind_core.database import (
+    CLIENT_SUPPORTS_METADATA,
+    ClientDatabase,
+    METADATA_SUPPORT_REQUIRED,
+)
+from hivemind_core.scripts import parse_client_metadata
+
+
+class MemoryDB:
+    def __init__(self):
+        self.clients = []
+
+    def search_by_value(self, key, value):
+        return [client for client in self.clients if getattr(client, key) == value]
+
+    def add_item(self, client):
+        self.clients.append(client)
+        return True
+
+    def update_item(self, client):
+        return True
+
+    def __len__(self):
+        return len(self.clients)
+
+
+def make_client_db():
+    db = object.__new__(ClientDatabase)
+    db.db = MemoryDB()
+    return db
+
+
+def test_parse_client_metadata_allows_json_object():
+    assert parse_client_metadata('{"account_id":"acct_123"}') == {
+        "account_id": "acct_123",
+    }
+
+
+def test_parse_client_metadata_allows_omitted_value():
+    assert parse_client_metadata(None) is None
+
+
+def test_parse_client_metadata_rejects_empty_value():
+    with pytest.raises(BadParameter):
+        parse_client_metadata("")
+
+
+def test_parse_client_metadata_rejects_invalid_json():
+    with pytest.raises(BadParameter):
+        parse_client_metadata("{")
+
+
+def test_parse_client_metadata_rejects_non_object():
+    with pytest.raises(BadParameter):
+        parse_client_metadata('["account_id"]')
+
+
+def test_add_client_rejects_metadata_when_not_supported(monkeypatch):
+    monkeypatch.setattr(db_module, "CLIENT_SUPPORTS_METADATA", False)
+    db = make_client_db()
+
+    with pytest.raises(RuntimeError) as exc:
+        db.add_client(name="satellite", key="access-key", metadata={"k": "v"})
+
+    assert str(exc.value) == METADATA_SUPPORT_REQUIRED
+
+
+def test_client_supports_metadata_falls_back_to_annotations(monkeypatch):
+    class ClientWithMetadata:
+        __annotations__ = {"metadata": dict}
+
+    def fail_fields(_client):
+        raise TypeError
+
+    monkeypatch.setattr(db_module, "Client", ClientWithMetadata)
+    monkeypatch.setattr(db_module, "fields", fail_fields)
+
+    assert db_module._client_supports_metadata()
+
+
+@pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
+def test_add_client_preserves_metadata():
+    db = make_client_db()
+
+    assert db.add_client(
+        name="satellite",
+        key="access-key",
+        metadata={"account_id": "acct_123"},
+    )
+
+    client = db.get_client_by_api_key("access-key")
+    assert client.metadata == {"account_id": "acct_123"}
+
+
+@pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
+def test_add_client_updates_existing_metadata():
+    db = make_client_db()
+    db.add_client(
+        name="satellite",
+        key="access-key",
+        metadata={"account_id": "acct_123"},
+    )
+
+    assert db.add_client(
+        name="satellite",
+        key="access-key",
+        metadata={"account_id": "acct_456", "group": "standard"},
+    )
+
+    client = db.get_client_by_api_key("access-key")
+    assert client.metadata == {"account_id": "acct_456", "group": "standard"}

--- a/tests/test_session_pipeline.py
+++ b/tests/test_session_pipeline.py
@@ -5,6 +5,7 @@ from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
 
 from hivemind_bus_client import HiveMessage, HiveMessageType
+from hivemind_bus_client.message import HiveMindBinaryPayloadType
 from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
 
 try:
@@ -167,6 +168,34 @@ class TestSessionPipelineHandling(unittest.TestCase):
         )
 
         protocol.agent_bus_callback.assert_called_once()
+
+    def test_no_policy_skips_hive_message_policy_user_lookup(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, ["client-pipeline"])
+        raw_session = {"session_id": "session-1", "site_id": "client-site"}
+        bus_message = _make_bus_message({"session": raw_session})
+
+        protocol.handle_message(
+            HiveMessage(HiveMessageType.BUS, bus_message), client
+        )
+
+        # One lookup updates blacklist data and one updates last_seen.
+        # Policy pre-authorization must not add a third lookup when disabled.
+        self.assertEqual(protocol.db.get_client_by_api_key.call_count, 2)
+
+    def test_no_policy_skips_binary_policy_user_lookup(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, ["client-pipeline"])
+        binary_message = HiveMessage(
+            HiveMessageType.BINARY,
+            b"audio",
+            bin_type=HiveMindBinaryPayloadType.RAW_AUDIO,
+            metadata={},
+        )
+
+        protocol.handle_binary_message(binary_message, client)
+
+        protocol.db.get_client_by_api_key.assert_not_called()
 
     @unittest.skipIf(PolicyDecision is None, "policy protocol support is not installed")
     def test_policy_context_patch_updates_session_acl(self):

--- a/tests/test_session_pipeline.py
+++ b/tests/test_session_pipeline.py
@@ -6,9 +6,29 @@ from ovos_bus_client.session import Session
 
 from hivemind_bus_client import HiveMessage, HiveMessageType
 from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
+from hivemind_plugin_manager.protocols import PolicyDecision, PolicyProtocol
 
 
-def _make_protocol():
+class CapturePolicy(PolicyProtocol):
+    def __init__(self, bus_decision=None):
+        super().__init__()
+        self.bus_decision = bus_decision or PolicyDecision()
+        self.contexts = []
+        self.recorded = []
+
+    def authorize_hive_message(self, message, context):
+        self.contexts.append(context)
+        return PolicyDecision()
+
+    def authorize_bus_message(self, message, context):
+        self.contexts.append(context)
+        return self.bus_decision
+
+    def record_bus_message(self, message, context, result=None):
+        self.recorded.append((message, context, result))
+
+
+def _make_protocol(policy_protocols=None):
     agent = MagicMock()
     agent.bus = MagicMock()
     agent.callbacks = MagicMock()
@@ -17,11 +37,17 @@ def _make_protocol():
     db_user.skill_blacklist = []
     db_user.intent_blacklist = []
     db_user.message_blacklist = []
+    db_user.api_key = "test-key"
+    db_user.name = "server-user"
 
     db = MagicMock()
     db.get_client_by_api_key.return_value = db_user
 
-    return HiveMindListenerProtocol(agent_protocol=agent, db=db)
+    return HiveMindListenerProtocol(
+        agent_protocol=agent,
+        db=db,
+        policy_protocols=policy_protocols or [],
+    )
 
 
 def _make_client(protocol, pipeline):
@@ -136,6 +162,74 @@ class TestSessionPipelineHandling(unittest.TestCase):
         )
 
         protocol.agent_bus_callback.assert_called_once()
+
+    def test_policy_context_patch_updates_session_acl(self):
+        policy = CapturePolicy(PolicyDecision(
+            context_patch={
+                "session": {
+                    "blacklisted_intents": ["quota.intent"],
+                    "blacklisted_skills": ["quota.skill"],
+                }
+            }
+        ))
+        protocol = _make_protocol([policy])
+        client = _make_client(protocol, ["client-pipeline"])
+        client.send = MagicMock()
+        raw_session = {"session_id": "session-1", "site_id": "client-site"}
+        bus_message = _make_bus_message({"session": raw_session})
+
+        protocol.handle_bus_message(
+            HiveMessage(HiveMessageType.BUS, bus_message), client
+        )
+
+        emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
+        self.assertIn("quota.intent", emitted.context["session"]["blacklisted_intents"])
+        self.assertIn("quota.skill", emitted.context["session"]["blacklisted_skills"])
+        self.assertEqual(len(policy.recorded), 1)
+
+    def test_policy_denial_blocks_bus_emit_and_notifies_client(self):
+        policy = CapturePolicy(PolicyDecision(
+            allowed=False,
+            reason="quota exceeded",
+            code="quota_exceeded",
+            data={"period": "daily"},
+        ))
+        protocol = _make_protocol([policy])
+        client = _make_client(protocol, ["client-pipeline"])
+        client.send = MagicMock()
+        raw_session = {"session_id": "session-1", "site_id": "client-site"}
+        bus_message = _make_bus_message({"session": raw_session})
+
+        protocol.handle_bus_message(
+            HiveMessage(HiveMessageType.BUS, bus_message), client
+        )
+
+        protocol.agent_protocol.bus.emit.assert_not_called()
+        response = client.send.call_args[0][0]
+        self.assertEqual(response.msg_type, HiveMessageType.BUS)
+        self.assertEqual(response.payload.msg_type, "hive.policy.denied")
+        self.assertEqual(response.payload.data["code"], "quota_exceeded")
+        self.assertEqual(response.payload.data["reason"], "quota exceeded")
+
+    def test_policy_context_uses_server_owned_user(self):
+        policy = CapturePolicy()
+        protocol = _make_protocol([policy])
+        client = _make_client(protocol, ["client-pipeline"])
+        raw_session = {"session_id": "session-1", "site_id": "client-site"}
+        bus_message = _make_bus_message({
+            "session": raw_session,
+            "api_key": "client-controlled",
+            "name": "client-controlled",
+        })
+
+        protocol.handle_bus_message(
+            HiveMessage(HiveMessageType.BUS, bus_message), client
+        )
+
+        self.assertTrue(policy.contexts)
+        self.assertEqual(policy.contexts[-1].client.key, "test-key")
+        self.assertEqual(policy.contexts[-1].user.api_key, "test-key")
+        self.assertEqual(policy.contexts[-1].user.name, "server-user")
 
 
 if __name__ == "__main__":

--- a/tests/test_session_pipeline.py
+++ b/tests/test_session_pipeline.py
@@ -6,7 +6,12 @@ from ovos_bus_client.session import Session
 
 from hivemind_bus_client import HiveMessage, HiveMessageType
 from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
-from hivemind_plugin_manager.protocols import PolicyDecision, PolicyProtocol
+
+try:
+    from hivemind_plugin_manager.protocols import PolicyDecision, PolicyProtocol
+except ImportError:
+    PolicyDecision = None
+    PolicyProtocol = object
 
 
 class CapturePolicy(PolicyProtocol):
@@ -163,6 +168,7 @@ class TestSessionPipelineHandling(unittest.TestCase):
 
         protocol.agent_bus_callback.assert_called_once()
 
+    @unittest.skipIf(PolicyDecision is None, "policy protocol support is not installed")
     def test_policy_context_patch_updates_session_acl(self):
         policy = CapturePolicy(PolicyDecision(
             context_patch={
@@ -187,6 +193,7 @@ class TestSessionPipelineHandling(unittest.TestCase):
         self.assertIn("quota.skill", emitted.context["session"]["blacklisted_skills"])
         self.assertEqual(len(policy.recorded), 1)
 
+    @unittest.skipIf(PolicyDecision is None, "policy protocol support is not installed")
     def test_policy_denial_blocks_bus_emit_and_notifies_client(self):
         policy = CapturePolicy(PolicyDecision(
             allowed=False,
@@ -211,6 +218,7 @@ class TestSessionPipelineHandling(unittest.TestCase):
         self.assertEqual(response.payload.data["code"], "quota_exceeded")
         self.assertEqual(response.payload.data["reason"], "quota exceeded")
 
+    @unittest.skipIf(PolicyDecision is None, "policy protocol support is not installed")
     def test_policy_context_uses_server_owned_user(self):
         policy = CapturePolicy()
         protocol = _make_protocol([policy])


### PR DESCRIPTION
## Summary

Wires policy plugins into the HiveMind client-to-bus path.

- loads configured policy plugins when the plugin manager supports them
- builds trusted context from the authenticated `api_key` and database record
- allows policy context patches for ACL data
- denies before `bus.emit()` and returns `hive.policy.denied`
- keeps existing static ACL behavior intact
- keeps existing installs working when no policy plugins are configured

## Why

Static ACLs cover fixed permissions well. Some checks depend on current server state. This gives core a small dynamic ACL hook while keeping quota, billing, and deployment-specific logic in plugins.

This does not add hub or account IDs to core. HiveMind stays `api_key` based; any shared quota mapping belongs in the policy plugin or an external service.

## Related

- Architecture: JarbasHiveMind/HiveMind-core#85
- Depends on JarbasHiveMind/hivemind-plugin-manager#19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added policy-driven message authorization with configurable denial handling
  * Added client metadata support accessible via CLI `--metadata` option
  * Extended server configuration for policy settings

* **Documentation**
  * Updated README with policy plugin configuration and metadata usage guidance

* **Tests**
  * Added comprehensive test coverage for policy protocols, client metadata, and end-to-end scenarios

* **Chores**
  * Updated hivemind-plugin-manager minimum version requirement to 0.4.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/HiveMind-core/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->