### PR TITLE
fix: basename BINARY(FILE) file_name to block path traversal (#119)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
 import json
+import os
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -584,7 +585,14 @@ class HiveMindListenerProtocol:
             self.binary_data_protocol.handle_receive_tts(bin_data, utt, lang, file_name, client)
         elif message.bin_type == HiveMindBinaryPayloadType.FILE:
             file_name = message.metadata.get("file_name")
-            self.binary_data_protocol.handle_receive_file(bin_data, file_name, client)
+            # SECURITY: file_name is client-supplied. Strip any directory
+            # components so a malicious peer can not escape the intended
+            # download directory (eg. "../../etc/passwd" -> "passwd").
+            safe_name = os.path.basename(file_name) if file_name else ""
+            if not safe_name or safe_name in (".", ".."):
+                LOG.warning(f"Rejecting binary FILE with unsafe file_name: {file_name!r}")
+                return
+            self.binary_data_protocol.handle_receive_file(bin_data, safe_name, client)
         elif message.bin_type == HiveMindBinaryPayloadType.NUMPY_IMAGE:
             # TODO - convert to numpy array
             camera_id = message.metadata.get("camera_id")

--- a/tests/test_binary_filename_traversal.py
+++ b/tests/test_binary_filename_traversal.py
@@ -1,0 +1,81 @@
+"""Regression tests for issue #119 — BINARY(FILE) path traversal.
+
+``handle_binary_message`` must not pass a client-supplied ``file_name``
+verbatim to ``handle_receive_file``: a malicious peer could send
+``../../etc/passwd`` and escape the intended download directory. The
+protocol layer must ``os.path.basename`` the name (and reject empty / "."
+/ ".." results) before handing it to the binary backend.
+"""
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.message import (
+    HiveMessage,
+    HiveMessageType,
+    HiveMindBinaryPayloadType,
+)
+
+from hivemind_core.policy import PolicyChain
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+class _RecordingBinaryProtocol:
+    """Captures the file_name handed to handle_receive_file."""
+
+    def __init__(self):
+        self.received = []
+
+    def handle_receive_file(self, bin_data, file_name, client):
+        self.received.append(file_name)
+
+
+def _make_protocol():
+    proto = object.__new__(HiveMindListenerProtocol)
+    proto.binary_data_protocol = _RecordingBinaryProtocol()
+    # empty chain allows everything
+    proto.policy_chain = PolicyChain()
+    return proto
+
+
+def _file_message(file_name):
+    return HiveMessage(
+        HiveMessageType.BINARY,
+        payload=b"malicious-bytes",
+        bin_type=HiveMindBinaryPayloadType.FILE,
+        metadata={"file_name": file_name},
+    )
+
+
+def test_traversal_filename_is_basenamed():
+    proto = _make_protocol()
+    client = MagicMock()
+    proto.handle_binary_message(_file_message("../../etc/passwd"), client)
+    assert proto.binary_data_protocol.received == ["passwd"]
+
+
+def test_absolute_path_is_basenamed():
+    proto = _make_protocol()
+    client = MagicMock()
+    proto.handle_binary_message(_file_message("/etc/shadow"), client)
+    assert proto.binary_data_protocol.received == ["shadow"]
+
+
+def test_plain_filename_passes_through():
+    proto = _make_protocol()
+    client = MagicMock()
+    proto.handle_binary_message(_file_message("notes.txt"), client)
+    assert proto.binary_data_protocol.received == ["notes.txt"]
+
+
+def test_dotdot_only_is_rejected():
+    proto = _make_protocol()
+    client = MagicMock()
+    proto.handle_binary_message(_file_message("../.."), client)
+    # basename("../..") == ".." -> rejected, nothing handed to backend
+    assert proto.binary_data_protocol.received == []
+
+
+def test_empty_filename_is_rejected():
+    proto = _make_protocol()
+    client = MagicMock()
+    proto.handle_binary_message(_file_message(""), client)
+    assert proto.binary_data_protocol.received == []


### PR DESCRIPTION
## Problem

`handle_binary_message` passes the client-supplied `file_name` (from `message.metadata`) verbatim to `handle_receive_file`. A malicious peer can send `bin_type=FILE` with `file_name="../../etc/passwd"` and escape the intended download directory.

## Fix

Sanitize at the protocol layer with `os.path.basename()` before dispatching to the binary backend, and reject names that reduce to empty / `.` / `..`.

- `../../etc/passwd` -> `passwd`
- `/etc/shadow` -> `shadow`
- `../..` / `""` -> rejected (nothing handed to the backend)

## Tests

`tests/test_binary_filename_traversal.py` — traversal, absolute path, plain name pass-through, and rejection of `..`-only / empty names. Full unit suite green locally.

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)