### PR TITLE
fix: guard update_last_seen against missing/revoked api key (#118)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -401,6 +401,10 @@ class HiveMindListenerProtocol:
         """track timestamps of last client interaction"""
         with self.db:
             user = self.db.get_client_by_api_key(client.key)
+            if user is None:
+                # key was revoked / never existed — nothing to update
+                LOG.debug(f"can not update last seen, no client for key: {client.key}")
+                return
             user.last_seen = time.time()
             LOG.debug(f"updated last seen timestamp: {client.key} - {user.last_seen}")
             self.db.update_item(user)

--- a/tests/test_update_last_seen.py
+++ b/tests/test_update_last_seen.py
@@ -1,0 +1,50 @@
+"""Regression tests for issue #118 — update_last_seen None deref.
+
+``update_last_seen`` looked up the client row by api-key and immediately
+dereferenced it (``user.last_seen = ...``). When the key has been revoked
+or never existed, ``get_client_by_api_key`` returns ``None`` and the
+method crashes with ``AttributeError``. It must guard for ``None`` and
+no-op instead.
+"""
+from unittest.mock import MagicMock
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_protocol(db):
+    proto = object.__new__(HiveMindListenerProtocol)
+    proto.db = db
+    return proto
+
+
+def _mock_db(returned_user):
+    db = MagicMock()
+    # support the `with self.db:` context manager used by update_last_seen
+    db.__enter__.return_value = db
+    db.__exit__.return_value = False
+    db.get_client_by_api_key.return_value = returned_user
+    return db
+
+
+def test_missing_key_does_not_crash():
+    db = _mock_db(None)
+    proto = _make_protocol(db)
+    client = MagicMock(key="revoked-key")
+
+    # must not raise AttributeError
+    proto.update_last_seen(client)
+
+    db.get_client_by_api_key.assert_called_once_with("revoked-key")
+    db.update_item.assert_not_called()
+
+
+def test_present_key_updates_last_seen():
+    user = MagicMock(last_seen=-1)
+    db = _mock_db(user)
+    proto = _make_protocol(db)
+    client = MagicMock(key="good-key")
+
+    proto.update_last_seen(client)
+
+    assert user.last_seen > 0
+    db.update_item.assert_called_once_with(user)


### PR DESCRIPTION
## Problem

`update_last_seen` looks up the client row via `get_client_by_api_key(client.key)` and immediately dereferences it (`user.last_seen = ...`). For a revoked or never-existing key the lookup returns `None`, so the method crashes with `AttributeError: 'NoneType' object has no attribute 'last_seen'`.

## Fix

None-check the lookup result and no-op (debug log) when no client row exists.

## Tests

`tests/test_update_last_seen.py` — missing key no longer raises and skips `update_item`; present key still updates `last_seen` and persists. Verified the missing-key test fails (AttributeError) without the fix.

Fixes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when attempting to update session timestamps with invalid or revoked API credentials. The system now gracefully handles missing credentials without interruption.

* **Tests**
  * Added regression tests to verify proper handling of invalid API key scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->