### PR TITLE
ci: add lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/lint.yml@dev
+    with:
+      ruff: true
+      pre_commit: false   # set true if .pre-commit-config.yaml exists
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
HiveMind-core was the only repo in the family without lint. Adds the shared OpenVoiceOS/gh-automations lint workflow (ruff, no pre-commit) — same pattern used by hivemind-plugin-manager, hivemind-ovos-agent-plugin, hivemind-sqlite-database, hivemind-redis-database, and hivemind-json-db-plugin.