### PR TITLE
fix: disconnect clients sending illegal BROADCAST/PROPAGATE/ESCALATE (#116)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -743,7 +743,8 @@ class HiveMindListenerProtocol:
             LOG.warning("Received broadcast message from downstream, illegal action")
             if self.illegal_callback:
                 self.illegal_callback(payload)
-            # TODO kick client for misbehaviour so it stops doing that?
+            # kick client for misbehaviour so it stops doing that
+            client.disconnect()
             return
 
         if self.broadcast_callback:
@@ -791,7 +792,8 @@ class HiveMindListenerProtocol:
             LOG.warning("Received propagate message from downstream, illegal action")
             if self.illegal_callback:
                 self.illegal_callback(payload)
-            # TODO kick client for misbehaviour so it stops doing that?
+            # kick client for misbehaviour so it stops doing that
+            client.disconnect()
             return
 
         if self.propagate_callback:
@@ -1170,7 +1172,8 @@ class HiveMindListenerProtocol:
             LOG.warning("Received escalate message from downstream, illegal action")
             if self.illegal_callback:
                 self.illegal_callback(payload)
-            # TODO kick client for misbehaviour so it stops doing that?
+            # kick client for misbehaviour so it stops doing that
+            client.disconnect()
             return
 
         if self.escalate_callback:

--- a/tests/test_illegal_action_disconnect.py
+++ b/tests/test_illegal_action_disconnect.py
@@ -1,0 +1,77 @@
+"""Regression tests for issue #116 — illegal BROADCAST/PROPAGATE/ESCALATE
+must disconnect the offending client.
+
+When a non-admin / unprivileged client sends a BROADCAST, PROPAGATE or
+ESCALATE it tried to fire ``illegal_callback`` and then ``return`` with an
+unfulfilled ``# TODO kick client``. ``handle_query_message`` and
+``handle_cascade_message`` already call ``client.disconnect()`` on the
+equivalent permission violation; these three must mirror that so a
+misbehaving peer is actually kicked.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_protocol():
+    proto = object.__new__(HiveMindListenerProtocol)
+    proto.peer = "master:0.0.0.0"
+    proto.clients = {}
+    proto.illegal_callback = MagicMock()
+    proto.broadcast_callback = MagicMock()
+    proto.propagate_callback = MagicMock()
+    proto.escalate_callback = MagicMock()
+    return proto
+
+
+def _make_client(**flags):
+    client = MagicMock()
+    client.peer = "evil::abc"
+    # default-deny the privilege relevant to each test
+    client.is_admin = flags.get("is_admin", False)
+    client.can_propagate = flags.get("can_propagate", False)
+    client.can_escalate = flags.get("can_escalate", False)
+    return client
+
+
+def _wrap(outer_type):
+    inner = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {"utterance": "hi"}))
+    return HiveMessage(outer_type, payload=inner)
+
+
+def test_illegal_broadcast_disconnects():
+    proto = _make_protocol()
+    client = _make_client(is_admin=False)
+    proto.handle_broadcast_message(_wrap(HiveMessageType.BROADCAST), client)
+    proto.illegal_callback.assert_called_once()
+    client.disconnect.assert_called_once_with()
+    proto.broadcast_callback.assert_not_called()
+
+
+def test_illegal_propagate_disconnects():
+    proto = _make_protocol()
+    client = _make_client(can_propagate=False)
+    proto.handle_propagate_message(_wrap(HiveMessageType.PROPAGATE), client)
+    proto.illegal_callback.assert_called_once()
+    client.disconnect.assert_called_once_with()
+    proto.propagate_callback.assert_not_called()
+
+
+def test_illegal_escalate_disconnects():
+    proto = _make_protocol()
+    client = _make_client(can_escalate=False)
+    proto.handle_escalate_message(_wrap(HiveMessageType.ESCALATE), client)
+    proto.illegal_callback.assert_called_once()
+    client.disconnect.assert_called_once_with()
+    proto.escalate_callback.assert_not_called()
+
+
+def test_authorized_broadcast_does_not_disconnect():
+    proto = _make_protocol()
+    client = _make_client(is_admin=True)
+    proto.handle_broadcast_message(_wrap(HiveMessageType.BROADCAST), client)
+    client.disconnect.assert_not_called()
+    proto.broadcast_callback.assert_called_once()


### PR DESCRIPTION
## Problem

When an unprivileged client sends a BROADCAST (non-admin), PROPAGATE (no `can_propagate`) or ESCALATE (no `can_escalate`), the handlers fire `illegal_callback` and then `return` with an unfulfilled `# TODO kick client` — the misbehaving peer stays connected and can keep spamming. `handle_query_message` and `handle_cascade_message` already call `client.disconnect()` on the equivalent permission violation, so the behaviour was inconsistent.

## Fix

Call `client.disconnect()` after `illegal_callback` in all three handlers, mirroring the QUERY/CASCADE pattern.

## Tests

`tests/test_illegal_action_disconnect.py` — each illegal action fires `illegal_callback`, disconnects the client, and does not run the action callback; an authorized broadcast is not disconnected. Verified the three disconnect assertions fail without the fix.

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)