### PR TITLE
ci: make release outcomes deterministic

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: write
+
 jobs:
   publish_stable:
     uses: OpenVoiceOS/gh-automations/.github/workflows/publish-stable.yml@dev
@@ -14,4 +17,4 @@ jobs:
     with:
       version_file: 'hivemind_core/version.py'
       publish_pypi: true
-      notify_matrix: true
+      notify_matrix: false

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -6,6 +6,10 @@ on:
     types: [closed]
     branches: [dev]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   publish_alpha:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
@@ -21,4 +25,4 @@ jobs:
       propose_release: true
       changelog_max_issues: 100
       publish_pypi: true
-      notify_matrix: true
+      notify_matrix: false


### PR DESCRIPTION
## Summary
- grant the release workflows the write permissions they require
- disable the failing optional Matrix notification for alpha and stable publication

## Validation
- parsed every workflow as YAML
- `git diff --check`