### PR TITLE
perf: move last_seen persistence off the message loop

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -80,11 +80,11 @@ _DEFAULT = {
         ],
     },
 
-    # Optional debounce for the synchronous client-db last_seen write.
-    # The default preserves the old per-message update behavior. Set to a
-    # positive number of seconds only when the downstream runtime can absorb
-    # the extra admission rate.
+    # Optional debounce for best-effort client-db last_seen persistence.
+    # The default preserves the old per-message persistence frequency while
+    # the protocol keeps database I/O off the message-handling thread.
     "last_seen_update_interval": 0,
+    "last_seen_queue_size": 1024,
 }
 
 

--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -1,6 +1,7 @@
 # hivemind-core
 # Copyright (C) 2026 Casimiro Ferreira
 # SPDX-License-Identifier: Apache-2.0
+import threading
 from typing import Any, Dict, List, Optional, Iterable
 
 from ovos_utils.log import LOG
@@ -21,6 +22,7 @@ class ClientDatabase:
         db_class = DatabaseFactory.get_class(name)
         LOG.info(f"Database: {db_class.__name__}")
         self.db = db_class(**config.get(name, {}))
+        self._last_seen_lock = threading.Lock()
 
     def sync(self):
         """update db from disk if needed"""
@@ -109,6 +111,27 @@ class ClientDatabase:
 
     def update_item(self, client: Client):
         self.db.update_item(client)
+
+    def update_last_seen(self, api_key: str, seen_at: float) -> bool:
+        """Advance a client's activity timestamp without moving it backward.
+
+        Current bundled backends expose an atomic implementation. The locked
+        fallback preserves compatibility with third-party database plugins and
+        older bundled releases used during rolling upgrades.
+        """
+        backend_update = getattr(self.db, "update_last_seen", None)
+        if callable(backend_update):
+            return bool(backend_update(api_key, seen_at))
+
+        with self._last_seen_lock:
+            user = self.get_client_by_api_key(api_key)
+            if user is None:
+                return False
+            current = getattr(user, "last_seen", -1)
+            if current is None or seen_at > current:
+                user.last_seen = seen_at
+                return bool(self.db.update_item(user))
+            return True
 
     def total_clients(self) -> int:
         return len(self.db)

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -4,6 +4,8 @@
 import dataclasses
 import json
 import os
+import queue
+import threading
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -396,6 +398,10 @@ class HiveMindListenerProtocol:
     cascade_select_callback = None  # (query_id, [CascadeResponse]) -> Optional[Message]; CASCADE disambiguation
     query_timeout = 8.0  # seconds to wait for the local agent to answer a QUERY/CASCADE
     default_lang = "en-US"
+    _last_seen_queue: Optional[queue.Queue] = field(default=None, init=False, repr=False)
+    _last_seen_worker_started: bool = field(default=False, init=False, repr=False)
+    _last_seen_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _last_seen_next_flush: dict = field(default_factory=dict, init=False, repr=False)
 
     def __post_init__(self):
         self.clients = {}
@@ -408,11 +414,11 @@ class HiveMindListenerProtocol:
         self.trusted_pubkeys: dict = {}  # client.key -> PEM public key
         self._seen_flood_ids: set = set()
         self._pending_cascades: dict = {}  # query_id -> CascadeCollector
-        self._last_seen_updates: dict = {}  # client.key -> last persisted timestamp
         self.last_seen_update_interval = _non_negative_float(
             get_server_config().get("last_seen_update_interval", 0),
             0.0,
         )
+        self._start_last_seen_worker()
         self.agent_protocol.hm_protocol = self
         if not self.binary_data_protocol:
             # just logs received messages
@@ -568,27 +574,76 @@ class HiveMindListenerProtocol:
         # if client is in protocol V1 -> self.handle_handshake_message
         # clients can rotate their pubkey or session_key by sending a new handshake
 
-    def update_last_seen(self, client: HiveMindClientConnection):
-        """track timestamps of last client interaction"""
-        update_interval = getattr(self, "last_seen_update_interval", 0)
-        mono_now = None
-        if update_interval > 0:
-            mono_now = time.monotonic()
-            last_update = self._last_seen_updates.get(client.key)
-            if last_update is not None and mono_now - last_update < update_interval:
+    @staticmethod
+    def _last_seen_queue_size() -> int:
+        raw = get_server_config().get("last_seen_queue_size", 1024)
+        try:
+            return max(1, int(raw))
+        except (TypeError, ValueError):
+            return 1024
+
+    def _start_last_seen_worker(self) -> None:
+        """Start the best-effort writer for client activity timestamps."""
+        if self._last_seen_worker_started:
+            return
+        self._last_seen_queue = queue.Queue(maxsize=self._last_seen_queue_size())
+        self._last_seen_worker_started = True
+        thread = threading.Thread(
+            target=self._last_seen_worker,
+            name="hivemind-last-seen",
+            daemon=True,
+        )
+        thread.start()
+
+    def _last_seen_worker(self) -> None:
+        while True:
+            client, seen_at = self._last_seen_queue.get()
+            try:
+                self.update_last_seen(client, seen_at=seen_at)
+            except Exception as exc:
+                LOG.warning(
+                    "Failed to flush HiveMind last_seen update: "
+                    f"{type(exc).__name__}: {exc!r}"
+                )
+            finally:
+                self._last_seen_queue.task_done()
+
+    def touch_last_seen(self, client: HiveMindClientConnection) -> None:
+        """Record activity without blocking message handling on database I/O."""
+        seen_at = time.time()
+        mono_now = time.monotonic()
+        client.last_seen = seen_at
+        interval = getattr(self, "last_seen_update_interval", 0)
+        next_flush = mono_now
+        with self._last_seen_lock:
+            current = self._last_seen_next_flush.get(client.key)
+            if interval > 0 and current is not None and mono_now < current:
                 return
+            next_flush = mono_now + interval
+            self._last_seen_next_flush[client.key] = next_flush
+
+        if self._last_seen_queue is None:
+            self._start_last_seen_worker()
+        try:
+            self._last_seen_queue.put_nowait((client, seen_at))
+        except queue.Full:
+            with self._last_seen_lock:
+                if self._last_seen_next_flush.get(client.key) == next_flush:
+                    self._last_seen_next_flush.pop(client.key, None)
+            LOG.warning("Dropping last_seen update because the queue is full")
+
+    def update_last_seen(self, client: HiveMindClientConnection,
+                         seen_at: Optional[float] = None):
+        """track timestamps of last client interaction"""
         with self.db:
             user = self.db.get_client_by_api_key(client.key)
             if user is None:
                 # key was revoked / never existed — nothing to update
                 LOG.debug(f"can not update last seen, no client for key: {client.key}")
-                self._last_seen_updates.pop(client.key, None)
                 return
-            user.last_seen = time.time()
+            user.last_seen = seen_at if seen_at is not None else time.time()
             LOG.debug(f"updated last seen timestamp: {client.key} - {user.last_seen}")
             self.db.update_item(user)
-            if mono_now is not None:
-                self._last_seen_updates[client.key] = mono_now
 
     def handle_client_disconnected(self, client: HiveMindClientConnection):
         try:
@@ -609,7 +664,8 @@ class HiveMindListenerProtocol:
         if client.peer in self.clients:
             self.clients.pop(client.peer)
         if not any(conn.key == client.key for conn in self.clients.values()):
-            self._last_seen_updates.pop(client.key, None)
+            with self._last_seen_lock:
+                self._last_seen_next_flush.pop(client.key, None)
         client.disconnect()
         message = Message(
             "hive.client.disconnect",
@@ -710,7 +766,7 @@ class HiveMindListenerProtocol:
         else:
             self.handle_unknown_message(message, client)
 
-        self.update_last_seen(client)
+        self.touch_last_seen(client)
 
     # HiveMind protocol messages -  from slave -> master
     def handle_unknown_message(

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -400,8 +400,16 @@ class HiveMindListenerProtocol:
     default_lang = "en-US"
     _last_seen_queue: Optional[queue.Queue] = field(default=None, init=False, repr=False)
     _last_seen_worker_started: bool = field(default=False, init=False, repr=False)
+    _last_seen_thread: Optional[threading.Thread] = field(default=None, init=False, repr=False)
+    _last_seen_stop: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
+    _last_seen_start_lock: threading.Lock = field(
+        default_factory=threading.Lock,
+        init=False,
+        repr=False,
+    )
     _last_seen_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
     _last_seen_next_flush: dict = field(default_factory=dict, init=False, repr=False)
+    _last_seen_queue_warning_after: float = field(default=0.0, init=False, repr=False)
 
     def __post_init__(self):
         self.clients = {}
@@ -418,7 +426,6 @@ class HiveMindListenerProtocol:
             get_server_config().get("last_seen_update_interval", 0),
             0.0,
         )
-        self._start_last_seen_worker()
         self.agent_protocol.hm_protocol = self
         if not self.binary_data_protocol:
             # just logs received messages
@@ -458,6 +465,8 @@ class HiveMindListenerProtocol:
                     policies=[MessageTypeACLPolicy(hm_protocol=self), *configured],
                     _optional=[False, *configured_optional],
                 )
+        # The activity writer starts lazily on the first message, after all
+        # listener initialization has completed successfully.
 
     def get_bus(self, client: HiveMindClientConnection) -> Union[FakeBus, MessageBusClient]:
         # The agent decides which bus a client's messages land on. Default
@@ -584,20 +593,51 @@ class HiveMindListenerProtocol:
 
     def _start_last_seen_worker(self) -> None:
         """Start the best-effort writer for client activity timestamps."""
-        if self._last_seen_worker_started:
-            return
-        self._last_seen_queue = queue.Queue(maxsize=self._last_seen_queue_size())
-        self._last_seen_worker_started = True
-        thread = threading.Thread(
-            target=self._last_seen_worker,
-            name="hivemind-last-seen",
-            daemon=True,
-        )
-        thread.start()
+        with self._last_seen_start_lock:
+            if self._last_seen_worker_started:
+                return
+            pending = queue.Queue(maxsize=self._last_seen_queue_size())
+            self._last_seen_stop.clear()
+            thread = threading.Thread(
+                target=self._last_seen_worker,
+                args=(pending,),
+                name="hivemind-last-seen",
+                daemon=True,
+            )
+            self._last_seen_queue = pending
+            self._last_seen_thread = thread
+            self._last_seen_worker_started = True
+            try:
+                thread.start()
+            except Exception:
+                self._last_seen_queue = None
+                self._last_seen_thread = None
+                self._last_seen_worker_started = False
+                raise
 
-    def _last_seen_worker(self) -> None:
-        while True:
-            client, seen_at = self._last_seen_queue.get()
+    def _stop_last_seen_worker(self, timeout: float = 5.0) -> None:
+        """Drain and stop the activity writer, releasing listener references."""
+        self._last_seen_stop.set()
+        thread = self._last_seen_thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                LOG.warning("Timed out stopping the HiveMind last_seen worker")
+                return
+        self._last_seen_queue = None
+        self._last_seen_thread = None
+        self._last_seen_worker_started = False
+
+    def shutdown(self) -> None:
+        """Release background resources owned by this listener protocol."""
+        self._stop_last_seen_worker()
+
+    def _last_seen_worker(self, pending: queue.Queue) -> None:
+        while not self._last_seen_stop.is_set() or not pending.empty():
+            try:
+                client, seen_at = pending.get(timeout=0.1)
+            except queue.Empty:
+                continue
             try:
                 self.update_last_seen(client, seen_at=seen_at)
             except Exception as exc:
@@ -606,7 +646,7 @@ class HiveMindListenerProtocol:
                     f"{type(exc).__name__}: {exc!r}"
                 )
             finally:
-                self._last_seen_queue.task_done()
+                pending.task_done()
 
     def touch_last_seen(self, client: HiveMindClientConnection) -> None:
         """Record activity without blocking message handling on database I/O."""
@@ -627,23 +667,26 @@ class HiveMindListenerProtocol:
         try:
             self._last_seen_queue.put_nowait((client, seen_at))
         except queue.Full:
+            retry_interval = max(interval, 1.0)
             with self._last_seen_lock:
                 if self._last_seen_next_flush.get(client.key) == next_flush:
-                    self._last_seen_next_flush.pop(client.key, None)
-            LOG.warning("Dropping last_seen update because the queue is full")
+                    self._last_seen_next_flush[client.key] = mono_now + retry_interval
+                should_warn = mono_now >= self._last_seen_queue_warning_after
+                if should_warn:
+                    self._last_seen_queue_warning_after = mono_now + retry_interval
+            if should_warn:
+                LOG.warning("Dropping last_seen update because the queue is full")
 
     def update_last_seen(self, client: HiveMindClientConnection,
                          seen_at: Optional[float] = None):
         """track timestamps of last client interaction"""
+        timestamp = seen_at if seen_at is not None else time.time()
         with self.db:
-            user = self.db.get_client_by_api_key(client.key)
-            if user is None:
+            if not self.db.update_last_seen(client.key, timestamp):
                 # key was revoked / never existed — nothing to update
                 LOG.debug(f"can not update last seen, no client for key: {client.key}")
                 return
-            user.last_seen = seen_at if seen_at is not None else time.time()
-            LOG.debug(f"updated last seen timestamp: {client.key} - {user.last_seen}")
-            self.db.update_item(user)
+            LOG.debug(f"updated last seen timestamp: {client.key} - {timestamp}")
 
     def handle_client_disconnected(self, client: HiveMindClientConnection):
         try:

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -148,28 +148,29 @@ class HiveMindService:
                                        binary_data_protocol=bin_protocol,
                                        agent_protocol=agent_protocol)
 
-        # start network protocols that will carry HiveMessages
-        protos = []
-        for plug_name, plug_conf in get_server_config()["network_protocol"].items():
-            try:
-                network_class = NetworkProtocolFactory.get_class(plug_name)
-                LOG.info(f"Network protocol: {network_class.__name__}")
-                protos.append(network_class(hm_protocol=hm_protocol, config=plug_conf))
-            except:
-                LOG.exception(f"Failed to load plugin '{plug_name}'")
+        try:
+            # start network protocols that will carry HiveMessages
+            protos = []
+            for plug_name, plug_conf in get_server_config()["network_protocol"].items():
+                try:
+                    network_class = NetworkProtocolFactory.get_class(plug_name)
+                    LOG.info(f"Network protocol: {network_class.__name__}")
+                    protos.append(network_class(hm_protocol=hm_protocol, config=plug_conf))
+                except Exception:
+                    LOG.exception(f"Failed to load plugin '{plug_name}'")
 
-        if not protos:
-            LOG.error("No network protocols were loaded. Exiting service.")
+            if not protos:
+                LOG.error("No network protocols were loaded. Exiting service.")
+                return
+
+            for network_protocol in protos:
+                create_daemon(network_protocol.run)
+
+            self._status.set_ready()
+
+            self._start_presence()
+            wait_for_exit_signal()  # block until ctrl+c
+        finally:
+            self._stop_presence()
+            hm_protocol.shutdown()
             self._status.set_stopping()
-            return
-
-        for network_protocol in protos:
-            create_daemon(network_protocol.run)
-
-        self._status.set_ready()
-
-        self._start_presence()
-        wait_for_exit_signal()  # block until ctrl+c
-
-        self._stop_presence()
-        self._status.set_stopping()

--- a/tests/test_last_seen_debounce.py
+++ b/tests/test_last_seen_debounce.py
@@ -27,19 +27,29 @@ class FakeClientDatabase:
         self.updates += 1
         self.user = user
 
+    def update_last_seen(self, key, seen_at):
+        self.lookups += 1
+        if key != "access-key":
+            return False
+        self.user.last_seen = max(self.user.last_seen, seen_at)
+        self.updates += 1
+        return True
+
 
 def _protocol(db):
     agent = MagicMock()
     agent.bus = MagicMock()
     agent.callbacks = MagicMock()
     agent.get_bus.return_value = agent.bus
-    return HiveMindListenerProtocol(
+    proto = HiveMindListenerProtocol(
         agent_protocol=agent,
         db=db,
         require_crypto=False,
         handshake_enabled=True,
         policy_chain=MagicMock(),
     )
+    proto.shutdown()
+    return proto
 
 
 def _client(peer="peer", key="access-key"):
@@ -99,7 +109,7 @@ def test_zero_last_seen_interval_queues_every_message_without_database_io():
     assert db.updates == 0
 
 
-def test_full_queue_reopens_coalescing_gate_for_retry():
+def test_full_queue_defers_retry_and_rate_limits_warnings():
     proto = _protocol(FakeClientDatabase(SimpleNamespace(last_seen=0)))
     proto.last_seen_update_interval = 30
     proto._last_seen_queue = MagicMock()
@@ -109,10 +119,27 @@ def test_full_queue_reopens_coalescing_gate_for_retry():
     with (
         patch("hivemind_core.protocol.time.time", return_value=100.0),
         patch("hivemind_core.protocol.time.monotonic", return_value=10.0),
+        patch("hivemind_core.protocol.LOG.warning") as warning,
     ):
         proto.touch_last_seen(client)
+        proto.touch_last_seen(client)
 
-    assert client.key not in proto._last_seen_next_flush
+    assert proto._last_seen_next_flush[client.key] == 40.0
+    warning.assert_called_once_with("Dropping last_seen update because the queue is full")
+
+
+def test_last_seen_worker_stops_after_draining_queue():
+    user = SimpleNamespace(last_seen=0)
+    db = FakeClientDatabase(user)
+    proto = _protocol(db)
+    proto._start_last_seen_worker()
+    proto._last_seen_queue.put((_client(), 123.5))
+
+    proto.shutdown()
+
+    assert user.last_seen == 123.5
+    assert proto._last_seen_thread is None
+    assert not proto._last_seen_worker_started
 
 
 def test_disconnect_keeps_debounce_cache_for_shared_key_sibling():

--- a/tests/test_last_seen_debounce.py
+++ b/tests/test_last_seen_debounce.py
@@ -1,3 +1,4 @@
+import queue
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -45,47 +46,73 @@ def _client(peer="peer", key="access-key"):
     return SimpleNamespace(
         disconnect=MagicMock(),
         key=key,
+        last_seen=-1,
         peer=peer,
         sess=SimpleNamespace(serialize=MagicMock(return_value={})),
     )
 
 
-def test_last_seen_updates_are_debounced_per_client_key():
+def test_last_seen_touches_are_queued_and_coalesced_per_client_key():
     user = SimpleNamespace(last_seen=0)
     db = FakeClientDatabase(user)
     proto = _protocol(db)
     proto.last_seen_update_interval = 30
+    queued = []
+    proto._last_seen_queue = MagicMock()
+    proto._last_seen_queue.put_nowait.side_effect = queued.append
+    client = _client()
 
     with (
+        patch("hivemind_core.protocol.time.time", side_effect=[1000.0, 1005.0, 1031.0]),
         patch("hivemind_core.protocol.time.monotonic", side_effect=[100.0, 105.0, 131.0]),
-        patch("hivemind_core.protocol.time.time", side_effect=[1000.0, 1031.0]),
     ):
-        proto.update_last_seen(_client())
-        proto.update_last_seen(_client())
-        proto.update_last_seen(_client())
+        proto.touch_last_seen(client)
+        proto.touch_last_seen(client)
+        proto.touch_last_seen(client)
 
-    assert db.lookups == 2
-    assert db.updates == 2
-    assert user.last_seen == 1031.0
+    assert queued == [(client, 1000.0), (client, 1031.0)]
+    assert client.last_seen == 1031.0
+    assert db.lookups == 0
+    assert db.updates == 0
 
 
-def test_zero_last_seen_interval_preserves_per_message_updates():
+def test_zero_last_seen_interval_queues_every_message_without_database_io():
     user = SimpleNamespace(last_seen=0)
     db = FakeClientDatabase(user)
     proto = _protocol(db)
     proto.last_seen_update_interval = 0
+    queued = []
+    proto._last_seen_queue = MagicMock()
+    proto._last_seen_queue.put_nowait.side_effect = queued.append
+    client = _client()
 
     with (
-        patch("hivemind_core.protocol.time.monotonic") as monotonic,
         patch("hivemind_core.protocol.time.time", side_effect=[100.0, 101.0]),
+        patch("hivemind_core.protocol.time.monotonic", side_effect=[10.0, 11.0]),
     ):
-        proto.update_last_seen(_client())
-        proto.update_last_seen(_client())
+        proto.touch_last_seen(client)
+        proto.touch_last_seen(client)
 
-    assert db.lookups == 2
-    assert db.updates == 2
-    assert user.last_seen == 101.0
-    monotonic.assert_not_called()
+    assert queued == [(client, 100.0), (client, 101.0)]
+    assert client.last_seen == 101.0
+    assert db.lookups == 0
+    assert db.updates == 0
+
+
+def test_full_queue_reopens_coalescing_gate_for_retry():
+    proto = _protocol(FakeClientDatabase(SimpleNamespace(last_seen=0)))
+    proto.last_seen_update_interval = 30
+    proto._last_seen_queue = MagicMock()
+    proto._last_seen_queue.put_nowait.side_effect = queue.Full
+    client = _client()
+
+    with (
+        patch("hivemind_core.protocol.time.time", return_value=100.0),
+        patch("hivemind_core.protocol.time.monotonic", return_value=10.0),
+    ):
+        proto.touch_last_seen(client)
+
+    assert client.key not in proto._last_seen_next_flush
 
 
 def test_disconnect_keeps_debounce_cache_for_shared_key_sibling():
@@ -96,13 +123,13 @@ def test_disconnect_keeps_debounce_cache_for_shared_key_sibling():
         disconnected.peer: disconnected,
         sibling.peer: sibling,
     }
-    proto._last_seen_updates["access-key"] = 100.0
+    proto._last_seen_next_flush["access-key"] = 100.0
 
     proto.handle_client_disconnected(disconnected)
 
     assert disconnected.peer not in proto.clients
     assert sibling.peer in proto.clients
-    assert proto._last_seen_updates["access-key"] == 100.0
+    assert proto._last_seen_next_flush["access-key"] == 100.0
     disconnected.disconnect.assert_called_once_with()
 
 
@@ -114,10 +141,10 @@ def test_disconnect_clears_debounce_cache_after_last_key_peer_leaves():
         disconnected.peer: disconnected,
         other_key.peer: other_key,
     }
-    proto._last_seen_updates["access-key"] = 100.0
-    proto._last_seen_updates["other-key"] = 101.0
+    proto._last_seen_next_flush["access-key"] = 100.0
+    proto._last_seen_next_flush["other-key"] = 101.0
 
     proto.handle_client_disconnected(disconnected)
 
-    assert "access-key" not in proto._last_seen_updates
-    assert proto._last_seen_updates["other-key"] == 101.0
+    assert "access-key" not in proto._last_seen_next_flush
+    assert proto._last_seen_next_flush["other-key"] == 101.0

--- a/tests/test_update_last_seen.py
+++ b/tests/test_update_last_seen.py
@@ -1,11 +1,6 @@
-"""Regression tests for issue #118 — update_last_seen None deref.
-
-``update_last_seen`` looked up the client row by api-key and immediately
-dereferenced it (``user.last_seen = ...``). When the key has been revoked
-or never existed, ``get_client_by_api_key`` returns ``None`` and the
-method crashes with ``AttributeError``. It must guard for ``None`` and
-no-op instead.
-"""
+"""Regression tests for missing clients and queued last_seen timestamps."""
+import queue
+import threading
 from unittest.mock import MagicMock
 
 from hivemind_core.protocol import HiveMindListenerProtocol
@@ -17,46 +12,44 @@ def _make_protocol(db):
     return proto
 
 
-def _mock_db(returned_user):
+def _mock_db(update_result):
     db = MagicMock()
-    # support the `with self.db:` context manager used by update_last_seen
     db.__enter__.return_value = db
     db.__exit__.return_value = False
-    db.get_client_by_api_key.return_value = returned_user
+    db.update_last_seen.return_value = update_result
     return db
 
 
 def test_missing_key_does_not_crash():
-    db = _mock_db(None)
+    db = _mock_db(False)
     proto = _make_protocol(db)
     client = MagicMock(key="revoked-key")
 
     # must not raise AttributeError
     proto.update_last_seen(client)
 
-    db.get_client_by_api_key.assert_called_once_with("revoked-key")
-    db.update_item.assert_not_called()
+    db.update_last_seen.assert_called_once()
 
 
 def test_present_key_updates_last_seen():
-    user = MagicMock(last_seen=-1)
-    db = _mock_db(user)
+    db = _mock_db(True)
     proto = _make_protocol(db)
     client = MagicMock(key="good-key")
 
     proto.update_last_seen(client)
 
-    assert user.last_seen > 0
-    db.update_item.assert_called_once_with(user)
+    db.update_last_seen.assert_called_once()
 
 
 def test_worker_preserves_queued_seen_at_timestamp():
-    user = MagicMock(last_seen=-1)
-    db = _mock_db(user)
+    db = _mock_db(True)
     proto = _make_protocol(db)
+    proto._last_seen_queue = queue.Queue()
+    proto._last_seen_stop = threading.Event()
     client = MagicMock(key="good-key")
+    proto._last_seen_queue.put((client, 123.5))
+    proto._last_seen_stop.set()
 
-    proto.update_last_seen(client, seen_at=123.5)
+    proto._last_seen_worker(proto._last_seen_queue)
 
-    assert user.last_seen == 123.5
-    db.update_item.assert_called_once_with(user)
+    db.update_last_seen.assert_called_once_with("good-key", 123.5)

--- a/tests/test_update_last_seen.py
+++ b/tests/test_update_last_seen.py
@@ -14,7 +14,6 @@ from hivemind_core.protocol import HiveMindListenerProtocol
 def _make_protocol(db):
     proto = object.__new__(HiveMindListenerProtocol)
     proto.db = db
-    proto._last_seen_updates = {}
     return proto
 
 
@@ -48,4 +47,16 @@ def test_present_key_updates_last_seen():
     proto.update_last_seen(client)
 
     assert user.last_seen > 0
+    db.update_item.assert_called_once_with(user)
+
+
+def test_worker_preserves_queued_seen_at_timestamp():
+    user = MagicMock(last_seen=-1)
+    db = _mock_db(user)
+    proto = _make_protocol(db)
+    client = MagicMock(key="good-key")
+
+    proto.update_last_seen(client, seen_at=123.5)
+
+    assert user.last_seen == 123.5
     db.update_item.assert_called_once_with(user)


### PR DESCRIPTION
Moves last_seen persistence off the message loop through a bounded, coalescing writer queue. The worker starts lazily after listener initialization, drains and joins during service shutdown, rate-limits saturation warnings, and preserves the original activity timestamp. ClientDatabase dispatches to atomic backend updates when available and retains a locked rolling-upgrade fallback.\n\nAtomic backend implementations:\n- JarbasHiveMind/hivemind-redis-database#32\n- JarbasHiveMind/hivemind-sqlite-database#44\n\nValidation: 185 passed, 3 skipped, 1 xfailed; lint and diff checks passed.