### PR TITLE
refactor: extract query offload into BoundedWorkerPool

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -4,10 +4,8 @@
 import dataclasses
 import json
 import os
-import threading
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 from typing import Union, List, Optional, Callable, Literal
@@ -61,6 +59,7 @@ except ImportError:
     def start_noise_handshake(*args, **kwargs):  # pragma: no cover
         raise NoiseHandshakeFailed("protocol v3 (Noise) support unavailable")
 from hivemind_core.database import ClientDatabase
+from hivemind_core.workers import BoundedWorkerPool
 from hivemind_bus_client.hive_map import HiveMapper
 from hivemind_plugin_manager.protocols import AgentProtocol, BinaryDataHandlerProtocol, ClientCallbacks
 from hivemind_plugin_manager.database import Client
@@ -116,6 +115,12 @@ class UnencryptedMessageError(ValueError):
 class HiveMindClientConnection:
     """represents a connection to the hivemind listener"""
     key: str
+    # Supplied by the transport. Must be safe to call from any thread:
+    # QUERY answers are produced on a worker pool (hivemind_core.workers),
+    # not on the thread that owns the socket. Transports whose socket is
+    # thread-affine hand the write back to their own loop — the websocket
+    # protocol wraps write_message in IOLoop.add_callback; paho's publish()
+    # locks internally.
     send_msg: Callable[[str, bool], None]
     disconnect: Callable[[], None]
 
@@ -390,11 +395,9 @@ class HiveMindListenerProtocol:
     cascade_select_callback = None  # (query_id, [CascadeResponse]) -> Optional[Message]; CASCADE disambiguation
     query_timeout = 8.0  # seconds to wait for the local agent to answer a QUERY/CASCADE
     default_lang = "en-US"
-    query_workers = 16
-    query_queue_size = 256
-    _query_executor: Optional[ThreadPoolExecutor] = field(default=None, init=False, repr=False)
-    _query_slots: Optional[threading.BoundedSemaphore] = field(default=None, init=False, repr=False)
-    _query_workers_started: bool = field(default=False, init=False, repr=False)
+    query_workers = 16  # threads answering QUERY off the transport thread
+    query_queue_size = 256  # queued queries before new ones are refused
+    _query_pool: Optional[BoundedWorkerPool] = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
         self.clients = {}
@@ -447,41 +450,15 @@ class HiveMindListenerProtocol:
                     _optional=[False, *configured_optional],
                 )
 
-    def _start_query_workers(self) -> None:
-        """Start the bounded pool used for local QUERY answering."""
-        if self._query_workers_started:
-            return
-        self._query_executor = ThreadPoolExecutor(
-            max_workers=self.query_workers,
-            thread_name_prefix="hivemind-query",
-        )
-        self._query_slots = threading.BoundedSemaphore(
-            self.query_workers + self.query_queue_size
-        )
-        self._query_workers_started = True
-
     def _submit_query_worker(self, fn, *args) -> bool:
-        if self._query_executor is None or self._query_slots is None:
-            self._start_query_workers()
-        assert self._query_executor is not None
-        assert self._query_slots is not None
-        if not self._query_slots.acquire(blocking=False):
-            return False
-
-        def _run() -> None:
-            try:
-                fn(*args)
-            except Exception:
-                LOG.exception("Unhandled HiveMind query worker error")
-            finally:
-                self._query_slots.release()
-
-        try:
-            self._query_executor.submit(_run)
-        except Exception:
-            self._query_slots.release()
-            raise
-        return True
+        """Answer one QUERY off the transport thread. False when saturated."""
+        if self._query_pool is None:
+            self._query_pool = BoundedWorkerPool(
+                max_workers=self.query_workers,
+                queue_size=self.query_queue_size,
+                thread_name_prefix="hivemind-query",
+            )
+        return self._query_pool.submit(fn, *args)
 
     def get_bus(self, client: HiveMindClientConnection) -> Union[FakeBus, MessageBusClient]:
         # The agent decides which bus a client's messages land on. Default

--- a/hivemind_core/workers.py
+++ b/hivemind_core/workers.py
@@ -1,0 +1,84 @@
+"""Bounded worker pool used to keep slow work off the transport hot path.
+
+Transports call into ``HiveMindListenerProtocol`` from whatever thread owns
+their socket — for Tornado that is the single IOLoop thread shared by every
+connected client. Work that blocks there (answering a QUERY through the agent
+can take up to ``query_timeout`` seconds) stalls every other client on the
+process, so it is submitted here instead.
+
+Callables submitted to the pool run on worker threads. Anything they touch
+must tolerate that; in particular they may only reach a client through
+``HiveMindClientConnection.send_msg``, whose thread-safety contract is
+documented on that field.
+"""
+from concurrent.futures import ThreadPoolExecutor
+from threading import BoundedSemaphore
+from typing import Any, Callable, Optional
+
+from ovos_utils.log import LOG
+
+
+class BoundedWorkerPool:
+    """A thread pool that refuses work instead of queueing it without limit.
+
+    ``max_workers`` threads run submitted callables. A further
+    ``queue_size`` callables may wait for a free thread; past that
+    ``submit`` returns False and the caller decides how to shed the load.
+    Backpressure is the point — an unbounded queue turns an overloaded
+    listener into one that accepts work it will never get to.
+    """
+
+    def __init__(self, max_workers: int, queue_size: int,
+                 thread_name_prefix: str = "hivemind-worker"):
+        self.max_workers = max_workers
+        self.queue_size = queue_size
+        self.thread_name_prefix = thread_name_prefix
+        self._executor: Optional[ThreadPoolExecutor] = None
+        self._slots: Optional[BoundedSemaphore] = None
+
+    @property
+    def started(self) -> bool:
+        return self._executor is not None
+
+    def start(self) -> None:
+        if self.started:
+            return
+        self._executor = ThreadPoolExecutor(
+            max_workers=self.max_workers,
+            thread_name_prefix=self.thread_name_prefix,
+        )
+        self._slots = BoundedSemaphore(self.max_workers + self.queue_size)
+
+    def submit(self, fn: Callable[..., Any], *args: Any) -> bool:
+        """Run ``fn(*args)`` on a worker thread.
+
+        Returns False when the pool is saturated, having run nothing.
+        Exceptions raised by ``fn`` are logged, never propagated to the
+        worker thread's caller — which has long since moved on.
+        """
+        if not self.started:
+            self.start()
+
+        if not self._slots.acquire(blocking=False):
+            return False
+
+        def _run() -> None:
+            try:
+                fn(*args)
+            except Exception:
+                LOG.exception(f"Unhandled error in {self.thread_name_prefix}")
+            finally:
+                self._slots.release()
+
+        try:
+            self._executor.submit(_run)
+        except Exception:
+            self._slots.release()
+            raise
+        return True
+
+    def shutdown(self, wait: bool = False) -> None:
+        if self._executor is not None:
+            self._executor.shutdown(wait=wait)
+        self._executor = None
+        self._slots = None

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,75 @@
+import threading
+
+from hivemind_core.workers import BoundedWorkerPool
+
+
+def test_submit_runs_callable_on_worker_thread():
+    pool = BoundedWorkerPool(max_workers=1, queue_size=1)
+    done = threading.Event()
+    seen = {}
+
+    def _work(value):
+        seen["value"] = value
+        seen["thread"] = threading.current_thread().name
+        done.set()
+
+    assert pool.submit(_work, 42) is True
+    assert done.wait(2)
+    assert seen["value"] == 42
+    assert seen["thread"] != threading.current_thread().name
+    pool.shutdown(wait=True)
+
+
+def test_submit_refuses_work_when_saturated():
+    pool = BoundedWorkerPool(max_workers=1, queue_size=0)
+    release = threading.Event()
+    started = threading.Event()
+
+    def _block():
+        started.set()
+        release.wait(2)
+
+    assert pool.submit(_block) is True
+    assert started.wait(2)
+    # the only slot is taken, so the pool sheds rather than queues
+    assert pool.submit(_block) is False
+
+    release.set()
+    pool.shutdown(wait=True)
+
+
+def test_slot_is_released_after_failure():
+    pool = BoundedWorkerPool(max_workers=1, queue_size=0)
+    failed = threading.Event()
+
+    def _boom():
+        failed.set()
+        raise RuntimeError("worker blew up")
+
+    assert pool.submit(_boom) is True
+    assert failed.wait(2)
+    pool.shutdown(wait=True)
+
+    # a worker that raised must not leak its slot
+    pool = BoundedWorkerPool(max_workers=1, queue_size=0)
+    done = threading.Event()
+    assert pool.submit(_boom) is True
+    assert failed.wait(2)
+    for _ in range(50):
+        if pool.submit(done.set):
+            break
+        threading.Event().wait(0.02)
+    assert done.wait(2)
+    pool.shutdown(wait=True)
+
+
+def test_shutdown_allows_restart():
+    pool = BoundedWorkerPool(max_workers=1, queue_size=1)
+    assert pool.submit(lambda: None) is True
+    pool.shutdown(wait=True)
+    assert pool.started is False
+
+    done = threading.Event()
+    assert pool.submit(done.set) is True
+    assert done.wait(2)
+    pool.shutdown(wait=True)


### PR DESCRIPTION
Targets `codex/agent-inject-hook` (#144), not `dev` — merge this into that branch and #144 carries it.

## Why

`HiveMindListenerProtocol` is already a 1326-line dataclass with 42 methods, in a 1691-line `protocol.py`. Every other module in `hivemind_core/` is under 300 lines. #144 adds an executor, a bounded semaphore, and their start/submit lifecycle to that class — and they are the first threading primitives anywhere in core (`grep -rn "import threading\|concurrent.futures" hivemind_core/` on `dev` returns nothing).

Two changes here:

**1. `hivemind_core/workers.py` — `BoundedWorkerPool`.** Lifts the pool out of the dataclass. It can now be unit-tested directly rather than through `object.__new__` on the protocol, which is what `tests/test_query_workers.py` has to do today. `_start_query_workers` / `_submit_query_worker` / `_query_executor` / `_query_slots` / `_query_workers_started` collapse to one `_query_pool` field and a four-line `_submit_query_worker`.

**2. The `send_msg` thread-safety contract, written down.** This is the part that matters.

#144 answers queries on worker threads, and those threads reach the client through `HiveMindClientConnection.send_msg`. Its type is `Callable[[str, bool], None]` — nothing said which thread may call it. The PR body of #144 notes "websocket thread-safe writes are handled in hivemind-websocket-protocol#36", which makes core correct only if a patch in another repository lands first.

That dependency is real and it is also *correct*: the transport owns the socket, so the transport owns thread-safety. Core cannot fix this for itself, and it should not grow a second callback to try. Both transports already satisfy the contract — websocket via `IOLoop.add_callback` in hivemind-websocket-protocol#36, MQTT via paho `publish()`, which locks internally. The invariant just was not stated anywhere, so the next transport author had no way to know. It is now a comment on the field.

## Not done here

`handle_new_client` (104 lines), `handle_noise_handshake_message` (87), `handle_handshake_message` (85), `handle_intercom_message` (75) are all pre-existing and untouched by #144. Out of scope.

## Verification

`tests/test_query_workers.py` passes unmodified — the public knobs `query_workers` and `query_queue_size` keep their meaning and saturation still sheds with `hive.query.timeout`. `tests/test_workers.py` adds direct coverage for the pool: work runs off the calling thread, saturation refuses instead of queueing, a raising worker does not leak its slot, and `shutdown()` allows restart.

Full suite on this branch: 184 passed, 3 skipped, 1 xfailed.

## Merge order

Unchanged, and now documented in code: **hivemind-websocket-protocol#36 must land before #144.** Until it does, the websocket transport writes to Tornado from a worker thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)