### PR TITLE
refactor: drop feature-detection around the client-db api-key lookup

### DIFF
--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -36,13 +36,7 @@ class ClientDatabase:
         return self.db.search_by_value("name", name)
 
     def get_client_by_api_key(self, api_key: str) -> Optional[Client]:
-        direct_lookup = getattr(self.db, "get_client_by_api_key", None)
-        if callable(direct_lookup):
-            return direct_lookup(api_key)
-        search: List[Client] = self.db.search_by_value("api_key", api_key)
-        if len(search):
-            return search[0]
-        return None
+        return self.db.get_client_by_api_key(api_key)
 
     def get_client_by_id(self, client_id: int) -> Optional[Client]:
         return self.db.get_client_by_id(client_id)

--- a/hivemind_core/policy.py
+++ b/hivemind_core/policy.py
@@ -252,18 +252,18 @@ class MessageTypeACLPolicy(PolicyPlugin):
 
     def review(self, message: Message,
                client: "HiveMindClientConnection") -> Verdict:
-        allowed = list(getattr(client, "allowed_types", []) or [])
-        db = getattr(self.hm_protocol, "db", None)
+        allowed = list(client.allowed_types or [])
+        db = self.hm_protocol.db if self.hm_protocol else None
         if db is not None:
             try:
                 user = client.resolve_user(db)
                 if user is not None:
-                    allowed = list(getattr(user, "allowed_types", allowed) or [])
+                    allowed = list(user.allowed_types or [])
             except Exception:
                 LOG.warning("MessageTypeACLPolicy: DB refresh failed; using cached value",
                             exc_info=True)
 
-        msg_type = getattr(message, "msg_type", None)
+        msg_type = message.msg_type
         if msg_type not in allowed:
             return Verdict.deny(
                 DenyCodes.ACL_DISALLOWED_TYPE,

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -182,7 +182,7 @@ class HiveMindClientConnection:
                 and self._resolved_user is not None
                 and time.time() - self._resolved_user_ts <= ttl):
             return self._resolved_user
-        client_id = getattr(self._resolved_user, "client_id", None)
+        client_id = self._resolved_user.client_id if self._resolved_user else None
         if client_id is not None:
             user = db.refresh(client_id)
         else:
@@ -570,7 +570,7 @@ class HiveMindListenerProtocol:
 
     def update_last_seen(self, client: HiveMindClientConnection):
         """track timestamps of last client interaction"""
-        update_interval = getattr(self, "last_seen_update_interval", 0)
+        update_interval = self.last_seen_update_interval
         mono_now = None
         if update_interval > 0:
             mono_now = time.monotonic()

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -68,6 +68,7 @@ class HiveMindService:
         _status (Optional[ProcessStatus]): The current status of the service.
     """
     hm_protocol: Type[HiveMindListenerProtocol] = HiveMindListenerProtocol
+    _presence = None  # LocalPresence, when hivemind-presence is installed and enabled
 
     identity: NodeIdentity = dataclasses.field(default_factory=NodeIdentity)
     db: ClientDatabase = dataclasses.field(default_factory=ClientDatabase)
@@ -121,9 +122,8 @@ class HiveMindService:
         LOG.info("LocalPresence started")
 
     def _stop_presence(self) -> None:
-        presence = getattr(self, "_presence", None)
-        if presence is not None:
-            presence.stop()
+        if self._presence is not None:
+            self._presence.stop()
 
     def run(self):
         self._status.set_started()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "hivemind_bus_client>=0.10.1a1,<1.0.0",
     "ovos_utils>=0.0.33,<1.0.0",
     "pybase64",
-    "hivemind-plugin-manager>=0.8.0a1,<1.0.0",
+    "hivemind-plugin-manager>=0.9.0a1,<1.0.0",
     "ovos-bus-client>=2.0.0a3",
     "json-database>=0.10.2a1,<2.0.0",
     "hivemind-sqlite-database>=0.4.0a2",

--- a/tests/test_client_metadata.py
+++ b/tests/test_client_metadata.py
@@ -22,6 +22,10 @@ class MemoryDB:
     def search_by_value(self, key, value):
         return [c for c in self.clients if getattr(c, key, None) == value]
 
+    def get_client_by_api_key(self, api_key):
+        matches = self.search_by_value("api_key", api_key)
+        return matches[0] if matches else None
+
     def add_item(self, client):
         self.clients.append(client)
         return True

--- a/tests/test_update_last_seen.py
+++ b/tests/test_update_last_seen.py
@@ -15,6 +15,7 @@ def _make_protocol(db):
     proto = object.__new__(HiveMindListenerProtocol)
     proto.db = db
     proto._last_seen_updates = {}
+    proto.last_seen_update_interval = 0.0
     return proto
 
 


### PR DESCRIPTION
Cleans up the defensive-without-substance patterns that landed with #138/#143:

- `ClientDatabase.get_client_by_api_key` calls the backend directly — `AbstractDB` now ships a `search_by_value`-based default (JarbasHiveMind/hivemind-plugin-manager#45), so the `getattr`/`callable` feature-detection and manual fallback are gone. Floor pin bumped to `hivemind-plugin-manager>=0.9.0a1`.
- `update_last_seen` reads `self.last_seen_update_interval` directly; the `object.__new__` test fixture now initialises the same state as `__post_init__` instead of production code guarding for it.
- `MessageTypeACLPolicy.review` uses plain attribute access for `client.allowed_types`, `hm_protocol.db` and `message.msg_type`.
- `HiveMindService._presence` gets a class-level `None` default instead of `getattr(self, "_presence", None)`.

**Merge order**: requires hivemind-plugin-manager#45 released as 0.9.0a1 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)