### PR TITLE
feat: default to SQLite (keep JSON for existing installs) + migrate-db

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -11,5 +11,5 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13"]'
       # Pinned to released PyPI prereleases; drop once these ship stable.
-      pre_install_pip: '"hivescope==0.3.0a1" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1"'
+      pre_install_pip: '"hivescope==0.3.0a1" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1" "hivemind-sqlite-database==0.4.0a1" "hivemind-json-db-plugin==0.0.3a1"'
       test_path: 'tests/'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,4 +13,4 @@ jobs:
       coverage_source: 'hivemind_core'
       test_path: 'tests/e2e/'
       # Pinned to released PyPI prereleases; drop once these ship stable.
-      pre_install_pip: '"hivescope==0.3.0a1" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1"'
+      pre_install_pip: '"hivescope==0.3.0a1" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1" "hivemind-sqlite-database==0.4.0a1" "hivemind-json-db-plugin==0.0.3a1"'

--- a/README.md
+++ b/README.md
@@ -91,14 +91,17 @@ The default configuration
     ]
   },
   "database": {
-    "module": "hivemind-json-db-plugin",
-    "hivemind-json-db-plugin": {
+    "module": "hivemind-sqlite-db-plugin",
+    "hivemind-sqlite-db-plugin": {
       "name": "clients",
       "subfolder": "hivemind-core"
     }
   }
 }
 ```
+
+
+> **Default backend:** fresh installs use **SQLite** (transactional, concurrency-safe, stdlib). An existing JSON deployment (a `clients.json` already on disk) keeps using JSON so upgrades never strand the credentials store. Move an existing store with `hivemind-core migrate-db --to sqlite` (also supports `--from`/`--to` for JSON ⇄ SQLite ⇄ Redis).
 
 ### Policy Admission Chain
 

--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -59,22 +59,41 @@ _DEFAULT = {
             {"module": "hivemind-ovos-agent-policy"},
         ],
     },
-    "database": {"module": "hivemind-json-db-plugin",
-                 "hivemind-json-db-plugin": {
-                     "name": "clients",
-                     "subfolder": "hivemind-core"
-                 }}
 }
+
+
+def _default_database() -> dict:
+    """Pick the default client-database backend.
+
+    Fresh installs default to **SQLite** — transactional, concurrency-safe,
+    stdlib-only — which suits a server authenticating and policy-checking
+    many clients concurrently. An existing JSON deployment (a ``clients.json``
+    already on disk, with no SQLite db yet) keeps its JSON backend so an
+    upgrade never strands the credentials store; move it with
+    ``hivemind-core migrate-db --to sqlite``.
+    """
+    base = os.path.join(xdg_data_home(), "hivemind-core")
+    json_db = os.path.join(base, "clients.json")
+    sqlite_db = os.path.join(base, "clients.db")
+    if os.path.isfile(json_db) and not os.path.isfile(sqlite_db):
+        module = "hivemind-json-db-plugin"
+    else:
+        module = "hivemind-sqlite-db-plugin"
+    return {"module": module,
+            module: {"name": "clients", "subfolder": "hivemind-core"}}
+
+
 def get_server_config() -> JsonStorageXDG:
     """from ~/.config/hivemind-core/server.json """
+    defaults = {**_DEFAULT, "database": _default_database()}
     db = JsonStorageXDG("server",
                           xdg_folder=xdg_config_home(),
                           subfolder="hivemind-core")
     if not os.path.isfile(db.path):
-        db.merge(_DEFAULT)
+        db.merge(defaults)
         db.store()
     # ensure all top level keys are present
-    for k, v in _DEFAULT.items():
+    for k, v in defaults.items():
         if k not in db:
             db[k] = v
     # back-compat for the policy block: legacy installs may have

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -575,6 +575,32 @@ def set_metadata(node_id, metadata, key, value, unset):
         print("Invalid Node ID!")
 
 
+@hmcore_cmds.command(
+    help="Copy all clients from one database backend to another (e.g. JSON "
+         "to SQLite). Records are copied with their full credentials and "
+         "metadata; the source is left untouched.",
+    name="migrate-db")
+@click.option("--from", "from_module", default="hivemind-json-db-plugin",
+              show_default=True, help="Source database backend module.")
+@click.option("--to", "to_module", default="hivemind-sqlite-db-plugin",
+              show_default=True, help="Target database backend module.")
+def migrate_db(from_module, to_module):
+    """Migrate the client store between backends, preserving each record's
+    api_key, password hash, allowed_types, and metadata."""
+    if from_module == to_module:
+        click.echo("--from and --to are the same backend; nothing to do.", err=True)
+        raise click.Abort()
+    cfg = {"name": "clients", "subfolder": "hivemind-core"}
+    src = ClientDatabase(config={"module": from_module, from_module: cfg})
+    dst = ClientDatabase(config={"module": to_module, to_module: cfg})
+    migrated = 0
+    for client in src:
+        dst.db.add_item(client)
+        migrated += 1
+    dst.sync()
+    print(f"Migrated {migrated} client(s) from {from_module} to {to_module}.")
+
+
 @hmcore_cmds.group(name="policy", help="Inspect the policy admission chain.")
 def policy_group():
     """Subcommands for introspecting the configured policy chain."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,11 @@ dependencies = [
     # to >=0.6.0a1 once #27 is released.
     "hivemind-plugin-manager>=0.5.0,<1.0.0",
     "ovos-bus-client>=1.3.1,<2.0.0",
-    "json-database>=0.9.1,<1.0.0",
+    "json-database>=0.10.2a1,<1.0.0",
+    # client-database backends shipped by default: SQLite (the default for
+    # fresh installs) and JSON (kept for existing deployments / opt-in)
+    "hivemind-sqlite-database>=0.2.1",
+    "hivemind-json-db-plugin>=0.0.2",
     "hivemind-websocket-protocol>=0.0.3,<1.0.0",
     "setuptools",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,13 @@ dependencies = [
     # NOTE: floor stays at 0.5.0 while #27 is in CI as a branch install
     # (gh-automations only bumps version.py on merge to dev). Tighten
     # to >=0.6.0a1 once #27 is released.
-    "hivemind-plugin-manager>=0.5.0,<1.0.0",
+    "hivemind-plugin-manager>=0.6.0a1,<1.0.0",
     "ovos-bus-client>=1.3.1,<2.0.0",
     "json-database>=0.10.2a1,<1.0.0",
     # client-database backends shipped by default: SQLite (the default for
     # fresh installs) and JSON (kept for existing deployments / opt-in)
-    "hivemind-sqlite-database>=0.2.1",
-    "hivemind-json-db-plugin>=0.0.2",
+    "hivemind-sqlite-database>=0.3.0a1",
+    "hivemind-json-db-plugin>=0.0.3a1",
     "hivemind-websocket-protocol>=0.0.3,<1.0.0",
     "setuptools",
 ]

--- a/tests/test_db_default.py
+++ b/tests/test_db_default.py
@@ -3,11 +3,24 @@ import os
 import tempfile
 from unittest import mock
 
+import pytest
 from click.testing import CliRunner
 
 from hivemind_core import config as C
 from hivemind_core.database import ClientDatabase
 from hivemind_core.scripts import migrate_db
+
+
+def _sqlite_supports_current_client_model() -> bool:
+    """The published sqlite plugin < 0.3.0a1 references the removed
+    Client.message_blacklist field in add_item; skip the migration test
+    until that schema-v2 build (HiveMind-sqlite-database#32) is released."""
+    try:
+        import importlib.metadata as _m
+        from packaging.version import Version
+        return Version(_m.version("hivemind-sqlite-database")) >= Version("0.3.0a1")
+    except Exception:
+        return False
 
 
 def _make_existing(json=False, sqlite=False):
@@ -36,6 +49,9 @@ def test_sqlite_wins_once_present():
         assert C._default_database()["module"] == "hivemind-sqlite-db-plugin"
 
 
+@pytest.mark.skipif(
+    not _sqlite_supports_current_client_model(),
+    reason="needs hivemind-sqlite-database>=0.3.0a1 (current Client model)")
 def test_migrate_db_copies_clients_json_to_sqlite():
     tmp_json = tempfile.mkdtemp()
     tmp_sqlite = tempfile.mkdtemp()

--- a/tests/test_db_default.py
+++ b/tests/test_db_default.py
@@ -1,0 +1,72 @@
+"""Default client-database backend selection + cross-backend migration."""
+import os
+import tempfile
+from unittest import mock
+
+from click.testing import CliRunner
+
+from hivemind_core import config as C
+from hivemind_core.database import ClientDatabase
+from hivemind_core.scripts import migrate_db
+
+
+def _make_existing(json=False, sqlite=False):
+    tmp = tempfile.mkdtemp()
+    base = os.path.join(tmp, "hivemind-core")
+    os.makedirs(base, exist_ok=True)
+    if json:
+        open(os.path.join(base, "clients.json"), "w").write("{}")
+    if sqlite:
+        open(os.path.join(base, "clients.db"), "w").write("")
+    return tmp
+
+
+def test_fresh_install_defaults_to_sqlite():
+    with mock.patch.object(C, "xdg_data_home", return_value=tempfile.mkdtemp()):
+        assert C._default_database()["module"] == "hivemind-sqlite-db-plugin"
+
+
+def test_existing_json_deployment_is_kept():
+    with mock.patch.object(C, "xdg_data_home", return_value=_make_existing(json=True)):
+        assert C._default_database()["module"] == "hivemind-json-db-plugin"
+
+
+def test_sqlite_wins_once_present():
+    with mock.patch.object(C, "xdg_data_home", return_value=_make_existing(json=True, sqlite=True)):
+        assert C._default_database()["module"] == "hivemind-sqlite-db-plugin"
+
+
+def test_migrate_db_copies_clients_json_to_sqlite():
+    tmp_json = tempfile.mkdtemp()
+    tmp_sqlite = tempfile.mkdtemp()
+    cfgj = {"module": "hivemind-json-db-plugin",
+            "hivemind-json-db-plugin": {"name": "clients", "subfolder": "hivemind-core"}}
+    # seed a JSON db with a client (commit the store explicitly)
+    with mock.patch("hivemind_json_database.xdg_data_home", return_value=tmp_json):
+        from hivemind_json_database import JsonDB
+        jdb = ClientDatabase(config=cfgj)
+        jdb.db = JsonDB(name="clients", subfolder="hivemind-core")
+        jdb.db._db.store()
+        jdb.add_client(name="sat", key="K1", password="pw",
+                       allowed_types=["recognizer_loop:utterance"],
+                       metadata={"skill_blacklist": ["skill-weather"]})
+        jdb.db._db.store()
+
+    runner = CliRunner()
+    with mock.patch("hivemind_json_database.xdg_data_home", return_value=tmp_json), \
+         mock.patch("hivemind_sqlite_database.xdg_data_home", return_value=tmp_sqlite):
+        result = runner.invoke(migrate_db, ["--from", "hivemind-json-db-plugin",
+                                            "--to", "hivemind-sqlite-db-plugin"])
+        assert result.exit_code == 0, result.output
+        assert "Migrated 1 client" in result.output
+        sdb = ClientDatabase(config={"module": "hivemind-sqlite-db-plugin",
+                                     "hivemind-sqlite-db-plugin": {"name": "clients", "subfolder": "hivemind-core"}})
+        got = sdb.get_client_by_api_key("K1")
+        assert got is not None
+        assert got.metadata.get("skill_blacklist") == ["skill-weather"]
+
+
+def test_migrate_db_rejects_same_backend():
+    runner = CliRunner()
+    result = runner.invoke(migrate_db, ["--from", "x", "--to", "x"])
+    assert result.exit_code != 0


### PR DESCRIPTION
Fresh installs now default to **SQLite** — transactional, concurrency-safe, stdlib-only — which fits a server doing concurrent auth + policy reads. An existing JSON deployment (a `clients.json` on disk, no SQLite db yet) keeps JSON so upgrades don't strand the credentials store; `hivemind-core migrate-db --to sqlite` copies records (api_key, password hash, allowed_types, metadata) across backends. Bumps `json_database>=0.10.2a1` — 0.9.1–0.10.1 bundle a colliding `hivemind-json-db-plugin` entry point — and ships both the sqlite + json plugins as deps. 5 new tests cover the detection + migration.