### PR TITLE
feat: route agent bus + query answering through AgentProtocol hooks

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -322,8 +322,11 @@ class HiveMindListenerProtocol:
                 )
 
     def get_bus(self, client: HiveMindClientConnection) -> Union[FakeBus, MessageBusClient]:
-        # allow subclasses to use dedicated bus per client
-        return self.agent_protocol.bus
+        # The agent decides which bus a client's messages land on. Default
+        # agents return their single shared bus; a multiplexing agent (one
+        # isolated brain per access key) returns a per-client bus, so per-key
+        # routing on the inject path stays transparent here.
+        return self.agent_protocol.get_bus(client)
 
     def handle_new_client(self, client: HiveMindClientConnection):
         try:
@@ -998,7 +1001,7 @@ class HiveMindListenerProtocol:
             return False
         answered = False
         try:
-            for chunk in self.agent_protocol.natural_language_query(utterance, lang):
+            for chunk in self.agent_protocol.answer_query(utterance, lang, client=client):
                 if chunk is None:
                     break
                 answered = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "hivemind_bus_client>=0.9.2a1,<1.0.0",
     "ovos_utils>=0.0.33,<1.0.0",
     "pybase64",
-    "hivemind-plugin-manager>=0.7.1a1,<1.0.0",
+    "hivemind-plugin-manager>=0.8.0a1,<1.0.0",
     "ovos-bus-client>=2.0.0a3",
     "json-database>=0.10.2a1,<2.0.0",
     "hivemind-sqlite-database>=0.4.0a2",

--- a/tests/test_policy_chain.py
+++ b/tests/test_policy_chain.py
@@ -706,6 +706,9 @@ class TestProtocolWiring(unittest.TestCase):
         bus = FakeBus()
         agent = MagicMock(spec=AgentProtocol)
         agent.bus = bus
+        # core routes the inject bus through agent.get_bus(client); mirror a
+        # real agent's default (return its own bus).
+        agent.get_bus.return_value = bus
         agent.hm_protocol = None
         agent.callbacks = MagicMock()
         agent.callbacks.on_connect = MagicMock()

--- a/tests/test_session_pipeline.py
+++ b/tests/test_session_pipeline.py
@@ -11,6 +11,9 @@ from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerPro
 def _make_protocol():
     agent = MagicMock()
     agent.bus = MagicMock()
+    # core obtains the inject bus via agent.get_bus(client); a real agent
+    # returns its own bus, so mirror that for the shared-bus case.
+    agent.get_bus.return_value = agent.bus
     agent.callbacks = MagicMock()
 
     db_user = MagicMock()


### PR DESCRIPTION
Routes the agent bus and query answering through the new `AgentProtocol` hooks (see JarbasHiveMind/hivemind-plugin-manager#39):

- `get_bus()` → `agent_protocol.get_bus(client)` (inject path)
- QUERY/CASCADE handler → `agent_protocol.answer_query(utterance, lang, client=client)` (streaming path)

This lets a multiplexing agent (one isolated sub-agent per access key) route per tenant on both paths. Behavior-preserving for existing agents (default hooks return the shared bus / delegate to NLQ).

Depends on hivemind-plugin-manager#39.

Tests: full unit suite green (92) + QUERY e2e (`test_query_e2e`, `test_query_streaming_e2e`) green; two mock-agent fixtures updated to mirror the `get_bus` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message routing so responses can be directed based on the connected client, making multi-client behavior more accurate.
* **Bug Fixes**
  * Fixed local query handling to use the originating connection when generating answers, improving consistency in chat responses.
* **Chores**
  * Updated a core package dependency to a newer compatible version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->