### PR TITLE
feat: native relay support (bind_upstream)

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -11,5 +11,5 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13"]'
       # Pinned to released PyPI prereleases; drop once these ship stable.
-      pre_install_pip: '"hivescope==0.3.0a1" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1" "hivemind-sqlite-database==0.4.0a1" "hivemind-json-db-plugin==0.0.3a1"'
+      pre_install_pip: '"hivescope==0.4.0a2" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1" "hivemind-sqlite-database==0.4.0a1" "hivemind-json-db-plugin==0.0.3a1"'
       test_path: 'tests/'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,4 +13,4 @@ jobs:
       coverage_source: 'hivemind_core'
       test_path: 'tests/e2e/'
       # Pinned to released PyPI prereleases; drop once these ship stable.
-      pre_install_pip: '"hivescope==0.3.0a1" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1" "hivemind-sqlite-database==0.4.0a1" "hivemind-json-db-plugin==0.0.3a1"'
+      pre_install_pip: '"hivescope==0.4.0a2" "hivemind-plugin-manager==0.6.0a1" "hivemind-ovos-agent-plugin==0.2.0a1" "hivemind-sqlite-database==0.4.0a1" "hivemind-json-db-plugin==0.0.3a1"'

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -234,6 +234,7 @@ class HiveMindListenerProtocol:
     broadcast_callback = None  # slave asked to broadcast payload
     agent_bus_callback = None  # slave asked to inject payload into mycroft bus
     shared_bus_callback = None  # passive sharing of slave device bus (info)
+    _upstream_hm = None  # HiveMessageBusClient to the upstream master when this node relays
 
     def __post_init__(self):
         self.clients = {}
@@ -769,18 +770,8 @@ class HiveMindListenerProtocol:
                 continue
             self.clients[peer].send(payload)
 
-        # send to other masters
-        message = Message(
-            "hive.send.upstream",
-            payload,
-            {
-                "destination": "hive",
-                "source": self.peer,
-                "session": client.sess.serialize(),
-            },
-        )
-        bus = self.get_bus(client)
-        bus.emit(message)
+        # forward upstream to the master this node relays to (no-op at top level)
+        self.propagate_to_master(payload)
 
     def handle_ping_message(
             self, message: HiveMessage, client: HiveMindClientConnection
@@ -832,6 +823,42 @@ class HiveMindListenerProtocol:
         for peer_id, conn in self.clients.items():
             conn.send(own_ping_outer)
 
+    def bind_upstream(self, slave) -> None:
+        """Bind a ``HiveMindSlaveProtocol`` as this node's upstream connection,
+        turning it into a relay: BROADCAST/PROPAGATE from the upstream master
+        are fanned out to downstream clients, and downstream PROPAGATE/ESCALATE
+        are forwarded upstream. ``slave`` must already be bound to a bus.
+        """
+        self._upstream_hm = slave.hm
+        slave.hm.on(HiveMessageType.BROADCAST, self.broadcast_from_master)
+        slave.hm.on(HiveMessageType.PROPAGATE, self.propagate_from_master)
+
+    def broadcast_from_master(self, message: HiveMessage) -> None:
+        """Fan a BROADCAST received from the upstream master out to all
+        downstream clients."""
+        for peer, conn in self.clients.items():
+            conn.send(message)
+
+    def propagate_from_master(self, message: HiveMessage) -> None:
+        """Fan a PROPAGATE received from the upstream master out to all
+        downstream clients."""
+        for peer, conn in self.clients.items():
+            conn.send(message)
+
+    def escalate_to_master(self, payload: HiveMessage) -> None:
+        """Forward an ESCALATE upstream. No-op when this node is the top-level
+        master (nothing bound via :meth:`bind_upstream`)."""
+        if self._upstream_hm is None:
+            return
+        self._upstream_hm.emit(HiveMessage(HiveMessageType.ESCALATE, payload=payload))
+
+    def propagate_to_master(self, payload: HiveMessage) -> None:
+        """Forward a PROPAGATE upstream. No-op when this node is the top-level
+        master (nothing bound via :meth:`bind_upstream`)."""
+        if self._upstream_hm is None:
+            return
+        self._upstream_hm.emit(HiveMessage(HiveMessageType.PROPAGATE, payload=payload))
+
     def handle_escalate_message(
             self, message: HiveMessage, client: HiveMindClientConnection
     ):
@@ -865,6 +892,9 @@ class HiveMindListenerProtocol:
             site = message.target_site_id
             if site and site == self.identity.site_id:
                 self.handle_bus_message(message.payload, client)
+
+        # escalate up the chain to the master this node relays to (no-op at top level)
+        self.escalate_to_master(payload)
 
     def handle_intercom_message(
             self, message: HiveMessage, client: HiveMindClientConnection

--- a/tests/e2e/test_relay_e2e.py
+++ b/tests/e2e/test_relay_e2e.py
@@ -1,0 +1,60 @@
+"""Relay e2e: a dual-role node bound via ``bind_upstream`` forwards downstream
+PROPAGATE/ESCALATE up to its master. Exercises HiveMindListenerProtocol's
+bind_upstream + escalate_to_master / propagate_to_master path.
+"""
+import time
+
+import pytest
+
+pytest.importorskip("hivescope")
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType  # noqa: E402
+from ovos_bus_client.message import Message  # noqa: E402
+from hivescope.topology import TopologyBuilder  # noqa: E402
+from hivescope.assertions import (  # noqa: E402
+    assert_escalate_delivered,
+    assert_propagate_delivered,
+)
+
+
+def _inner(utt):
+    return HiveMessage(HiveMessageType.BUS,
+                       payload=Message("speak", {"utterance": utt}))
+
+
+def _relay_chain():
+    """M0 -> R0 (relay) -> S0, built directly (the bundled chain_topology
+    scenario mishandles add_relay's (sat, master) tuple)."""
+    b = TopologyBuilder()
+    m = b.add_master("M0")
+    m.register_satellite("relay-key", password="relay-password")
+    _sat_side, master_side = b.add_relay("R0", upstream=m)
+    master_side.register_satellite("sat-key", password="sat-password")
+    b.add_satellite("S0", upstream=master_side)
+    return b
+
+
+def test_escalate_forwarded_up_the_relay_chain():
+    b = _relay_chain()
+    b.start_all()
+    try:
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+        s.send(HiveMessage(HiveMessageType.ESCALATE, payload=_inner("up")))
+        time.sleep(0.3)
+        assert_escalate_delivered(m, count=1)
+    finally:
+        b.stop_all()
+
+
+def test_propagate_forwarded_up_the_relay_chain():
+    b = _relay_chain()
+    b.start_all()
+    try:
+        m = b.get_master("M0")
+        s = b.get_satellite("S0")
+        s.send(HiveMessage(HiveMessageType.PROPAGATE, payload=_inner("around")))
+        time.sleep(0.3)
+        assert_propagate_delivered(m, count=1)
+    finally:
+        b.stop_all()


### PR DESCRIPTION
Slice 2 of #74, re-implemented onto current dev's policy-chain dispatch. Adds `HiveMindListenerProtocol.bind_upstream(slave)` — a node binds an upstream slave connection and becomes a relay: the master's BROADCAST/PROPAGATE fan out to downstream clients (`broadcast_from_master`/`propagate_from_master`), and downstream PROPAGATE/ESCALATE forward up (`propagate_to_master`/`escalate_to_master`). Replaces the old `hive.send.upstream` bus-event relay with a direct upstream emit. hivescope e2e (M0→R0→S0 chain) asserts escalate + propagate reach the top master. PING/INTERCOM already landed in dev; QUERY/CASCADE stack on this next. NOTE: hivescope's bundled chain_topology/with_relay scenarios mishandle add_relay's (sat, master) tuple — the e2e builds the chain directly; a hivescope scenario fix is a small follow-up.