### PR TITLE
fix: allow json-database 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pybase64",
     "hivemind-plugin-manager>=0.7.1a1,<1.0.0",
     "ovos-bus-client>=2.0.0a3",
-    "json-database>=0.10.2a1,<1.0.0",
+    "json-database>=0.10.2a1,<2.0.0",
     "hivemind-sqlite-database>=0.4.0a2",
     "hivemind-json-db-plugin>=0.0.3a2",
     "hivemind-websocket-protocol>=0.0.3,<1.0.0",


### PR DESCRIPTION
`json_database` 1.0.x (now published as `1.0.2a1`) dropped the duplicate `hivemind-json-db-plugin` entry point. hivemind-core capped `json-database<1.0.0`, which (a) keeps the duplicate-entry-point ambiguity and (b) is the **sole remaining blocker** preventing json_database 1.x from resolving in the unified ovos-releases alpha set. Widen to `<2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints to support a broader range of compatible library versions, improving flexibility for installation and integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->