### PR TITLE
fix: enforce the per-client can_broadcast ACL

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -136,6 +136,9 @@ class HiveMindClientConnection:
     site_id: str = "unknown"
     can_escalate: bool = True
     can_propagate: bool = True
+    # BROADCAST additionally requires is_admin; this narrows an admin that
+    # should not be able to broadcast. Default True preserves prior behaviour.
+    can_broadcast: bool = True
     is_admin: bool = False
     last_seen: float = -1
 
@@ -1059,7 +1062,7 @@ class HiveMindListenerProtocol:
         """
         payload = self._unpack_message(message, client)
 
-        if not client.is_admin:
+        if not client.is_admin or not client.can_broadcast:
             LOG.warning("Received broadcast message from downstream, illegal action")
             if self.illegal_callback:
                 self.illegal_callback(payload)

--- a/tests/test_can_broadcast_acl.py
+++ b/tests/test_can_broadcast_acl.py
@@ -1,0 +1,84 @@
+"""BROADCAST admission honours the per-client ``can_broadcast`` ACL.
+
+Broadcast has always required ``is_admin``. ``can_broadcast`` is a ``Client``
+DB field that the websocket and mqtt transports copy onto the connection, but
+the listener never read it — an admin with ``can_broadcast=False`` could still
+broadcast. ``can_broadcast`` narrows an admin; it never grants rights to a
+non-admin.
+"""
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+
+def _protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    proto = HiveMindListenerProtocol(agent_protocol=agent, db=MagicMock())
+    proto.broadcast_callback = MagicMock()
+    proto.illegal_callback = MagicMock()
+    return proto
+
+
+def _client(proto, **kwargs):
+    client = HiveMindClientConnection(
+        key="k", send_msg=MagicMock(), disconnect=MagicMock(),
+        hm_protocol=proto, **kwargs)
+    client.name = "caster"
+    return client
+
+
+def _broadcast():
+    return HiveMessage(
+        HiveMessageType.BROADCAST,
+        payload=HiveMessage(HiveMessageType.BUS,
+                            payload=Message("test.event", {"ping": "pong"})),
+    )
+
+
+def test_admin_with_can_broadcast_is_relayed():
+    proto = _protocol()
+    client = _client(proto, is_admin=True, can_broadcast=True)
+
+    proto.handle_broadcast_message(_broadcast(), client)
+
+    proto.broadcast_callback.assert_called_once()
+    proto.illegal_callback.assert_not_called()
+    client.disconnect.assert_not_called()
+
+
+def test_admin_without_can_broadcast_is_refused():
+    proto = _protocol()
+    client = _client(proto, is_admin=True, can_broadcast=False)
+
+    proto.handle_broadcast_message(_broadcast(), client)
+
+    proto.broadcast_callback.assert_not_called()
+    proto.illegal_callback.assert_called_once()
+    client.disconnect.assert_called_once()
+
+
+def test_non_admin_is_refused_even_with_can_broadcast():
+    """can_broadcast narrows admin rights; it never grants them."""
+    proto = _protocol()
+    client = _client(proto, is_admin=False, can_broadcast=True)
+
+    proto.handle_broadcast_message(_broadcast(), client)
+
+    proto.broadcast_callback.assert_not_called()
+    proto.illegal_callback.assert_called_once()
+    client.disconnect.assert_called_once()
+
+
+def test_can_broadcast_defaults_to_true():
+    """Existing deployments keep the prior is_admin-only behaviour."""
+    proto = _protocol()
+    client = _client(proto, is_admin=True)
+
+    assert client.can_broadcast is True
+    proto.handle_broadcast_message(_broadcast(), client)
+    proto.broadcast_callback.assert_called_once()


### PR DESCRIPTION
`can_broadcast` is a `Client` DB field. The websocket and mqtt transports copy it onto the connection:

```python
self.client.can_broadcast = user.can_broadcast   # hivemind-websocket-protocol
conn.can_broadcast = user.can_broadcast          # hivemind-mqtt-protocol
```

`HiveMindClientConnection` never declared it — the dataclass just accepted the ad-hoc attribute — and `handle_broadcast_message` never read it. Broadcast was gated on `is_admin` alone (`protocol.py:1081`), so **an admin registered with `can_broadcast=False` could still broadcast.**

Not currently exploitable: core's CLI does not expose `can_broadcast`, so it cannot be set to `False` today. It defaults `True` on the DB row. That is why nobody has hit it. But it is a permission the data model offers and the listener ignores, and `hivescope.MasterNode.register_satellite()` already accepts it — the harness anticipated an enforcement that was never written.

## Change

Declare `can_broadcast: bool = True` on the connection and require it alongside `is_admin`:

```python
if not client.is_admin or not client.can_broadcast:
```

`can_broadcast` **narrows** an admin. It never grants rights to a non-admin. Default `True`, so existing deployments keep the prior `is_admin`-only behaviour exactly.

## Found while removing dead code

Three sibling PRs delete `skill_blacklist` / `intent_blacklist` / `msg_blacklist` assignments from the transports — those really are dead, superseded by `OVOSAgentPolicy` reading the DB row through `client.resolve_user(db)`. `can_broadcast` sits on the same lines and looks identical, but it was never superseded by anything. Deleting it would have buried an unenforced permission, so it is fixed here instead.

- JarbasHiveMind/hivemind-http-protocol#18
- JarbasHiveMind/hivemind-websocket-protocol#38
- JarbasHiveMind/hivemind-mqtt-protocol#12

## Verification

`tests/test_can_broadcast_acl.py`: admin + `can_broadcast` relays; admin without it is refused, kicked, and the `illegal_callback` fires; a non-admin is refused regardless; and the default stays `True`.

Unit suite: **132 passed, 1 skipped**.

An end-to-end test needs `hivescope` to forward the field — its `plugins/network.py:64` and `plugins/loopback.py:262` copy `is_admin` / `can_escalate` / `can_propagate` but not `can_broadcast`, so a live topology cannot currently exercise this. A hivescope PR adds the forwarding and the e2e coverage, floor-pinned to the core release carrying this field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)