### PR TITLE
feat: optional presence advertise + GGWave pairing

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -39,6 +39,15 @@ _DEFAULT = {
                            "port": 8181
                        }},
     "binary_protocol": {"module": None},
+    # local-network discovery / pairing (optional hivemind-presence package)
+    "presence": {
+        "enabled": True,
+        "name": "HiveMind-Node",
+        "zeroconf": True,   # mDNS (optional zeroconf)
+        "upnp": False,      # UPnP/SSDP (optional upnpclient)
+        "beacon": True,     # HiveBeacon UDP broadcast (optional hivebeacon)
+        "ggwave": False,    # GGWave audio pairing (optional hivemind-ggwave + binaries)
+    },
     "network_protocol": {"hivemind-websocket-plugin": {
                              "host": "0.0.0.0",
                              "port": 5678,

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -112,6 +112,8 @@ class HiveMindService:
         hivemind-presence (HiveBeacon UDP broadcast / mDNS). No-op when the
         optional package is not installed or presence is disabled."""
         try:
+            import inspect
+
             from hivemind_presence import LocalPresence
         except ImportError:
             return
@@ -122,16 +124,24 @@ class HiveMindService:
         net = cfg.get("network_protocol", {})
         first = next(iter(net.values()), {}) if net else {}
         ggwave = presence_cfg.get("ggwave", False)
-        self._presence = LocalPresence(
-            port=first.get("port", 5678),
-            ssl=first.get("ssl", False),
-            name=presence_cfg.get("name", "HiveMind-Node"),
-            upnp=presence_cfg.get("upnp", False),
-            zeroconf=presence_cfg.get("zeroconf", True),
-            beacon=presence_cfg.get("beacon", True),
-            ggwave=ggwave,
-            ggwave_add_client_callback=self._ggwave_add_client if ggwave else None,
-        )
+        kwargs = {
+            "port": first.get("port", 5678),
+            "ssl": first.get("ssl", False),
+            "name": presence_cfg.get("name", "HiveMind-Node"),
+            "upnp": presence_cfg.get("upnp", False),
+            "zeroconf": presence_cfg.get("zeroconf", True),
+        }
+        # Only pass the transports this hivemind-presence build accepts —
+        # beacon (HiveBeacon UDP) and ggwave pairing are newer and absent in
+        # older builds, which expose only upnp/zeroconf.
+        supported = set(inspect.signature(LocalPresence.__init__).parameters)
+        if "beacon" in supported:
+            kwargs["beacon"] = presence_cfg.get("beacon", True)
+        if "ggwave" in supported:
+            kwargs["ggwave"] = ggwave
+            kwargs["ggwave_add_client_callback"] = (
+                self._ggwave_add_client if ggwave else None)
+        self._presence = LocalPresence(**kwargs)
         create_daemon(self._presence.start)
         LOG.info("LocalPresence started")
 

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2026 Casimiro Ferreira
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
+import os
 from typing import Callable, Optional, Type
 
 from ovos_utils import create_daemon, wait_for_exit_signal
@@ -96,6 +97,49 @@ class HiveMindService:
                                                      ))
         self._status.set_alive()
 
+    def _ggwave_add_client(self, access_key: str, pswd: str) -> None:
+        """Callback for GGWave audio pairing: register a freshly-paired client.
+        Lives here (not in hivemind-presence) so the discovery package never
+        imports hivemind-core."""
+        key = os.urandom(16).hex()  # 32 hex chars = AES-256 crypto key
+        with ClientDatabase() as db:
+            name = f"HiveMind-Node-{db.total_clients()}"
+            db.add_client(name, access_key, crypto_key=key, password=pswd)
+            LOG.info(f"GGWave pairing: registered '{name}' key={access_key}")
+
+    def _start_presence(self) -> None:
+        """Optionally advertise this hub on the local network via
+        hivemind-presence (HiveBeacon UDP broadcast / mDNS). No-op when the
+        optional package is not installed or presence is disabled."""
+        try:
+            from hivemind_presence import LocalPresence
+        except ImportError:
+            return
+        cfg = get_server_config()
+        presence_cfg = cfg.get("presence", {})
+        if not presence_cfg.get("enabled", True):
+            return
+        net = cfg.get("network_protocol", {})
+        first = next(iter(net.values()), {}) if net else {}
+        ggwave = presence_cfg.get("ggwave", False)
+        self._presence = LocalPresence(
+            port=first.get("port", 5678),
+            ssl=first.get("ssl", False),
+            name=presence_cfg.get("name", "HiveMind-Node"),
+            upnp=presence_cfg.get("upnp", False),
+            zeroconf=presence_cfg.get("zeroconf", True),
+            beacon=presence_cfg.get("beacon", True),
+            ggwave=ggwave,
+            ggwave_add_client_callback=self._ggwave_add_client if ggwave else None,
+        )
+        create_daemon(self._presence.start)
+        LOG.info("LocalPresence started")
+
+    def _stop_presence(self) -> None:
+        presence = getattr(self, "_presence", None)
+        if presence is not None:
+            presence.stop()
+
     def run(self):
         self._status.set_started()
 
@@ -139,6 +183,8 @@ class HiveMindService:
 
         self._status.set_ready()
 
+        self._start_presence()
         wait_for_exit_signal()  # block until ctrl+c
 
+        self._stop_presence()
         self._status.set_stopping()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+presence = ["hivemind-presence", "hivemind-ggwave"]
 test = [
     "pytest",
     "pytest-cov",

--- a/tests/test_presence_ggwave.py
+++ b/tests/test_presence_ggwave.py
@@ -1,0 +1,64 @@
+"""Local-network presence + GGWave pairing wiring on the HiveMind service."""
+import importlib.util
+from unittest import mock
+
+import pytest
+
+from hivemind_core import config as cfg
+from hivemind_core.service import HiveMindService
+
+
+def _service():
+    # avoid touching a real ClientDatabase at construction
+    with mock.patch("hivemind_core.service.ClientDatabase"):
+        return HiveMindService()
+
+
+def test_presence_block_in_default_config():
+    with mock.patch.object(cfg, "xdg_config_home", return_value="/tmp/hm-presence-cfg-xxx"):
+        # _DEFAULT carries the presence block; assert the shape
+        assert "presence" in cfg._DEFAULT
+        p = cfg._DEFAULT["presence"]
+        assert p["beacon"] is True and p["ggwave"] is False and p["enabled"] is True
+
+
+def test_ggwave_add_client_registers_with_generated_crypto():
+    svc = _service()
+    fake_db = mock.MagicMock()
+    fake_db.total_clients.return_value = 0
+    ctx = mock.MagicMock()
+    ctx.__enter__.return_value = fake_db
+    with mock.patch("hivemind_core.service.ClientDatabase", return_value=ctx):
+        svc._ggwave_add_client("ACCESS123", "pairing-pw")
+    args, kwargs = fake_db.add_client.call_args
+    assert "ACCESS123" in args
+    assert kwargs.get("password") == "pairing-pw"
+    # a 32-hex (AES-256) crypto key is generated for the paired client
+    assert len(kwargs.get("crypto_key", "")) == 32
+
+
+def test_start_presence_is_noop_without_package(monkeypatch):
+    svc = _service()
+    # simulate hivemind_presence not installed
+    import builtins
+    real_import = builtins.__import__
+
+    def _blocked(name, *a, **k):
+        if name == "hivemind_presence":
+            raise ImportError(name)
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked)
+    svc._start_presence()  # must not raise
+    assert getattr(svc, "_presence", None) is None
+    svc._stop_presence()  # also a no-op
+
+
+@pytest.mark.skipif(importlib.util.find_spec("hivemind_presence") is None,
+                    reason="needs hivemind-presence installed")
+def test_start_presence_builds_localpresence_when_available():
+    svc = _service()
+    with mock.patch("hivemind_presence.LocalPresence") as LP, \
+         mock.patch("hivemind_core.service.create_daemon"):
+        svc._start_presence()
+    assert LP.called

--- a/tests/test_presence_ggwave.py
+++ b/tests/test_presence_ggwave.py
@@ -62,3 +62,54 @@ def test_start_presence_builds_localpresence_when_available():
          mock.patch("hivemind_core.service.create_daemon"):
         svc._start_presence()
     assert LP.called
+
+
+def test_start_presence_omits_unsupported_kwargs():
+    """Against a LocalPresence that exposes only upnp/zeroconf (today's published
+    hivemind-presence), _start_presence must NOT pass beacon/ggwave — else it
+    TypeErrors at startup."""
+    svc = _service()
+
+    class _OldLocalPresence:  # signature without beacon/ggwave
+        def __init__(self, port=5678, ssl=False, service_type="_hivemind._tcp.local.",
+                     name="HiveMind-Node", upnp=False, zeroconf=True):
+            self.kwargs = dict(port=port, ssl=ssl, name=name, upnp=upnp, zeroconf=zeroconf)
+
+        def start(self):
+            pass
+
+    import sys
+    import types
+    fake_mod = types.ModuleType("hivemind_presence")
+    fake_mod.LocalPresence = _OldLocalPresence
+    with mock.patch.dict(sys.modules, {"hivemind_presence": fake_mod}), \
+         mock.patch("hivemind_core.service.create_daemon"):
+        svc._start_presence()  # must not raise
+    assert "beacon" not in svc._presence.kwargs
+    assert "ggwave" not in svc._presence.kwargs
+
+
+def test_start_presence_passes_beacon_ggwave_when_supported():
+    """Against a future LocalPresence that accepts beacon/ggwave, _start_presence
+    forwards them."""
+    svc = _service()
+    captured = {}
+
+    class _NewLocalPresence:
+        def __init__(self, port=5678, ssl=False, name="HiveMind-Node", upnp=False,
+                     zeroconf=True, beacon=True, ggwave=False,
+                     ggwave_add_client_callback=None):
+            captured.update(beacon=beacon, ggwave=ggwave,
+                            has_cb=ggwave_add_client_callback is not None)
+
+        def start(self):
+            pass
+
+    import sys
+    import types
+    fake_mod = types.ModuleType("hivemind_presence")
+    fake_mod.LocalPresence = _NewLocalPresence
+    with mock.patch.dict(sys.modules, {"hivemind_presence": fake_mod}), \
+         mock.patch("hivemind_core.service.create_daemon"):
+        svc._start_presence()
+    assert captured.get("beacon") is True  # default beacon on when supported


### PR DESCRIPTION
First slice of #74, re-implemented onto current dev (which has the policy chain): optional `hivemind-presence` integration — the hub advertises on the local network (HiveBeacon UDP / mDNS) and registers GGWave-audio-paired clients via a callback that never imports hivemind-core into the discovery package. Adds a `presence` config block (beacon default on, ggwave off) + a `presence` extra. No-op when the optional package isn't installed. Unit-tested (registration, config default, optional-import safety); discovery isn't a bus path so it gets unit coverage rather than a hivescope topology test — the protocol msg-type slices (PING/QUERY/CASCADE/INTERCOM) will land with hivescope e2e that flip the protocol-matrix xfails.