### PR TITLE
Add client metadata option

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ $ hivemind-core add-client --name "satellite_1" --access-key "mykey123" --passwo
 - **When to use**:  
   Use this command when setting up a new HiveMind client (e.g., Raspberry Pi, IoT device). Provide credentials for
   secure communication with the server.
+- **Optional metadata**:
+  Admins can attach plugin-specific client context with `--metadata`:
+
+```bash
+hivemind-core add-client --name "satellite_1" --metadata '{"account_id":"acct_123","device_type":"satellite"}'
+```
 
 ---
 

--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -13,13 +13,26 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from typing import List, Optional, Iterable
+from dataclasses import fields
+from typing import Any, Dict, List, Optional, Iterable
 
 from ovos_utils.log import LOG
 
 from hivemind_core.config import get_server_config
 from hivemind_plugin_manager import DatabaseFactory
 from hivemind_plugin_manager.database import Client
+
+
+def _client_supports_metadata() -> bool:
+    try:
+        return any(field.name == "metadata" for field in fields(Client))
+    except TypeError:
+        annotations = getattr(Client, "__annotations__", {})
+        return "metadata" in annotations or hasattr(Client, "metadata")
+
+
+CLIENT_SUPPORTS_METADATA = _client_supports_metadata()
+METADATA_SUPPORT_REQUIRED = "Client.metadata requires hivemind-plugin-manager metadata support"
 
 
 class ClientDatabase:
@@ -62,9 +75,12 @@ class ClientDatabase:
                    message_blacklist: Optional[List[str]] = None,
                    allowed_types: Optional[List[str]] = None,
                    crypto_key: Optional[str] = None,
-                   password: Optional[str] = None) -> bool:
+                   password: Optional[str] = None,
+                   metadata: Optional[Dict[str, Any]] = None) -> bool:
         if crypto_key is not None:
             crypto_key = crypto_key[:16]
+        if metadata is not None and not CLIENT_SUPPORTS_METADATA:
+            raise RuntimeError(METADATA_SUPPORT_REQUIRED)
 
         user = self.get_client_by_api_key(key)
         if user:
@@ -85,20 +101,25 @@ class ClientDatabase:
                 user.crypto_key = crypto_key
             if password:
                 user.password = password
+            if metadata is not None:
+                user.metadata = dict(metadata)
             return self.db.update_item(user)
 
-        user = Client(
-            api_key=key,
-            name=name,
-            intent_blacklist=intent_blacklist,
-            skill_blacklist=skill_blacklist,
-            message_blacklist=message_blacklist,
-            crypto_key=crypto_key,
-            client_id=self.total_clients() + 1,
-            is_admin=admin,
-            password=password,
-            allowed_types=allowed_types,
-        )
+        client_data = {
+            "api_key": key,
+            "name": name,
+            "intent_blacklist": intent_blacklist,
+            "skill_blacklist": skill_blacklist,
+            "message_blacklist": message_blacklist,
+            "crypto_key": crypto_key,
+            "client_id": self.total_clients() + 1,
+            "is_admin": admin,
+            "password": password,
+            "allowed_types": allowed_types,
+        }
+        if metadata is not None:
+            client_data["metadata"] = dict(metadata)
+        user = Client(**client_data)
         return self.db.add_item(user)
 
     def update_item(self, client: Client):

--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -13,7 +13,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from dataclasses import fields
 from typing import Any, Dict, List, Optional, Iterable
 
 from ovos_utils.log import LOG
@@ -21,18 +20,6 @@ from ovos_utils.log import LOG
 from hivemind_core.config import get_server_config
 from hivemind_plugin_manager import DatabaseFactory
 from hivemind_plugin_manager.database import Client
-
-
-def _client_supports_metadata() -> bool:
-    try:
-        return any(field.name == "metadata" for field in fields(Client))
-    except TypeError:
-        annotations = getattr(Client, "__annotations__", {})
-        return "metadata" in annotations or hasattr(Client, "metadata")
-
-
-CLIENT_SUPPORTS_METADATA = _client_supports_metadata()
-METADATA_SUPPORT_REQUIRED = "Client.metadata requires hivemind-plugin-manager metadata support"
 
 
 class ClientDatabase:
@@ -79,8 +66,6 @@ class ClientDatabase:
                    metadata: Optional[Dict[str, Any]] = None) -> bool:
         if crypto_key is not None:
             crypto_key = crypto_key[:16]
-        if metadata is not None and not CLIENT_SUPPORTS_METADATA:
-            raise RuntimeError(METADATA_SUPPORT_REQUIRED)
 
         user = self.get_client_by_api_key(key)
         if user:
@@ -105,21 +90,19 @@ class ClientDatabase:
                 user.metadata = dict(metadata)
             return self.db.update_item(user)
 
-        client_data = {
-            "api_key": key,
-            "name": name,
-            "intent_blacklist": intent_blacklist,
-            "skill_blacklist": skill_blacklist,
-            "message_blacklist": message_blacklist,
-            "crypto_key": crypto_key,
-            "client_id": self.total_clients() + 1,
-            "is_admin": admin,
-            "password": password,
-            "allowed_types": allowed_types,
-        }
-        if metadata is not None:
-            client_data["metadata"] = dict(metadata)
-        user = Client(**client_data)
+        user = Client(
+            api_key=key,
+            name=name,
+            intent_blacklist=intent_blacklist,
+            skill_blacklist=skill_blacklist,
+            message_blacklist=message_blacklist,
+            crypto_key=crypto_key,
+            client_id=self.total_clients() + 1,
+            is_admin=admin,
+            password=password,
+            allowed_types=allowed_types,
+            metadata=dict(metadata) if metadata else {},
+        )
         return self.db.add_item(user)
 
     def update_item(self, client: Client):

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -26,6 +26,19 @@ from hivemind_core.service import HiveMindService
 from hivemind_core.config import get_server_config
 
 
+def parse_client_metadata(metadata):
+    """Parse client metadata from a JSON object string."""
+    if metadata is None:
+        return None
+    try:
+        parsed = json.loads(metadata)
+    except json.JSONDecodeError as e:
+        raise click.BadParameter("must be valid JSON") from e
+    if not isinstance(parsed, dict):
+        raise click.BadParameter("must be a JSON object")
+    return parsed
+
+
 def prompt_node_id(db: ClientDatabase) -> int:
     """
     Prompts the user to select a client ID from the database, displaying available clients in a table.
@@ -108,7 +121,8 @@ def listen():
 @click.option("--password", required=False, type=str)
 @click.option("--crypto-key", required=False, type=str)
 @click.option("--admin", default=False, required=False, type=bool)
-def add_client(name, access_key, password, crypto_key, admin):
+@click.option("--metadata", required=False, type=str, help="Client metadata as a JSON object.")
+def add_client(name, access_key, password, crypto_key, admin, metadata):
     """
     Adds a new client to the database, generating credentials if not provided.
     
@@ -122,6 +136,7 @@ def add_client(name, access_key, password, crypto_key, admin):
         password: Optional password. If not provided, a random password is generated.
         crypto_key: Optional 16-character encryption key. If not provided, a random key is generated.
         admin: Boolean indicating whether the client should have administrator privileges.
+        metadata: Optional JSON object with admin-defined client metadata.
     
     Raises:
         ValueError: If the crypto key is not exactly 16 characters, or if the client cannot be added.
@@ -143,11 +158,13 @@ def add_client(name, access_key, password, crypto_key, admin):
 
     password = password or os.urandom(16).hex()
     access_key = access_key or os.urandom(16).hex()
+    client_metadata = parse_client_metadata(metadata)
 
     with ClientDatabase() as db:
         name = name or f"HiveMind-Node-{db.total_clients()}"
         print(f"Database backend: {db.db.__class__.__name__}")
-        success = db.add_client(name, access_key, crypto_key=key, password=password, admin=admin)
+        success = db.add_client(name, access_key, crypto_key=key, password=password,
+                                admin=admin, metadata=client_metadata)
         if not success:
             raise ValueError(f"Error adding User to database: {name}")
 
@@ -161,8 +178,10 @@ def add_client(name, access_key, password, crypto_key, admin):
         print("Admin Privileges:", admin)
         print("Friendly Name:", name)
         print("Access Key:", access_key)
-        print("Password:", password)
+        click.echo(f"Password: {password}")
         print("Encryption Key:", key)
+        if client_metadata is not None:
+            print("Metadata:", json.dumps(user.metadata, sort_keys=True, ensure_ascii=False))
 
         print(
             "WARNING: Encryption Key is deprecated, only use if your client does not support password"
@@ -247,11 +266,11 @@ def delete_client(node_id):
         for client in db:
             if client.client_id == int(node_id):
                 db.delete_client(client.api_key)
-                print(f"Revoked credentials!\n")
+                print("Revoked credentials!\n")
                 print("Node ID:", client.client_id)
                 print("Friendly Name:", client.name)
                 print("Access Key:", client.api_key)
-                print("Password:", client.password)
+                click.echo(f"Password: {client.password}")
                 print("Encryption Key:", client.crypto_key)
                 break
         else:

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -178,7 +178,7 @@ def add_client(name, access_key, password, crypto_key, admin, metadata):
         print("Admin Privileges:", admin)
         print("Friendly Name:", name)
         print("Access Key:", access_key)
-        click.echo(f"Password: {password}")
+        print("Password:", password)
         print("Encryption Key:", key)
         if client_metadata is not None:
             print("Metadata:", json.dumps(user.metadata, sort_keys=True, ensure_ascii=False))
@@ -266,11 +266,11 @@ def delete_client(node_id):
         for client in db:
             if client.client_id == int(node_id):
                 db.delete_client(client.api_key)
-                print("Revoked credentials!\n")
+                print(f"Revoked credentials!\n")
                 print("Node ID:", client.client_id)
                 print("Friendly Name:", client.name)
                 print("Access Key:", client.api_key)
-                click.echo(f"Password: {client.password}")
+                print("Password:", client.password)
                 print("Encryption Key:", client.crypto_key)
                 break
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "hivemind_bus_client>=0.7.0a2,<1.0.0",
     "ovos_utils>=0.0.33,<1.0.0",
     "pybase64",
-    "hivemind-plugin-manager>=0.3.0,<1.0.0",
+    "hivemind-plugin-manager>=0.5.0,<1.0.0",
     "ovos-bus-client>=1.3.1,<2.0.0",
     "json-database>=0.9.1,<1.0.0",
     "hivemind-websocket-protocol>=0.0.3,<1.0.0",

--- a/tests/test_client_metadata.py
+++ b/tests/test_client_metadata.py
@@ -1,0 +1,115 @@
+import pytest
+from click import BadParameter
+
+import hivemind_core.database as db_module
+from hivemind_core.database import (
+    CLIENT_SUPPORTS_METADATA,
+    ClientDatabase,
+    METADATA_SUPPORT_REQUIRED,
+)
+from hivemind_core.scripts import parse_client_metadata
+
+
+class MemoryDB:
+    def __init__(self):
+        self.clients = []
+
+    def search_by_value(self, key, value):
+        return [client for client in self.clients if getattr(client, key) == value]
+
+    def add_item(self, client):
+        self.clients.append(client)
+        return True
+
+    def update_item(self, client):
+        return True
+
+    def __len__(self):
+        return len(self.clients)
+
+
+def make_client_db():
+    db = object.__new__(ClientDatabase)
+    db.db = MemoryDB()
+    return db
+
+
+def test_parse_client_metadata_allows_json_object():
+    assert parse_client_metadata('{"account_id":"acct_123"}') == {
+        "account_id": "acct_123",
+    }
+
+
+def test_parse_client_metadata_allows_omitted_value():
+    assert parse_client_metadata(None) is None
+
+
+def test_parse_client_metadata_rejects_empty_value():
+    with pytest.raises(BadParameter):
+        parse_client_metadata("")
+
+
+def test_parse_client_metadata_rejects_invalid_json():
+    with pytest.raises(BadParameter):
+        parse_client_metadata("{")
+
+
+def test_parse_client_metadata_rejects_non_object():
+    with pytest.raises(BadParameter):
+        parse_client_metadata('["account_id"]')
+
+
+def test_add_client_rejects_metadata_when_not_supported(monkeypatch):
+    monkeypatch.setattr(db_module, "CLIENT_SUPPORTS_METADATA", False)
+    db = make_client_db()
+
+    with pytest.raises(RuntimeError) as exc:
+        db.add_client(name="satellite", key="access-key", metadata={"k": "v"})
+
+    assert str(exc.value) == METADATA_SUPPORT_REQUIRED
+
+
+def test_client_supports_metadata_falls_back_to_annotations(monkeypatch):
+    class ClientWithMetadata:
+        __annotations__ = {"metadata": dict}
+
+    def fail_fields(_client):
+        raise TypeError
+
+    monkeypatch.setattr(db_module, "Client", ClientWithMetadata)
+    monkeypatch.setattr(db_module, "fields", fail_fields)
+
+    assert db_module._client_supports_metadata()
+
+
+@pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
+def test_add_client_preserves_metadata():
+    db = make_client_db()
+
+    assert db.add_client(
+        name="satellite",
+        key="access-key",
+        metadata={"account_id": "acct_123"},
+    )
+
+    client = db.get_client_by_api_key("access-key")
+    assert client.metadata == {"account_id": "acct_123"}
+
+
+@pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
+def test_add_client_updates_existing_metadata():
+    db = make_client_db()
+    db.add_client(
+        name="satellite",
+        key="access-key",
+        metadata={"account_id": "acct_123"},
+    )
+
+    assert db.add_client(
+        name="satellite",
+        key="access-key",
+        metadata={"account_id": "acct_456", "group": "standard"},
+    )
+
+    client = db.get_client_by_api_key("access-key")
+    assert client.metadata == {"account_id": "acct_456", "group": "standard"}

--- a/tests/test_client_metadata.py
+++ b/tests/test_client_metadata.py
@@ -1,31 +1,39 @@
+from unittest.mock import patch
+
 import pytest
 from click import BadParameter
+from click.testing import CliRunner
 
-import hivemind_core.database as db_module
-from hivemind_core.database import (
-    CLIENT_SUPPORTS_METADATA,
-    ClientDatabase,
-    METADATA_SUPPORT_REQUIRED,
-)
-from hivemind_core.scripts import parse_client_metadata
+from hivemind_core.database import ClientDatabase
+from hivemind_core.scripts import add_client, parse_client_metadata
 
 
 class MemoryDB:
+    """Minimal AbstractDB stand-in for ClientDatabase tests."""
+
     def __init__(self):
         self.clients = []
 
     def search_by_value(self, key, value):
-        return [client for client in self.clients if getattr(client, key) == value]
+        return [c for c in self.clients if getattr(c, key, None) == value]
 
     def add_item(self, client):
         self.clients.append(client)
         return True
 
     def update_item(self, client):
+        for i, c in enumerate(self.clients):
+            if c.client_id == client.client_id:
+                self.clients[i] = client
+                return True
+        self.clients.append(client)
         return True
 
     def __len__(self):
         return len(self.clients)
+
+    def __iter__(self):
+        return iter(self.clients)
 
 
 def make_client_db():
@@ -34,82 +42,168 @@ def make_client_db():
     return db
 
 
-def test_parse_client_metadata_allows_json_object():
+# --- parse_client_metadata ---------------------------------------------------
+
+
+def test_parse_metadata_accepts_json_object():
     assert parse_client_metadata('{"account_id":"acct_123"}') == {
         "account_id": "acct_123",
     }
 
 
-def test_parse_client_metadata_allows_omitted_value():
+def test_parse_metadata_accepts_empty_object():
+    assert parse_client_metadata("{}") == {}
+
+
+def test_parse_metadata_passes_through_none():
     assert parse_client_metadata(None) is None
 
 
-def test_parse_client_metadata_rejects_empty_value():
+def test_parse_metadata_rejects_empty_string():
     with pytest.raises(BadParameter):
         parse_client_metadata("")
 
 
-def test_parse_client_metadata_rejects_invalid_json():
+def test_parse_metadata_rejects_malformed_json():
     with pytest.raises(BadParameter):
         parse_client_metadata("{")
 
 
-def test_parse_client_metadata_rejects_non_object():
+def test_parse_metadata_rejects_top_level_array():
     with pytest.raises(BadParameter):
         parse_client_metadata('["account_id"]')
 
 
-def test_add_client_rejects_metadata_when_not_supported(monkeypatch):
-    monkeypatch.setattr(db_module, "CLIENT_SUPPORTS_METADATA", False)
+def test_parse_metadata_rejects_top_level_string():
+    with pytest.raises(BadParameter):
+        parse_client_metadata('"just-a-string"')
+
+
+def test_parse_metadata_rejects_top_level_number():
+    with pytest.raises(BadParameter):
+        parse_client_metadata("42")
+
+
+def test_parse_metadata_accepts_nested_structures():
+    payload = '{"tags":["a","b"],"flags":{"premium":true}}'
+    assert parse_client_metadata(payload) == {
+        "tags": ["a", "b"],
+        "flags": {"premium": True},
+    }
+
+
+# --- ClientDatabase.add_client metadata round-trip --------------------------
+
+
+def test_add_client_persists_metadata():
     db = make_client_db()
-
-    with pytest.raises(RuntimeError) as exc:
-        db.add_client(name="satellite", key="access-key", metadata={"k": "v"})
-
-    assert str(exc.value) == METADATA_SUPPORT_REQUIRED
-
-
-def test_client_supports_metadata_falls_back_to_annotations(monkeypatch):
-    class ClientWithMetadata:
-        __annotations__ = {"metadata": dict}
-
-    def fail_fields(_client):
-        raise TypeError
-
-    monkeypatch.setattr(db_module, "Client", ClientWithMetadata)
-    monkeypatch.setattr(db_module, "fields", fail_fields)
-
-    assert db_module._client_supports_metadata()
-
-
-@pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
-def test_add_client_preserves_metadata():
-    db = make_client_db()
-
     assert db.add_client(
         name="satellite",
         key="access-key",
         metadata={"account_id": "acct_123"},
     )
-
     client = db.get_client_by_api_key("access-key")
     assert client.metadata == {"account_id": "acct_123"}
 
 
-@pytest.mark.skipif(not CLIENT_SUPPORTS_METADATA, reason=METADATA_SUPPORT_REQUIRED)
-def test_add_client_updates_existing_metadata():
+def test_add_client_defaults_metadata_to_empty_dict():
     db = make_client_db()
-    db.add_client(
-        name="satellite",
-        key="access-key",
-        metadata={"account_id": "acct_123"},
-    )
+    assert db.add_client(name="satellite", key="access-key")
+    client = db.get_client_by_api_key("access-key")
+    assert client.metadata == {}
 
+
+def test_add_client_overwrites_metadata_on_existing_client():
+    db = make_client_db()
+    db.add_client(name="satellite", key="access-key", metadata={"account_id": "acct_123"})
     assert db.add_client(
         name="satellite",
         key="access-key",
         metadata={"account_id": "acct_456", "group": "standard"},
     )
-
     client = db.get_client_by_api_key("access-key")
     assert client.metadata == {"account_id": "acct_456", "group": "standard"}
+
+
+def test_add_client_leaves_metadata_alone_when_not_provided_on_update():
+    db = make_client_db()
+    db.add_client(name="satellite", key="access-key", metadata={"account_id": "acct_123"})
+    db.add_client(name="satellite-renamed", key="access-key")
+    client = db.get_client_by_api_key("access-key")
+    assert client.metadata == {"account_id": "acct_123"}
+    assert client.name == "satellite-renamed"
+
+
+def test_add_client_copies_metadata_dict():
+    db = make_client_db()
+    payload = {"account_id": "acct_123"}
+    db.add_client(name="satellite", key="access-key", metadata=payload)
+    payload["account_id"] = "mutated"
+    client = db.get_client_by_api_key("access-key")
+    assert client.metadata == {"account_id": "acct_123"}
+
+
+# --- CLI end-to-end ----------------------------------------------------------
+
+
+def _patched_db_ctx(fake_db):
+    class _Ctx:
+        def __enter__(self): return fake_db
+        def __exit__(self, *a): return False
+    return _Ctx()
+
+
+def test_cli_add_client_with_metadata_flows_to_db():
+    runner = CliRunner()
+    fake_db = make_client_db()
+
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=_patched_db_ctx(fake_db)):
+        result = runner.invoke(
+            add_client,
+            [
+                "--name", "satellite",
+                "--access-key", "access-key",
+                "--password", "pw",
+                "--metadata", '{"account_id":"acct_123"}',
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    client = fake_db.get_client_by_api_key("access-key")
+    assert client.metadata == {"account_id": "acct_123"}
+    assert "Metadata:" in result.output
+    assert '"account_id": "acct_123"' in result.output
+
+
+def test_cli_add_client_rejects_invalid_metadata_json():
+    runner = CliRunner()
+    result = runner.invoke(
+        add_client,
+        ["--name", "satellite", "--access-key", "k", "--password", "pw", "--metadata", "{"],
+    )
+    assert result.exit_code != 0
+    assert "must be valid JSON" in result.output
+
+
+def test_cli_add_client_rejects_metadata_top_level_array():
+    runner = CliRunner()
+    result = runner.invoke(
+        add_client,
+        ["--name", "satellite", "--access-key", "k", "--password", "pw", "--metadata", "[]"],
+    )
+    assert result.exit_code != 0
+    assert "must be a JSON object" in result.output
+
+
+def test_cli_add_client_without_metadata_omits_metadata_line():
+    runner = CliRunner()
+    fake_db = make_client_db()
+
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=_patched_db_ctx(fake_db)):
+        result = runner.invoke(
+            add_client,
+            ["--name", "satellite", "--access-key", "k", "--password", "pw"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Metadata:" not in result.output


### PR DESCRIPTION
Adds `--metadata` to `hivemind-core add-client` so admins can attach optional client context when creating or updating credentials.

Metadata must be a JSON object. If the installed plugin-manager does not support `Client.metadata` yet, the command fails clearly instead of dropping it.

Related: JarbasHiveMind/hivemind-plugin-manager#20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional metadata support when creating clients via the `add-client` CLI command using `--metadata` flag with JSON input.

* **Documentation**
  * Updated README with instructions for passing metadata when creating clients.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/HiveMind-core/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->