### PR TITLE
Delegate client refresh in ClientDatabase

### DIFF
--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -41,6 +41,12 @@ class ClientDatabase:
             return search[0]
         return None
 
+    def get_client_by_id(self, client_id: int) -> Optional[Client]:
+        return self.db.get_client_by_id(client_id)
+
+    def refresh(self, client_id: int) -> Optional[Client]:
+        return self.db.refresh(client_id)
+
     def add_client(self,
                    name: str,
                    key: str = "",

--- a/tests/test_db_default.py
+++ b/tests/test_db_default.py
@@ -44,6 +44,20 @@ def test_existing_json_deployment_is_kept():
         assert C._default_database()["module"] == "hivemind-json-db-plugin"
 
 
+def test_client_database_delegates_client_refresh():
+    backend = mock.Mock()
+    backend.get_client_by_id.return_value = "by-id"
+    backend.refresh.return_value = "fresh"
+
+    db = object.__new__(ClientDatabase)
+    db.db = backend
+
+    assert db.get_client_by_id(7) == "by-id"
+    assert db.refresh(7) == "fresh"
+    backend.get_client_by_id.assert_called_once_with(7)
+    backend.refresh.assert_called_once_with(7)
+
+
 def test_sqlite_wins_once_present():
     with mock.patch.object(C, "xdg_data_home", return_value=_make_existing(json=True, sqlite=True)):
         assert C._default_database()["module"] == "hivemind-sqlite-db-plugin"


### PR DESCRIPTION
Fixes #45.

Small wrapper mismatch in the admission path.

`HiveMindClientConnection.resolve_user()` calls `db.refresh(client_id)`. The backends already expose that, but `ClientDatabase` did not proxy it, so policy refresh could fall back to stale connection state.

This adds the missing `get_client_by_id` / `refresh` delegation and a small regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new client lookup and refresh capabilities to the database interface, making it easier to retrieve and update client records.
* **Tests**
  * Added coverage to ensure client lookup and refresh requests are correctly passed through to the underlying database layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->