### PR TITLE
feat: enforce crypto_required, verify+pin INTERCOM signatures

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -65,7 +65,7 @@ from hivemind_plugin_manager.database import Client
 from hivemind_plugin_manager.policy import PolicyPlugin
 from hivemind_core.policy import PolicyChain
 from poorman_handshake import HandShake, PasswordHandShake
-from poorman_handshake.asymmetric.utils import decrypt_RSA, load_RSA_key
+from poorman_handshake.asymmetric.utils import decrypt_RSA, load_RSA_key, verify_RSA
 
 
 class ProtocolVersion(IntEnum):
@@ -98,6 +98,16 @@ class HiveMindNodeType(str, Enum):
 # response wrapping this control message — the end-of-stream is part of the
 # protocol content, not loose metadata.
 QUERY_STREAM_END = "hive.query.complete"
+
+
+class UnencryptedMessageError(ValueError):
+    """Raised when a cleartext frame arrives on a connection that requires crypto.
+
+    Only HELLO and HANDSHAKE messages may travel unencrypted (they precede
+    session-key establishment); any other cleartext frame on a
+    ``crypto_required`` server is rejected and the client disconnected
+    (HIVEMIND-CRYPTO-1 §4).
+    """
 
 
 @dataclass
@@ -237,7 +247,17 @@ class HiveMindClientConnection:
 
         self.send_msg(payload, is_bin)
 
+    @property
+    def crypto_required(self) -> bool:
+        """True when the listener this connection belongs to mandates encryption.
+
+        Mirrors the ``crypto_required`` flag advertised to clients in the
+        HANDSHAKE payload (``HiveMindListenerProtocol.require_crypto``).
+        """
+        return bool(self.hm_protocol and self.hm_protocol.require_crypto)
+
     def decode(self, payload: str) -> HiveMessage:
+        encrypted = False
         if self.noise_transport is not None:
             # protocol v3 session: only valid Noise transport messages are
             # accepted; tampering/replay/reordering fails AEAD and is fatal
@@ -253,26 +273,44 @@ class HiveMindClientConnection:
                           "disconnecting")
                 self.disconnect()
                 raise
+            # a decoded Noise transport frame is authenticated + encrypted
+            encrypted = True
         elif self.crypto_key:
             # handle binary encryption
             if isinstance(payload, bytes):
                 payload = decrypt_bin(key=self.crypto_key, ciphertext=payload,
                                       cipher=self.cipher)
+                encrypted = True
             # handle json encryption
             elif "ciphertext" in payload:
                 payload = decrypt_from_json(key=self.crypto_key, ciphertext_json=payload,
                                             encoding=self.encoding, cipher=self.cipher)
+                encrypted = True
             else:
                 LOG.warning("Message was unencrypted")
-                # TODO - some error if crypto is required
-        else:
-            pass  # TODO - reject anything except HELLO and HANDSHAKE
 
         if isinstance(payload, bytes):
-            return decode_bitstring(payload)
-        elif isinstance(payload, str):
-            payload = json.loads(payload)
-        return HiveMessage(**payload)
+            message = decode_bitstring(payload)
+        else:
+            if isinstance(payload, str):
+                payload = json.loads(payload)
+            message = HiveMessage(**payload)
+
+        # HIVEMIND-CRYPTO-1 §4 - when the server requires crypto, drop any
+        # cleartext frame that is not part of key establishment. HELLO and
+        # HANDSHAKE MUST remain accepted in the clear (they precede the
+        # session key); everything else is rejected and the client dropped.
+        if (not encrypted
+                and self.crypto_required
+                and message.msg_type not in (HiveMessageType.HELLO,
+                                             HiveMessageType.HANDSHAKE)):
+            LOG.error(f"Dropping unencrypted {message.msg_type} message from "
+                      f"{self.peer}: server requires crypto")
+            self.disconnect()
+            raise UnencryptedMessageError(
+                f"unencrypted {message.msg_type} message rejected: "
+                f"crypto is required")
+        return message
 
     def authorize(self, message: Message) -> bool:
         """Subclass override hook — return False to short-circuit bus
@@ -353,6 +391,13 @@ class HiveMindListenerProtocol:
 
     def __post_init__(self):
         self.clients = {}
+        # TOFU pinning store for INTERCOM origin authentication
+        # (HIVEMIND-CRYPTO-1 §5). Maps a client's access key to the PEM
+        # public key it presented; once pinned, INTERCOM signatures from that
+        # client MUST verify against the pinned key. In-memory for now — pins
+        # last for the lifetime of this listener (the Client DB model has no
+        # pubkey column yet).
+        self.trusted_pubkeys: dict = {}  # client.key -> PEM public key
         self._seen_flood_ids: set = set()
         self._pending_cascades: dict = {}  # query_id -> CascadeCollector
         self.agent_protocol.hm_protocol = self
@@ -895,13 +940,19 @@ class HiveMindListenerProtocol:
 
             envelope = message.payload["envelope"]
             envelope_out = client.pswd_handshake.generate_handshake()
-            client.pswd_handshake.receive_handshake(envelope)
-
-            # if not client.pswd_handshake.receive_and_verify(envelope):
-            #     # TODO - different handles for invalid access key / invalid password
-            #     self.handle_invalid_key_connected(client)
-            #     client.disconnect()
-            #     return
+            # fail-fast: verify the client's envelope was built with the same
+            # password before deriving a key (HIVEMIND-CRYPTO-1 §3.2
+            # RECOMMENDED explicit reject). A wrong password previously only
+            # surfaced as a decrypt failure on the first encrypted frame.
+            try:
+                verified = client.pswd_handshake.receive_and_verify(envelope)
+            except Exception:
+                verified = False
+            if not verified:
+                LOG.warning("Client password handshake verification failed")
+                self.handle_invalid_key_connected(client)
+                client.disconnect()
+                return
 
             # key is derived safely from password in both sides
             # the handshake is validating both ends have the same password
@@ -938,6 +989,16 @@ class HiveMindListenerProtocol:
         if "pubkey" in payload:
             client.pub_key = payload["pubkey"]
             LOG.debug(f"client sent public key")
+            # TOFU pin: first pubkey seen for this access key becomes the
+            # trust anchor for INTERCOM signature verification. A later HELLO
+            # presenting a different key does NOT overwrite the pin.
+            pinned = self.trusted_pubkeys.get(client.key)
+            if pinned is None:
+                self.trusted_pubkeys[client.key] = client.pub_key
+                LOG.debug(f"pinned public key for {client.peer}")
+            elif pinned != client.pub_key:
+                LOG.warning(f"client {client.peer} presented a public key that "
+                            f"does not match its pinned key; keeping the pin")
         else:
             LOG.warning(f"client did NOT send public key")
 
@@ -1467,9 +1528,26 @@ class HiveMindListenerProtocol:
                 ciphertext = pybase64.b64decode(pload["ciphertext"])
                 signature = pybase64.b64decode(pload["signature"])
 
-                # TODO - allow verifying, we need to store trusted pubkeys before this can be done
-                # pub = ""
-                # verified = verify_RSA(pub, ciphertext, signature)
+                # HIVEMIND-CRYPTO-1 §5 - verify the origin signature against
+                # the TOFU-pinned public key (pinned from the client's HELLO).
+                # A signature that fails against a known key means a forged
+                # origin — reject. If no pubkey was ever presented we cannot
+                # authenticate the origin; keep permissive behavior but say so.
+                pub = self.trusted_pubkeys.get(client.key) or client.pub_key
+                if pub:
+                    try:
+                        verified = verify_RSA(pub, ciphertext, signature)
+                    except Exception:
+                        verified = False
+                    if not verified:
+                        LOG.error(f"INTERCOM signature verification failed for "
+                                  f"{client.peer}: rejecting forged/mismatched message")
+                        return False
+                    # first verified sighting pins the key for this listener's lifetime
+                    self.trusted_pubkeys.setdefault(client.key, pub)
+                else:
+                    LOG.warning(f"INTERCOM from {client.peer} has no pinned/known "
+                                f"public key: origin authenticity is unverified")
 
                 private_key = load_RSA_key(self.identity.private_key)
 

--- a/tests/test_crypto_enforcement.py
+++ b/tests/test_crypto_enforcement.py
@@ -1,0 +1,255 @@
+"""Crypto enforcement at the protocol layer (HIVEMIND-CRYPTO-1).
+
+Covers the additive, wire-compatible enforcement paths:
+
+- ``crypto_required`` on receive (§4): a crypto-required server rejects any
+  cleartext frame that is not HELLO/HANDSHAKE and drops the client; a
+  non-required server keeps accepting cleartext; HELLO/HANDSHAKE are always
+  accepted in the clear (they precede key establishment). Encrypted frames
+  are unaffected.
+- INTERCOM origin authentication (§5): signatures are verified against a
+  TOFU-pinned public key (pin source = the pubkey presented in HELLO); a
+  forged/mismatched signature after pinning is rejected; when no pubkey was
+  ever presented the message is still processed (permissive fallback) but
+  origin authenticity is unverified.
+- Password handshake fail-fast (§3.2): a client envelope built with the
+  wrong password is rejected at handshake time instead of only failing to
+  decrypt the first encrypted frame.
+"""
+
+import json
+import os
+import unittest
+from unittest.mock import MagicMock
+
+import pybase64
+import pytest
+from ovos_bus_client.message import Message
+from poorman_handshake import PasswordHandShake
+from poorman_handshake.asymmetric.utils import (create_RSA_key, encrypt_RSA,
+                                                sign_RSA)
+
+from hivemind_bus_client import HiveMessage, HiveMessageType
+from hivemind_bus_client.encryption import (SupportedCiphers,
+                                            SupportedEncodings,
+                                            encrypt_as_json)
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol,
+                                    UnencryptedMessageError)
+
+
+def _make_protocol(require_crypto=True):
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.callbacks = MagicMock()
+
+    db_user = MagicMock()
+    db_user.skill_blacklist = []
+    db_user.intent_blacklist = []
+    db_user.message_blacklist = []
+    db_user.allowed_types = ["speak", "recognizer_loop:utterance"]
+    db_user.is_admin = True
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=require_crypto)
+
+
+def _make_client(protocol, **kwargs):
+    client = HiveMindClientConnection(
+        key="test-key",
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+        **kwargs,
+    )
+    client.name = "test-client"
+    return client
+
+
+def _cleartext_bus_frame():
+    return HiveMessage(HiveMessageType.BUS,
+                       payload=Message("speak", {"utterance": "hi"})).serialize()
+
+
+class TestCryptoRequiredOnReceive(unittest.TestCase):
+    """Fix for: crypto_required advertised but not enforced on inbound frames."""
+
+    def test_cleartext_bus_rejected_when_crypto_required_post_handshake(self):
+        proto = _make_protocol(require_crypto=True)
+        client = _make_client(proto)
+        client.crypto_key = os.urandom(32)  # handshake done
+        with pytest.raises(UnencryptedMessageError):
+            client.decode(_cleartext_bus_frame())
+        client.disconnect.assert_called_once()
+
+    def test_cleartext_bus_rejected_when_crypto_required_pre_handshake(self):
+        proto = _make_protocol(require_crypto=True)
+        client = _make_client(proto)  # no crypto_key yet
+        with pytest.raises(UnencryptedMessageError):
+            client.decode(_cleartext_bus_frame())
+        client.disconnect.assert_called_once()
+
+    def test_cleartext_hello_and_handshake_always_accepted(self):
+        proto = _make_protocol(require_crypto=True)
+        client = _make_client(proto)
+        hello = HiveMessage(HiveMessageType.HELLO,
+                            payload={"pubkey": "xxx"}).serialize()
+        shake = HiveMessage(HiveMessageType.HANDSHAKE,
+                            payload={"envelope": "yyy"}).serialize()
+        assert client.decode(hello).msg_type == HiveMessageType.HELLO
+        assert client.decode(shake).msg_type == HiveMessageType.HANDSHAKE
+        client.disconnect.assert_not_called()
+
+    def test_cleartext_bus_accepted_when_crypto_not_required(self):
+        proto = _make_protocol(require_crypto=False)
+        client = _make_client(proto)
+        msg = client.decode(_cleartext_bus_frame())
+        assert msg.msg_type == HiveMessageType.BUS
+        client.disconnect.assert_not_called()
+
+    def test_cleartext_bus_accepted_without_listener_protocol(self):
+        # connection not attached to a listener: keep permissive behavior
+        client = HiveMindClientConnection(key="k", send_msg=MagicMock(),
+                                          disconnect=MagicMock(),
+                                          handshake=MagicMock())
+        msg = client.decode(_cleartext_bus_frame())
+        assert msg.msg_type == HiveMessageType.BUS
+
+    def test_encrypted_bus_accepted_when_crypto_required(self):
+        proto = _make_protocol(require_crypto=True)
+        client = _make_client(proto)
+        client.crypto_key = os.urandom(32)
+        ciphertext = encrypt_as_json(key=client.crypto_key,
+                                     plaintext=_cleartext_bus_frame(),
+                                     cipher=SupportedCiphers.AES_GCM,
+                                     encoding=SupportedEncodings.JSON_HEX)
+        msg = client.decode(ciphertext)
+        assert msg.msg_type == HiveMessageType.BUS
+        client.disconnect.assert_not_called()
+
+
+class TestIntercomSignatureVerification(unittest.TestCase):
+    """Fix for: INTERCOM end-to-end signatures never verified (origin forgery)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server_pub, cls.server_priv = create_RSA_key()
+        cls.client_pub, cls.client_priv = create_RSA_key()
+        cls.forger_pub, cls.forger_priv = create_RSA_key()
+
+    def setUp(self):
+        self.proto = _make_protocol()
+        import tempfile
+        self._priv_file = tempfile.NamedTemporaryFile(
+            "w", suffix=".pem", delete=False)
+        self._priv_file.write(self.server_priv)
+        self._priv_file.close()
+        self.proto.identity = MagicMock()
+        self.proto.identity.private_key = self._priv_file.name
+        self.proto.identity.public_key = self.server_pub
+        self.client = _make_client(self.proto)
+
+    def tearDown(self):
+        os.unlink(self._priv_file.name)
+
+    def _intercom(self, sign_key):
+        inner = HiveMessage(HiveMessageType.SHARED_BUS,
+                            payload=Message("speak", {"utterance": "hi"}))
+        ciphertext = encrypt_RSA(self.server_pub, inner.serialize())
+        signature = sign_RSA(sign_key, ciphertext)
+        return HiveMessage(
+            HiveMessageType.INTERCOM,
+            payload={"ciphertext": pybase64.b64encode(ciphertext).decode(),
+                     "signature": pybase64.b64encode(signature).decode()})
+
+    def test_valid_signature_accepted_and_pins_on_first_use(self):
+        # pubkey presented in HELLO, nothing pinned yet
+        self.client.pub_key = self.client_pub
+        assert "test-key" not in self.proto.trusted_pubkeys
+        assert self.proto.handle_intercom_message(
+            self._intercom(self.client_priv), self.client) is True
+        assert self.proto.trusted_pubkeys["test-key"] == self.client_pub
+
+    def test_forged_signature_rejected_after_pinning(self):
+        self.proto.trusted_pubkeys["test-key"] = self.client_pub
+        assert self.proto.handle_intercom_message(
+            self._intercom(self.forger_priv), self.client) is False
+
+    def test_pinned_key_wins_over_hello_key(self):
+        # attacker re-HELLOs with its own pubkey but the pin is authoritative
+        self.proto.trusted_pubkeys["test-key"] = self.client_pub
+        self.client.pub_key = self.forger_pub
+        assert self.proto.handle_intercom_message(
+            self._intercom(self.forger_priv), self.client) is False
+
+    def test_no_pubkey_falls_back_to_unverified_processing(self):
+        # peer never presented a pubkey: keep permissive (additive) behavior
+        self.client.pub_key = None
+        assert self.proto.handle_intercom_message(
+            self._intercom(self.forger_priv), self.client) is True
+
+    def test_hello_pins_pubkey_and_keeps_first_pin(self):
+        hello = HiveMessage(HiveMessageType.HELLO,
+                            payload={"pubkey": self.client_pub})
+        self.client.is_admin = True
+        self.proto.handle_hello_message(hello, self.client)
+        assert self.proto.trusted_pubkeys["test-key"] == self.client_pub
+        # a later HELLO with a different key must not overwrite the pin
+        hello2 = HiveMessage(HiveMessageType.HELLO,
+                             payload={"pubkey": self.forger_pub})
+        self.proto.handle_hello_message(hello2, self.client)
+        assert self.proto.trusted_pubkeys["test-key"] == self.client_pub
+
+
+class TestPasswordHandshakeFailFast(unittest.TestCase):
+    """Fix for: wrong password only failed via implicit key-confirmation."""
+
+    # High-entropy passphrases: poorman_handshake>=2.0 rejects weak passwords
+    # in PasswordHandShake, so these tests (which target handshake verification,
+    # not password strength) use secrets that clear the strength floor.
+    _RIGHT_PASSWORD = "correct-horse-battery-staple-92"
+    _WRONG_PASSWORD = "totally-different-quokka-melody-47"
+
+    def _handshake_msg(self, password):
+        peer_side = PasswordHandShake(password)
+        return HiveMessage(HiveMessageType.HANDSHAKE,
+                           payload={"envelope": peer_side.generate_handshake()})
+
+    def test_correct_password_handshake_succeeds(self):
+        proto = _make_protocol()
+        client = _make_client(proto)
+        client.pswd_handshake = PasswordHandShake(self._RIGHT_PASSWORD)
+        proto.handle_handshake_message(self._handshake_msg(self._RIGHT_PASSWORD), client)
+        assert client.crypto_key is not None
+        client.disconnect.assert_not_called()
+        # HANDSHAKE reply with our envelope was sent back
+        client.send_msg.assert_called_once()
+        reply = json.loads(client.send_msg.call_args[0][0])
+        assert reply["msg_type"] == HiveMessageType.HANDSHAKE
+        assert "envelope" in reply["payload"]
+
+    def test_wrong_password_rejected_at_handshake_time(self):
+        proto = _make_protocol()
+        client = _make_client(proto)
+        client.pswd_handshake = PasswordHandShake(self._RIGHT_PASSWORD)
+        proto.handle_handshake_message(self._handshake_msg(self._WRONG_PASSWORD), client)
+        assert client.crypto_key is None
+        client.disconnect.assert_called_once()
+        client.send_msg.assert_not_called()
+
+    def test_garbage_envelope_rejected_at_handshake_time(self):
+        proto = _make_protocol()
+        client = _make_client(proto)
+        client.pswd_handshake = PasswordHandShake(self._RIGHT_PASSWORD)
+        msg = HiveMessage(HiveMessageType.HANDSHAKE,
+                          payload={"envelope": "not-a-real-envelope"})
+        proto.handle_handshake_message(msg, client)
+        assert client.crypto_key is None
+        client.disconnect.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tier-0 additive crypto-enforcement fixes from the security audit (`reviews/architecture-audit-2026-07-04/crypto-audit.md`). All changes live in `hivemind_core/protocol.py`; the wire format, serialization, encodings and handshake key derivation are untouched, so a correctly-behaving existing client is unaffected.

## Fix 1 — enforce `crypto_required` on receive (audit Finding 3)
`HiveMindClientConnection.decode()` now rejects any cleartext inbound frame that is not HELLO or HANDSHAKE when the listener has `require_crypto` set (the same flag already advertised to clients as `crypto_required` in the HANDSHAKE payload). The client is disconnected and a new `UnencryptedMessageError` is raised. HELLO/HANDSHAKE stay accepted in the clear (they precede key establishment), and servers with `require_crypto=False` keep the previous permissive behavior. This closes the "MUST drop unencrypted post-handshake frames" spec-vs-code gap (HIVEMIND-CRYPTO-1 §4).

## Fix 2 — INTERCOM signature verification with TOFU pubkey pinning (audit Finding 5)
`handle_intercom_message()` now verifies the payload signature with `verify_RSA(pub, ciphertext, signature)` before decrypting. The trust anchor is the pubkey the client presented in HELLO, pinned trust-on-first-use in a new `trusted_pubkeys` store keyed by access key; a later HELLO with a different key does not overwrite the pin, and a signature that fails against a known key is rejected (message dropped, logged). Peers that never presented a pubkey keep working — the message is processed but logged as origin-unverified (additive, no hard-fail).

Note: the pin store is **in-memory** (lifetime of the listener). The `Client` DB model has no pubkey column yet (`pub_key` on the connection carries a `TODO add field to database`); persisting pins across restarts is follow-up work.

## Fix 3 — password handshake fail-fast (audit Finding 9)
The previously commented-out server-side verification is enabled: `pswd_handshake.receive_and_verify(envelope)` rejects a client envelope built with the wrong password at handshake time (via `handle_invalid_key_connected` + disconnect) instead of only failing implicitly on the first encrypted frame. Key derivation for a correct password is byte-identical to before (`receive_and_verify` performs the same `receive_handshake` after verifying).

## Test evidence
New `tests/test_crypto_enforcement.py` (14 tests): cleartext BUS rejected pre- and post-handshake on a crypto-required server; HELLO/HANDSHAKE always accepted in clear; permissive server unaffected; encrypted frames unaffected; valid signed INTERCOM accepted + pins on first use; forged/mismatched signature rejected after pinning; pinned key wins over a re-HELLO'd key; no-pubkey fallback stays permissive; correct-password handshake succeeds; wrong-password and garbage envelopes rejected at handshake time.

Full suite (including hivescope e2e handshake/relay/query tests):

```
164 passed, 2 skipped, 1 xfailed in 149.39s (0:02:29)
```

ruff: no new violations introduced (remaining findings pre-date this PR).

⚠️ security code — human review required before merge; the breaking crypto overhaul (Noise handshake, forward secrecy, replay sequence-binding) remains a separate protocol-v3 decision, see reviews/architecture-audit-2026-07-04/crypto-audit.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**CI note:** the one failing job (`test_explicit_none_pipeline_is_treated_as_absent`) is a **pre-existing dev-wide failure**, not introduced here — the test predates this branch, this PR does not touch session serialization, and `origin/dev` itself is currently red on the same test (ovos-bus-client now serializes `pipeline: []`). This PR's own new tests (`test_crypto_enforcement.py`, 14) all pass; 163 passed / 1 failed = the inherited failure. The bus-client/test fix is a separate dev-hygiene item.
