### PR TITLE
ci: fix integration workflow startup_failure (system_deps input)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,7 +12,7 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     with:
       python_versions: '["3.11"]'
-      apt_packages: 'python3-dev swig'
+      system_deps: 'python3-dev swig'
       # the streaming stack + a real OVOS (ovos-core) + ovoscope + one test skill
       pre_install_pip: '"ovoscope" "ovos-core" "ovos-skill-hello-world" "hivescope==0.5.0a1" "hivemind-plugin-manager==0.7.0a1" "hivemind-ovos-agent-plugin==0.3.0a1"'
       test_path: 'tests/e2e/test_query_ovoscope_e2e.py'


### PR DESCRIPTION
The integration (live-OVOS) workflow used `apt_packages:` — not a valid gh-automations build-tests input — causing a startup_failure on every PR. Renamed to `system_deps:` (the correct input name).