### PR TITLE
fix: build the RSA handshake on first use, not on connection construction

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -120,7 +120,6 @@ class HiveMindClientConnection:
     sess: Session = dataclasses.field(default_factory=Session)  # unique session per client
     name: str = "AnonClient"
     node_type: HiveMindNodeType = HiveMindNodeType.CANDIDATE_NODE
-    handshake: Optional[HandShake] = None
     pswd_handshake: Optional[PasswordHandShake] = None
 
     crypto_key: Optional[str] = None
@@ -153,6 +152,12 @@ class HiveMindClientConnection:
     # client, retained for Noise prologue binding (CRYPTO-1 §3.4.3)
     _hello_payload: Optional[dict] = field(default=None, init=False, repr=False)
     _handshake_payload: Optional[dict] = field(default=None, init=False, repr=False)
+
+    # The RSA key is the node identity: one immutable file, shared by every
+    # connection. Parsing it costs ~25ms, so it is deferred until a handshake
+    # actually begins — a connection rejected for a bad api_key never gets
+    # here. See the ``handshake`` property.
+    _handshake: Optional[HandShake] = field(default=None, init=False, repr=False)
 
     # Connection-scoped resolved-user cache. Policies call ``resolve_user``
     # which hits the DB at most once per ``ttl`` window; ``invalidate_user``
@@ -189,8 +194,22 @@ class HiveMindClientConnection:
         self._resolved_user = None
         self._resolved_user_ts = 0.0
 
-    def __post_init__(self):
-        self.handshake = self.handshake or HandShake(self.hm_protocol.identity.private_key)
+    @property
+    def handshake(self) -> HandShake:
+        """The legacy RSA handshake, built on first use.
+
+        Transports construct the connection before they can look the api_key
+        up — ``handle_invalid_key_connected`` needs something to hand to the
+        callbacks — so building this eagerly made every rejected connection
+        parse the node's private key first.
+        """
+        if self._handshake is None:
+            self._handshake = HandShake(self.hm_protocol.identity.private_key)
+        return self._handshake
+
+    @handshake.setter
+    def handshake(self, value: Optional[HandShake]) -> None:
+        self._handshake = value
 
     @property
     def peer(self) -> str:

--- a/tests/test_crypto_enforcement.py
+++ b/tests/test_crypto_enforcement.py
@@ -113,8 +113,8 @@ class TestCryptoRequiredOnReceive(unittest.TestCase):
     def test_cleartext_bus_accepted_without_listener_protocol(self):
         # connection not attached to a listener: keep permissive behavior
         client = HiveMindClientConnection(key="k", send_msg=MagicMock(),
-                                          disconnect=MagicMock(),
-                                          handshake=MagicMock())
+                                          disconnect=MagicMock())
+        client.handshake = MagicMock()
         msg = client.decode(_cleartext_bus_frame())
         assert msg.msg_type == HiveMessageType.BUS
 

--- a/tests/test_lazy_handshake.py
+++ b/tests/test_lazy_handshake.py
@@ -1,0 +1,56 @@
+"""The RSA handshake is built on first use, not on connection construction.
+
+Transports build a HiveMindClientConnection before they can validate the
+api_key, so an eager handshake made every rejected connection parse the node's
+private key first.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hivemind_core.protocol import HiveMindClientConnection
+
+
+def _connection(**kwargs):
+    return HiveMindClientConnection(
+        key="k", send_msg=MagicMock(), disconnect=MagicMock(),
+        hm_protocol=SimpleNamespace(
+            identity=SimpleNamespace(private_key="/nonexistent/key.pem")),
+        **kwargs,
+    )
+
+
+def test_construction_does_not_build_a_handshake():
+    with patch("hivemind_core.protocol.HandShake") as handshake:
+        client = _connection()
+        handshake.assert_not_called()
+    assert client._handshake is None
+
+
+def test_handshake_is_built_on_first_access_and_cached():
+    with patch("hivemind_core.protocol.HandShake") as handshake:
+        client = _connection()
+        first = client.handshake
+        second = client.handshake
+
+    handshake.assert_called_once_with("/nonexistent/key.pem")
+    assert first is second
+
+
+def test_handshake_can_be_injected():
+    injected = MagicMock()
+    with patch("hivemind_core.protocol.HandShake") as handshake:
+        client = _connection()
+        client.handshake = injected
+        assert client.handshake is injected
+        handshake.assert_not_called()
+
+
+def test_rejected_connection_never_parses_the_identity_key():
+    """A connection built for an invalid api_key is discarded untouched."""
+    with patch("hivemind_core.protocol.HandShake") as handshake:
+        client = _connection()
+        # what a transport does on a key miss: hand the client to the
+        # invalid-key callback, then drop it
+        client.disconnect()
+        handshake.assert_not_called()
+    assert client._handshake is None


### PR DESCRIPTION
Every transport constructs `HiveMindClientConnection` **before** it can validate the api_key, because `handle_invalid_key_connected(client)` needs a client to hand to the callbacks:

| transport | connection built | key validated |
| --- | --- | --- |
| hivemind-http-protocol | `__init__.py:171` | `:179` |
| hivemind-websocket-protocol | `__init__.py:375` | `:383` |
| hivemind-mqtt-protocol | `__init__.py:163` | `:173` |

And `__post_init__` did:

```python
self.handshake = self.handshake or HandShake(self.hm_protocol.identity.private_key)
```

So a connection that is about to be rejected for a bad api_key parses the node private key first. Measured at **~25ms** per construction — per connection on websocket and mqtt, per *request* on http, which is request-oriented and caches nothing on the invalid path.

The RSA key is the node identity: one immutable file, the same key for every connection. There is no reason to touch it before we know who is calling, and no reason to touch it at all for a caller we are about to reject.

## Change

`handshake` becomes a property over a `_handshake` field, built on first access and cached. A rejected connection never reaches it.

**Breaking, narrowly:** `handshake` is no longer an `__init__` argument. Assign it after construction instead — `client.handshake = ...` goes through the setter. Exactly one caller did this (`tests/test_crypto_enforcement.py`), and no transport in the org passes it; I checked http, websocket, mqtt, audio-binary, and the ovos agent plugin.

## What this does not do

Legitimate connections still re-parse the same PEM once each — ~25ms × every client that connects. Caching the import (keyed on path + mtime) is the obvious follow-up, but each connection needs its own `HandShake` instance for its per-session `target_key`/`secret`, and `poorman_handshake` welds the PEM parse into `HandShake.__init__`. That wants a `HandShake.from_key()` upstream first. Filed as a note, not done here — this PR is about the pre-auth path.

Worth stating plainly: **this is not a fix for a denial-of-service.** An earlier draft of the description in JarbasHiveMind/hivemind-http-protocol#17 claimed 0.67s per unauthenticated request and an exhaustion attack. That measured `HandShake(None)`, which regenerates a keypair because it has no path to export to — reachable only from a test fake. `NodeIdentity.private_key` always returns a path, so production loads. The description has been corrected. What is left is 25ms of misplaced work, which is worth removing on a hot path this stack is otherwise busy optimising, and nothing more.

`HandShake` is deprecated in favour of `NoiseHandShake` (protocol v3 uses `noise_transport`), so this is legacy-path maintenance.

## Verification

`tests/test_lazy_handshake.py`: construction builds no handshake, first access builds exactly one and caches it, injection via the setter bypasses construction, and a connection discarded on an invalid key never parses the identity key.

Full suite: **182 passed, 3 skipped, 1 xfailed** — same skip/xfail profile as `dev`.

## Related

- JarbasHiveMind/hivemind-http-protocol#17 — where this was found; fixes a real per-request `db.sync()` on the same pre-auth path
- #145 / JarbasHiveMind/hivemind-websocket-protocol#37 — the query-pool and db-sync refactors

🤖 Generated with [Claude Code](https://claude.com/claude-code)