### PR TITLE
Debounce last_seen database updates

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -80,9 +80,11 @@ _DEFAULT = {
         ],
     },
 
-    # Avoid a synchronous client-db write on every single client message.
-    # Set to 0 to restore the old per-message last_seen update behavior.
-    "last_seen_update_interval": 30,
+    # Optional debounce for the synchronous client-db last_seen write.
+    # The default preserves the old per-message update behavior. Set to a
+    # positive number of seconds only when the downstream runtime can absorb
+    # the extra admission rate.
+    "last_seen_update_interval": 0,
 }
 
 

--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -79,6 +79,10 @@ _DEFAULT = {
             {"module": "hivemind-ovos-agent-policy"},
         ],
     },
+
+    # Avoid a synchronous client-db write on every single client message.
+    # Set to 0 to restore the old per-message last_seen update behavior.
+    "last_seen_update_interval": 30,
 }
 
 

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -410,8 +410,8 @@ class HiveMindListenerProtocol:
         self._pending_cascades: dict = {}  # query_id -> CascadeCollector
         self._last_seen_updates: dict = {}  # client.key -> last persisted timestamp
         self.last_seen_update_interval = _non_negative_float(
-            get_server_config().get("last_seen_update_interval", 30),
-            30.0,
+            get_server_config().get("last_seen_update_interval", 0),
+            0.0,
         )
         self.agent_protocol.hm_protocol = self
         if not self.binary_data_protocol:
@@ -571,11 +571,14 @@ class HiveMindListenerProtocol:
     def update_last_seen(self, client: HiveMindClientConnection):
         """track timestamps of last client interaction"""
         now = time.time()
+        if not hasattr(self, "_last_seen_updates"):
+            self._last_seen_updates = {}
+        update_interval = getattr(self, "last_seen_update_interval", 0)
         last_update = self._last_seen_updates.get(client.key)
         if (
-                self.last_seen_update_interval > 0
+                update_interval > 0
                 and last_update is not None
-                and now - last_update < self.last_seen_update_interval
+                and now - last_update < update_interval
         ):
             return
         with self.db:

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -611,7 +611,8 @@ class HiveMindListenerProtocol:
 
         if client.peer in self.clients:
             self.clients.pop(client.peer)
-        self._last_seen_updates.pop(client.key, None)
+        if not any(conn.key == client.key for conn in self.clients.values()):
+            self._last_seen_updates.pop(client.key, None)
         client.disconnect()
         message = Message(
             "hive.client.disconnect",

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -570,17 +570,15 @@ class HiveMindListenerProtocol:
 
     def update_last_seen(self, client: HiveMindClientConnection):
         """track timestamps of last client interaction"""
-        now = time.time()
         if not hasattr(self, "_last_seen_updates"):
             self._last_seen_updates = {}
         update_interval = getattr(self, "last_seen_update_interval", 0)
-        last_update = self._last_seen_updates.get(client.key)
-        if (
-                update_interval > 0
-                and last_update is not None
-                and now - last_update < update_interval
-        ):
-            return
+        mono_now = None
+        if update_interval > 0:
+            mono_now = time.monotonic()
+            last_update = self._last_seen_updates.get(client.key)
+            if last_update is not None and mono_now - last_update < update_interval:
+                return
         with self.db:
             user = self.db.get_client_by_api_key(client.key)
             if user is None:
@@ -588,10 +586,11 @@ class HiveMindListenerProtocol:
                 LOG.debug(f"can not update last seen, no client for key: {client.key}")
                 self._last_seen_updates.pop(client.key, None)
                 return
-            user.last_seen = now
+            user.last_seen = time.time()
             LOG.debug(f"updated last seen timestamp: {client.key} - {user.last_seen}")
             self.db.update_item(user)
-            self._last_seen_updates[client.key] = now
+            if mono_now is not None:
+                self._last_seen_updates[client.key] = mono_now
 
     def handle_client_disconnected(self, client: HiveMindClientConnection):
         try:

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -570,8 +570,6 @@ class HiveMindListenerProtocol:
 
     def update_last_seen(self, client: HiveMindClientConnection):
         """track timestamps of last client interaction"""
-        if not hasattr(self, "_last_seen_updates"):
-            self._last_seen_updates = {}
         update_interval = getattr(self, "last_seen_update_interval", 0)
         mono_now = None
         if update_interval > 0:

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -100,6 +100,14 @@ class HiveMindNodeType(str, Enum):
 QUERY_STREAM_END = "hive.query.complete"
 
 
+def _non_negative_float(value, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
 class UnencryptedMessageError(ValueError):
     """Raised when a cleartext frame arrives on a connection that requires crypto.
 
@@ -400,6 +408,11 @@ class HiveMindListenerProtocol:
         self.trusted_pubkeys: dict = {}  # client.key -> PEM public key
         self._seen_flood_ids: set = set()
         self._pending_cascades: dict = {}  # query_id -> CascadeCollector
+        self._last_seen_updates: dict = {}  # client.key -> last persisted timestamp
+        self.last_seen_update_interval = _non_negative_float(
+            get_server_config().get("last_seen_update_interval", 30),
+            30.0,
+        )
         self.agent_protocol.hm_protocol = self
         if not self.binary_data_protocol:
             # just logs received messages
@@ -557,15 +570,25 @@ class HiveMindListenerProtocol:
 
     def update_last_seen(self, client: HiveMindClientConnection):
         """track timestamps of last client interaction"""
+        now = time.time()
+        last_update = self._last_seen_updates.get(client.key)
+        if (
+                self.last_seen_update_interval > 0
+                and last_update is not None
+                and now - last_update < self.last_seen_update_interval
+        ):
+            return
         with self.db:
             user = self.db.get_client_by_api_key(client.key)
             if user is None:
                 # key was revoked / never existed — nothing to update
                 LOG.debug(f"can not update last seen, no client for key: {client.key}")
+                self._last_seen_updates.pop(client.key, None)
                 return
-            user.last_seen = time.time()
+            user.last_seen = now
             LOG.debug(f"updated last seen timestamp: {client.key} - {user.last_seen}")
             self.db.update_item(user)
+            self._last_seen_updates[client.key] = now
 
     def handle_client_disconnected(self, client: HiveMindClientConnection):
         try:
@@ -585,6 +608,7 @@ class HiveMindListenerProtocol:
 
         if client.peer in self.clients:
             self.clients.pop(client.peer)
+        self._last_seen_updates.pop(client.key, None)
         client.disconnect()
         message = Message(
             "hive.client.disconnect",

--- a/tests/test_last_seen_debounce.py
+++ b/tests/test_last_seen_debounce.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+class FakeClientDatabase:
+    def __init__(self, user):
+        self.user = user
+        self.lookups = 0
+        self.updates = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def get_client_by_api_key(self, key):
+        self.lookups += 1
+        if key == "access-key":
+            return self.user
+        return None
+
+    def update_item(self, user):
+        self.updates += 1
+        self.user = user
+
+
+def _protocol(db):
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.callbacks = MagicMock()
+    agent.get_bus.return_value = agent.bus
+    return HiveMindListenerProtocol(
+        agent_protocol=agent,
+        db=db,
+        require_crypto=False,
+        handshake_enabled=True,
+        policy_chain=MagicMock(),
+    )
+
+
+def _client():
+    return SimpleNamespace(key="access-key", peer="peer")
+
+
+def test_last_seen_updates_are_debounced_per_client_key():
+    user = SimpleNamespace(last_seen=0)
+    db = FakeClientDatabase(user)
+    proto = _protocol(db)
+    proto.last_seen_update_interval = 30
+
+    with patch("hivemind_core.protocol.time.time", side_effect=[100.0, 105.0, 131.0]):
+        proto.update_last_seen(_client())
+        proto.update_last_seen(_client())
+        proto.update_last_seen(_client())
+
+    assert db.lookups == 2
+    assert db.updates == 2
+    assert user.last_seen == 131.0
+
+
+def test_zero_last_seen_interval_preserves_per_message_updates():
+    user = SimpleNamespace(last_seen=0)
+    db = FakeClientDatabase(user)
+    proto = _protocol(db)
+    proto.last_seen_update_interval = 0
+
+    with patch("hivemind_core.protocol.time.time", side_effect=[100.0, 101.0]):
+        proto.update_last_seen(_client())
+        proto.update_last_seen(_client())
+
+    assert db.lookups == 2
+    assert db.updates == 2
+    assert user.last_seen == 101.0

--- a/tests/test_last_seen_debounce.py
+++ b/tests/test_last_seen_debounce.py
@@ -56,14 +56,17 @@ def test_last_seen_updates_are_debounced_per_client_key():
     proto = _protocol(db)
     proto.last_seen_update_interval = 30
 
-    with patch("hivemind_core.protocol.time.time", side_effect=[100.0, 105.0, 131.0]):
+    with (
+        patch("hivemind_core.protocol.time.monotonic", side_effect=[100.0, 105.0, 131.0]),
+        patch("hivemind_core.protocol.time.time", side_effect=[1000.0, 1031.0]),
+    ):
         proto.update_last_seen(_client())
         proto.update_last_seen(_client())
         proto.update_last_seen(_client())
 
     assert db.lookups == 2
     assert db.updates == 2
-    assert user.last_seen == 131.0
+    assert user.last_seen == 1031.0
 
 
 def test_zero_last_seen_interval_preserves_per_message_updates():
@@ -72,13 +75,17 @@ def test_zero_last_seen_interval_preserves_per_message_updates():
     proto = _protocol(db)
     proto.last_seen_update_interval = 0
 
-    with patch("hivemind_core.protocol.time.time", side_effect=[100.0, 101.0]):
+    with (
+        patch("hivemind_core.protocol.time.monotonic") as monotonic,
+        patch("hivemind_core.protocol.time.time", side_effect=[100.0, 101.0]),
+    ):
         proto.update_last_seen(_client())
         proto.update_last_seen(_client())
 
     assert db.lookups == 2
     assert db.updates == 2
     assert user.last_seen == 101.0
+    monotonic.assert_not_called()
 
 
 def test_disconnect_keeps_debounce_cache_for_shared_key_sibling():

--- a/tests/test_last_seen_debounce.py
+++ b/tests/test_last_seen_debounce.py
@@ -41,8 +41,13 @@ def _protocol(db):
     )
 
 
-def _client():
-    return SimpleNamespace(key="access-key", peer="peer")
+def _client(peer="peer", key="access-key"):
+    return SimpleNamespace(
+        disconnect=MagicMock(),
+        key=key,
+        peer=peer,
+        sess=SimpleNamespace(serialize=MagicMock(return_value={})),
+    )
 
 
 def test_last_seen_updates_are_debounced_per_client_key():
@@ -74,3 +79,38 @@ def test_zero_last_seen_interval_preserves_per_message_updates():
     assert db.lookups == 2
     assert db.updates == 2
     assert user.last_seen == 101.0
+
+
+def test_disconnect_keeps_debounce_cache_for_shared_key_sibling():
+    proto = _protocol(FakeClientDatabase(SimpleNamespace(last_seen=0)))
+    disconnected = _client(peer="peer-1")
+    sibling = _client(peer="peer-2")
+    proto.clients = {
+        disconnected.peer: disconnected,
+        sibling.peer: sibling,
+    }
+    proto._last_seen_updates["access-key"] = 100.0
+
+    proto.handle_client_disconnected(disconnected)
+
+    assert disconnected.peer not in proto.clients
+    assert sibling.peer in proto.clients
+    assert proto._last_seen_updates["access-key"] == 100.0
+    disconnected.disconnect.assert_called_once_with()
+
+
+def test_disconnect_clears_debounce_cache_after_last_key_peer_leaves():
+    proto = _protocol(FakeClientDatabase(SimpleNamespace(last_seen=0)))
+    disconnected = _client(peer="peer-1")
+    other_key = _client(peer="peer-2", key="other-key")
+    proto.clients = {
+        disconnected.peer: disconnected,
+        other_key.peer: other_key,
+    }
+    proto._last_seen_updates["access-key"] = 100.0
+    proto._last_seen_updates["other-key"] = 101.0
+
+    proto.handle_client_disconnected(disconnected)
+
+    assert "access-key" not in proto._last_seen_updates
+    assert proto._last_seen_updates["other-key"] == 101.0

--- a/tests/test_update_last_seen.py
+++ b/tests/test_update_last_seen.py
@@ -14,6 +14,7 @@ from hivemind_core.protocol import HiveMindListenerProtocol
 def _make_protocol(db):
     proto = object.__new__(HiveMindListenerProtocol)
     proto.db = db
+    proto._last_seen_updates = {}
     return proto
 
 


### PR DESCRIPTION
Debounces last_seen writes so normal message traffic does not write the client row on every frame.

Cleaned after review: removed the redundant runtime hasattr guard and made the object-construction fixture initialise the same state as __post_init__.

Tested:
- PYTHONPATH=. pytest tests/test_last_seen_debounce.py tests/test_update_last_seen.py -q