### PR TITLE
fix: deliver unencrypted INTERCOM inner messages (#117)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1212,31 +1212,39 @@ class HiveMindListenerProtocol:
                 private_key = load_RSA_key(self.identity.private_key)
 
                 decrypted: str = decrypt_RSA(private_key, ciphertext).decode("utf-8")
-                message._payload = HiveMessage.deserialize(decrypted)
+                inner = HiveMessage.deserialize(decrypted)
             except:
                 if k:
                     LOG.error("failed to decrypt message!")
                 else:
                     LOG.debug("failed to decrypt message, not for us")
                 return False
+        elif isinstance(pload, HiveMessage):
+            inner = pload
+        else:
+            # unencrypted intercom: the inner HiveMessage is carried as a
+            # plain dict. Deserialize it so it is dispatched on its OWN
+            # (inner) msg_type instead of the outer INTERCOM type, which
+            # matches no branch below and silently drops the message.
+            inner = HiveMessage.deserialize(pload)
 
-        if message.msg_type == HiveMessageType.BUS:
-            self.handle_bus_message(message, client)
+        if inner.msg_type == HiveMessageType.BUS:
+            self.handle_bus_message(inner, client)
             return True
-        elif message.msg_type == HiveMessageType.PROPAGATE:
-            self.handle_propagate_message(message, client)
+        elif inner.msg_type == HiveMessageType.PROPAGATE:
+            self.handle_propagate_message(inner, client)
             return True
-        elif message.msg_type == HiveMessageType.BROADCAST:
-            self.handle_broadcast_message(message, client)
+        elif inner.msg_type == HiveMessageType.BROADCAST:
+            self.handle_broadcast_message(inner, client)
             return True
-        elif message.msg_type == HiveMessageType.ESCALATE:
-            self.handle_escalate_message(message, client)
+        elif inner.msg_type == HiveMessageType.ESCALATE:
+            self.handle_escalate_message(inner, client)
             return True
-        elif message.msg_type == HiveMessageType.BINARY:
-            self.handle_binary_message(message, client)
+        elif inner.msg_type == HiveMessageType.BINARY:
+            self.handle_binary_message(inner, client)
             return True
-        elif message.msg_type == HiveMessageType.SHARED_BUS:
-            self.handle_client_shared_bus(message.payload, client)
+        elif inner.msg_type == HiveMessageType.SHARED_BUS:
+            self.handle_client_shared_bus(inner.payload, client)
             return True
 
         return False

--- a/tests/test_intercom_unencrypted_delivery.py
+++ b/tests/test_intercom_unencrypted_delivery.py
@@ -1,0 +1,76 @@
+"""Regression tests for issue #117 — unencrypted INTERCOM inner BUS dropped.
+
+``handle_intercom_message`` only deserialized the inner payload in the
+``"ciphertext"`` branch and then dispatched on the OUTER message's
+``msg_type`` (always ``INTERCOM``), which matches no branch — so an
+unencrypted intercom carrying an inner BUS (or PROPAGATE/BROADCAST/...)
+was silently dropped. The inner HiveMessage must be deserialized and
+dispatched on its own (inner) type in both the encrypted and unencrypted
+cases.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_protocol():
+    proto = object.__new__(HiveMindListenerProtocol)
+    proto.identity = MagicMock(public_key="OUR_PUBKEY")
+    proto.handle_bus_message = MagicMock()
+    proto.handle_propagate_message = MagicMock()
+    proto.handle_broadcast_message = MagicMock()
+    proto.handle_escalate_message = MagicMock()
+    proto.handle_binary_message = MagicMock()
+    proto.handle_client_shared_bus = MagicMock()
+    return proto
+
+
+def _unencrypted_intercom(inner, target_pubkey=None):
+    return HiveMessage(
+        HiveMessageType.INTERCOM,
+        payload=inner,
+        target_pubkey=target_pubkey,
+    )
+
+
+def test_unencrypted_inner_bus_is_delivered():
+    proto = _make_protocol()
+    client = MagicMock()
+    inner = HiveMessage(HiveMessageType.BUS,
+                        payload=Message("speak", {"utterance": "hi"}))
+
+    handled = proto.handle_intercom_message(_unencrypted_intercom(inner), client)
+
+    assert handled is True
+    proto.handle_bus_message.assert_called_once()
+    dispatched = proto.handle_bus_message.call_args.args[0]
+    assert dispatched.msg_type == HiveMessageType.BUS
+    assert dispatched.payload.msg_type == "speak"
+
+
+def test_unencrypted_inner_propagate_is_delivered():
+    proto = _make_protocol()
+    client = MagicMock()
+    bus = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {}))
+    inner = HiveMessage(HiveMessageType.PROPAGATE, payload=bus)
+
+    handled = proto.handle_intercom_message(_unencrypted_intercom(inner), client)
+
+    assert handled is True
+    proto.handle_propagate_message.assert_called_once()
+    proto.handle_bus_message.assert_not_called()
+
+
+def test_intercom_for_other_pubkey_is_ignored():
+    proto = _make_protocol()
+    client = MagicMock()
+    inner = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {}))
+
+    handled = proto.handle_intercom_message(
+        _unencrypted_intercom(inner, target_pubkey="SOMEONE_ELSE"), client)
+
+    assert handled is False
+    proto.handle_bus_message.assert_not_called()


### PR DESCRIPTION
## Problem

`handle_intercom_message` only deserialized the inner payload inside the `"ciphertext"` branch, then dispatched on `message.msg_type` — the OUTER message, which for an intercom is always `INTERCOM` and matches none of the BUS/PROPAGATE/BROADCAST/ESCALATE/BINARY/SHARED_BUS branches. So an **unencrypted** intercom (payload is a plain inner-HiveMessage dict) had its inner BUS silently dropped.

## Fix

Resolve the inner `HiveMessage` once — from the decrypted text (encrypted case) or by `HiveMessage.deserialize`-ing the plain dict payload (unencrypted case) — and dispatch on `inner.msg_type`, passing the inner message to the handlers. This also corrects the encrypted path, which previously dispatched the outer message.

## Tests

`tests/test_intercom_unencrypted_delivery.py` — unencrypted inner BUS and inner PROPAGATE are routed to the right handler; an intercom addressed to another pubkey is ignored. Verified the two delivery tests fail (message dropped, returns False) without the fix. Full unit suite green (95 passed).

Fixes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)