### PR TITLE
feat: QUERY message handler

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -470,6 +470,8 @@ class HiveMindListenerProtocol:
             self.handle_broadcast_message(message, client)
         elif message.msg_type == HiveMessageType.ESCALATE:
             self.handle_escalate_message(message, client)
+        elif message.msg_type == HiveMessageType.QUERY:
+            self.handle_query_message(message, client)
         elif message.msg_type == HiveMessageType.INTERCOM:
             self.handle_intercom_message(message, client)
         elif message.msg_type == HiveMessageType.BINARY:
@@ -832,6 +834,7 @@ class HiveMindListenerProtocol:
         self._upstream_hm = slave.hm
         slave.hm.on(HiveMessageType.BROADCAST, self.broadcast_from_master)
         slave.hm.on(HiveMessageType.PROPAGATE, self.propagate_from_master)
+        slave.hm.on(HiveMessageType.QUERY, self.query_from_master)
 
     def broadcast_from_master(self, message: HiveMessage) -> None:
         """Fan a BROADCAST received from the upstream master out to all
@@ -858,6 +861,128 @@ class HiveMindListenerProtocol:
         if self._upstream_hm is None:
             return
         self._upstream_hm.emit(HiveMessage(HiveMessageType.PROPAGATE, payload=payload))
+
+    def query_from_master(self, message: HiveMessage) -> None:
+        """Fan a QUERY received from the upstream master out to downstream clients."""
+        for peer, conn in self.clients.items():
+            conn.send(message)
+
+    def query_to_master(self, payload: HiveMessage, metadata: Optional[dict] = None) -> None:
+        """Forward a QUERY upstream. No-op at the top-level master."""
+        if self._upstream_hm is None:
+            return
+        self._upstream_hm.emit(HiveMessage(HiveMessageType.QUERY, payload=payload,
+                                           metadata=metadata))
+
+    def _try_local_agent_query(self, bus_message: Message,
+                               client: HiveMindClientConnection,
+                               query_id: str) -> Optional[Message]:
+        """Inject *bus_message* into the local agent through the policy
+        admission chain and capture a synchronous response carrying the same
+        ``query_id``. Returns the response Message, or None if the agent did
+        not answer (or the policy denied it)."""
+        bus = self.get_bus(client)
+        holder: List[Message] = []
+        injected_type = bus_message.msg_type
+
+        def _on_response(msg: Union[Message, str]):
+            if isinstance(msg, str):
+                try:
+                    msg = Message.deserialize(msg)
+                except Exception:
+                    return
+            if msg.msg_type == injected_type:
+                return  # the injected request itself
+            if msg.context.get("query_id") == query_id:
+                holder.append(msg)
+
+        bus.on("message", _on_response)
+        try:
+            bus_message.context["query_id"] = query_id
+            # route through the policy admission chain (authorize + review + emit)
+            self.handle_inject_agent_msg(bus_message, client)
+            return holder[0] if holder else None
+        finally:
+            bus.remove("message", _on_response)
+
+    def _build_query_response(self, msg_type: HiveMessageType, response: Message,
+                              query_id: str, originator_peer: str,
+                              responder_peer: str,
+                              route: Optional[list] = None) -> HiveMessage:
+        """Wrap an OVOS *response* as a QUERY/CASCADE response HiveMessage
+        (``is_response=True``)."""
+        inner = HiveMessage(HiveMessageType.BUS, payload=response)
+        msg = HiveMessage(
+            msg_type, payload=inner,
+            metadata={
+                "query_id": query_id,
+                "originator_peer": originator_peer,
+                "responder_peer": responder_peer,
+                "is_response": True,
+            },
+        )
+        if route:
+            msg.replace_route(route)
+        return msg
+
+    def _route_query_response(self, message: HiveMessage,
+                              client: HiveMindClientConnection):
+        """Route a QUERY response downstream toward its originator (direct
+        client if connected here, else fan to downstream peers)."""
+        metadata = message.metadata or {}
+        originator_peer = metadata.get("originator_peer", "")
+        if originator_peer in self.clients:
+            self.clients[originator_peer].send(message)
+        else:
+            for peer in self.clients:
+                if peer == client.peer:
+                    continue
+                self.clients[peer].send(message)
+
+    def handle_query_message(self, message: HiveMessage,
+                             client: HiveMindClientConnection):
+        """QUERY — like ESCALATE but expects a response. Request: try the local
+        agent; if answered, reply downstream; else escalate upstream (or return
+        a no-answer error at the top). Response: route downstream to originator.
+        """
+        LOG.info(f"Received QUERY from: {client.peer}")
+        metadata = message.metadata or {}
+        if metadata.get("is_response", False):
+            self._route_query_response(message, client)
+            return
+
+        payload = self._unpack_message(message, client)
+        if not client.can_escalate:
+            LOG.warning("Received QUERY from client without escalate permission")
+            if self.illegal_callback:
+                self.illegal_callback(payload)
+            client.disconnect()
+            return
+
+        query_id = metadata.get("query_id", str(uuid.uuid4()))
+        originator_peer = metadata.get("originator_peer", client.peer)
+        bus = self.get_bus(client)
+        bus.emit(Message("hive.query.received",
+                         {"query_id": query_id, "originator_peer": originator_peer},
+                         {"source": client.peer}))
+
+        inner = message.payload
+        if inner.msg_type == HiveMessageType.BUS:
+            response = self._try_local_agent_query(inner.payload, client, query_id)
+            if response is not None:
+                client.send(self._build_query_response(
+                    HiveMessageType.QUERY, response, query_id,
+                    originator_peer, self.peer, route=message.route))
+                return
+
+        if self._upstream_hm is not None:
+            self.query_to_master(payload, metadata)
+        else:
+            error_bus = Message("hive.query.timeout",
+                                {"query_id": query_id, "error": "no_answer"})
+            client.send(self._build_query_response(
+                HiveMessageType.QUERY, error_bus, query_id,
+                originator_peer, self.peer, route=message.route))
 
     def handle_escalate_message(
             self, message: HiveMessage, client: HiveMindClientConnection

--- a/tests/e2e/test_query_e2e.py
+++ b/tests/e2e/test_query_e2e.py
@@ -1,0 +1,64 @@
+"""QUERY e2e: a satellite issues a QUERY; the master's local agent answers
+synchronously through the policy admission chain; the response is routed back
+to the originating satellite.
+"""
+import time
+
+import pytest
+
+pytest.importorskip("hivescope")
+
+import inspect  # noqa: E402
+
+
+def _bus_client_has_query_companion() -> bool:
+    """The QUERY round-trip needs the bus-client companion fix: handle_query
+    must unwrap to ``handle_bus(message.payload)``, not pass the QUERY wrapper."""
+    try:
+        from hivemind_bus_client.protocol import HiveMindSlaveProtocol
+        return "message.payload" in inspect.getsource(HiveMindSlaveProtocol.handle_query)
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _bus_client_has_query_companion(),
+    reason="needs hivemind-bus-client QUERY companion (handle_query -> handle_bus(message.payload))",
+)
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType  # noqa: E402
+from ovos_bus_client.message import Message  # noqa: E402
+from hivescope.topology import TopologyBuilder  # noqa: E402
+
+
+def test_query_local_agent_round_trip():
+    b = TopologyBuilder()
+    m = b.add_master("M0")
+    m.register_satellite("sat-key", password="sat-pw",
+                         allowed_types=["recognizer_loop:utterance"])
+    s = b.add_satellite("S0", upstream=m,
+                        allowed_types=["recognizer_loop:utterance"])
+    b.start_all()
+    try:
+        master = b.get_master("M0")
+        sat = b.get_satellite("S0")
+
+        # local agent answers any utterance
+        def _responder(msg):
+            master.agent_protocol.bus.emit(
+                msg.response(data={"answer": "the weather is sunny"}))
+        master.agent_protocol.bus.on("recognizer_loop:utterance", _responder)
+
+        inner = HiveMessage(HiveMessageType.BUS,
+                            payload=Message("recognizer_loop:utterance",
+                                            {"utterances": ["weather"]}))
+        sat.send(HiveMessage(HiveMessageType.QUERY, payload=inner,
+                             metadata={"query_id": "q1", "originator_peer": sat.peer}))
+
+        # the satellite receives an inbound QUERY — the agent's response routed
+        # back to the originator (wait_for already filters direction="in" + QUERY)
+        recv = sat.recorder.wait_for(HiveMessageType.QUERY.value,
+                                     direction="in", timeout=2.0)
+        assert recv is not None, "satellite never received a QUERY response"
+    finally:
+        b.stop_all()


### PR DESCRIPTION
Slice 3 of #74 (stacked on relay #98). QUERY = ESCALATE-with-a-response. `handle_query_message`: request → inject the inner BUS into the local agent **through the policy admission chain** (`handle_inject_agent_msg`, not the removed `_update_blacklist`) and capture a synchronous response by `query_id`; if answered, reply downstream; else `query_to_master` upstream (or a no-answer error at the top). Response → route downstream toward the originator. Relay-aware: `bind_upstream` now also fans QUERY from the master down (`query_from_master`). hivescope e2e does a real satellite→agent→satellite round-trip. **Pairs with the bus-client QUERY companion** (handle_query unwrap fix) — the e2e is gated until that ships. CASCADE stacks next.