### PR TITLE
fix: restore hive.ping.received agent-bus event (regression from #98)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -844,6 +844,16 @@ class HiveMindListenerProtocol:
         # Always feed mapper (register sender info)
         self.hive_mapper.on_ping(message, received_at=time.time())
 
+        # Surface every observed PING on the agent bus (discovery/telemetry).
+        # Fires for satellite-originated and flood-cycle pings alike, before the
+        # dedup gate below.
+        self.agent_protocol.bus.emit(Message("hive.ping.received", {
+            "flood_id": flood_id,
+            "peer": ping_payload.get("peer"),
+            "site_id": ping_payload.get("site_id"),
+            "timestamp": ping_payload.get("timestamp"),
+        }))
+
         # Flood-loop prevention: if we already responded to this flood_id, stop
         if not flood_id or flood_id in self._seen_flood_ids:
             return


### PR DESCRIPTION
`handle_ping_message` documents emitting `hive.ping.received` on the agent bus, but #98's relay rework dropped the actual emit — so PING discovery/telemetry silently stopped surfacing on the bus. The **hivemind-test-harness** PING suite (TS-PING-03/04) caught it.

Restores the emit (flood_id + peer + site_id + timestamp), fired per observed PING before the flood-dedup gate. Verified against the harness: TestHivePingReceived{Bus,Flood}Event now pass.