### PR TITLE
Document horizontal scaling limits

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,27 +147,16 @@ fleets.
 
 ### Load-test signal
 
-A July 2026 production-style WSS benchmark on Thalovant public hubs showed the current
-limit clearly. The corrected run used direct WSS through the Node SDK with disposable
-HiveMind client identities, so each connection authenticated as a real client instead of
-sharing one preview credential.
-
-| Hub | Shape | Result | Bottleneck signal |
-|---|---|---|---|
-| Daily Desk | 100 held clients, 25 asks in flight | 100/100 replies, p95 about 13s | clean run; listener not saturated |
-| Daily Desk | 200 held clients, 50 asks in flight | 200/200 replies, p95 about 25s | listener doing most of the work; OVOS still low |
-| Daily Desk | 400 held clients, 100 asks in flight | 400/400 replies, p95 about 52s, p99 about 72s | listener around 1.17 CPU; busiest OVOS worker around 0.44 CPU |
-| Learning Lounge | 200 held clients, 50 asks in flight | 200/200 replies, p95 about 29s | listener around 1.15 CPU; OVOS lower than listener |
-
-An earlier 200-socket burst reused the same preview-bridge credential for every
-connection and produced WSS open timeouts. That is useful as a transport/admission
-stress case, but it is not a clean model of many independent clients.
+Recent production-style WSS benchmarks with many independent client identities showed a
+consistent pattern: one logical hub can complete concurrent direct WSS requests, but high
+fan-in increases tail latency inside the listener before OVOS runtime CPU becomes the only
+pressure point.
 
 That pattern means adding OVOS replicas alone does not solve one-hub concurrency. The
 first pressure point is the websocket/listener process: handshake admission, message
 decode/logging, policy review, and agent-bus injection all pass through one process-local
-router. OVOS bus pooling and runtime replicas help once messages leave the listener, but
-the listener must first drain inbound clients quickly enough.
+router. Runtime replicas help once messages leave the listener, but the listener must
+first drain inbound clients quickly enough.
 
 The control plane has its own burst cost: provisioning hundreds of disposable clients and
 credential secrets took minutes. Large launches should pre-provision client identities or
@@ -178,8 +167,6 @@ Near-term mitigations:
 - keep per-message and per-disconnect logs at debug level on hot paths;
 - use direct database lookup for API-key admission instead of full database sync on every
   websocket open;
-- apply bounded admission/backpressure so clients fail fast instead of waiting for long
-  socket or query timeouts;
 - benchmark with independent client identities when measuring user concurrency;
 - shard load across more logical hubs when interactive latency matters.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,35 @@ Central Hub
 
 ---
 
+## Horizontal Scaling Status
+
+A single `HiveMindListenerProtocol` instance is currently the authoritative runtime for
+one hub process. The listener keeps live connection state in memory (`clients`,
+`hive_mapper`, pending cascade collectors, trusted public keys, query callbacks, and the
+agent bus binding). Running two pods behind the same load balancer is therefore safe only
+with sticky websocket routing and an external database; it is not yet active-active
+sharding.
+
+Before HiveMind can scale one logical hub across several listener pods, these pieces need
+to move out of process-local memory:
+
+- **Client/session registry**: live peers, session ids, node type, capabilities, and
+  disconnect events need a shared registry or a transport backplane.
+- **Routing map**: `HiveMapper` routes must be shared so any pod can find the pod that
+  owns a target peer.
+- **QUERY/CASCADE collectors**: pending query ids and streamed answer chunks need a
+  shared collector or deterministic ownership.
+- **Inter-pod delivery**: messages for a client connected to another pod need a pub/sub
+  backplane instead of direct in-process method calls.
+- **Admission metrics**: policy timing, quota timing, bus emit timing, and agent response
+  timing should be recorded separately so operators can see which stage is saturated.
+
+Until those pieces exist, scale by sharding at the hub level: run multiple independent
+hubs, keep websocket stickiness for each hub, and use relay/nested topology for larger
+fleets.
+
+---
+
 ## Identity and Encryption
 
 Each hub has a `NodeIdentity` (stored by `hivemind-bus-client`). Satellites and hubs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,20 +148,30 @@ fleets.
 ### Load-test signal
 
 A July 2026 production-style WSS benchmark on Thalovant public hubs showed the current
-limit clearly:
+limit clearly. The corrected run used direct WSS through the Node SDK with disposable
+HiveMind client identities, so each connection authenticated as a real client instead of
+sharing one preview credential.
 
 | Hub | Shape | Result | Bottleneck signal |
 |---|---|---|---|
-| Daily Desk | 400 held clients, 50 asks in flight | 400/400 replies, p95 about 37s | listener near 1.2 CPU, OVOS workers below 0.2 CPU |
-| Daily Desk | 200 connected clients, 200 asks in flight | 200/200 replies, p95 about 99s | listener dispatch saturated before OVOS |
-| Daily Desk | 200 simultaneous opens and asks | 140/200 replies; most failures were WSS open timeouts | websocket open/admission path saturated |
-| Learning Lounge | 100 held clients, 50 asks in flight | 100/100 replies, p95 about 32s | listener near 1.1 CPU, busiest OVOS worker about 0.3 CPU |
+| Daily Desk | 100 held clients, 25 asks in flight | 100/100 replies, p95 about 13s | clean run; listener not saturated |
+| Daily Desk | 200 held clients, 50 asks in flight | 200/200 replies, p95 about 25s | listener doing most of the work; OVOS still low |
+| Daily Desk | 400 held clients, 100 asks in flight | 400/400 replies, p95 about 52s, p99 about 72s | listener around 1.17 CPU; busiest OVOS worker around 0.44 CPU |
+| Learning Lounge | 200 held clients, 50 asks in flight | 200/200 replies, p95 about 29s | listener around 1.15 CPU; OVOS lower than listener |
+
+An earlier 200-socket burst reused the same preview-bridge credential for every
+connection and produced WSS open timeouts. That is useful as a transport/admission
+stress case, but it is not a clean model of many independent clients.
 
 That pattern means adding OVOS replicas alone does not solve one-hub concurrency. The
 first pressure point is the websocket/listener process: handshake admission, message
 decode/logging, policy review, and agent-bus injection all pass through one process-local
 router. OVOS bus pooling and runtime replicas help once messages leave the listener, but
 the listener must first drain inbound clients quickly enough.
+
+The control plane has its own burst cost: provisioning hundreds of disposable clients and
+credential secrets took minutes. Large launches should pre-provision client identities or
+batch onboarding separately from runtime WSS capacity tests.
 
 Near-term mitigations:
 
@@ -170,6 +180,7 @@ Near-term mitigations:
   websocket open;
 - apply bounded admission/backpressure so clients fail fast instead of waiting for long
   socket or query timeouts;
+- benchmark with independent client identities when measuring user concurrency;
 - shard load across more logical hubs when interactive latency matters.
 
 Active-active listener scale needs a larger change: a shared connection/session registry,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,6 +145,38 @@ Until those pieces exist, scale by sharding at the hub level: run multiple indep
 hubs, keep websocket stickiness for each hub, and use relay/nested topology for larger
 fleets.
 
+### Load-test signal
+
+A July 2026 production-style WSS benchmark on Thalovant public hubs showed the current
+limit clearly:
+
+| Hub | Shape | Result | Bottleneck signal |
+|---|---|---|---|
+| Daily Desk | 400 held clients, 50 asks in flight | 400/400 replies, p95 about 37s | listener near 1.2 CPU, OVOS workers below 0.2 CPU |
+| Daily Desk | 200 connected clients, 200 asks in flight | 200/200 replies, p95 about 99s | listener dispatch saturated before OVOS |
+| Daily Desk | 200 simultaneous opens and asks | 140/200 replies; most failures were WSS open timeouts | websocket open/admission path saturated |
+| Learning Lounge | 100 held clients, 50 asks in flight | 100/100 replies, p95 about 32s | listener near 1.1 CPU, busiest OVOS worker about 0.3 CPU |
+
+That pattern means adding OVOS replicas alone does not solve one-hub concurrency. The
+first pressure point is the websocket/listener process: handshake admission, message
+decode/logging, policy review, and agent-bus injection all pass through one process-local
+router. OVOS bus pooling and runtime replicas help once messages leave the listener, but
+the listener must first drain inbound clients quickly enough.
+
+Near-term mitigations:
+
+- keep per-message and per-disconnect logs at debug level on hot paths;
+- use direct database lookup for API-key admission instead of full database sync on every
+  websocket open;
+- apply bounded admission/backpressure so clients fail fast instead of waiting for long
+  socket or query timeouts;
+- shard load across more logical hubs when interactive latency matters.
+
+Active-active listener scale needs a larger change: a shared connection/session registry,
+cross-listener message delivery, and deterministic ownership for query/cascade collectors.
+Without that, multiple listener pods behind one service can only safely work as sticky
+websocket replicas, not as a true shared hub.
+
 ---
 
 ## Identity and Encryption


### PR DESCRIPTION
Documents the current active-active limits in HiveMind-core: in-memory clients, mapper state, cascade collectors, TOFU pins, sticky routing needs, and DB sync behavior.

Trimmed after review to remove Thalovant-specific benchmark names and claims about unmerged mitigations.

Tested: docs-only change.