### PR TITLE
ci: release merged fork pull requests with trusted token

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -2,7 +2,7 @@ name: Release Alpha and Propose Stable
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [dev]
 


### PR DESCRIPTION
## Summary
- run the closed-PR release workflow on `pull_request_target`
- retain the merged-only guard and explicit write permissions
- allow version bump commits for reviewed fork contributions

## Validation
- workflow YAML parses successfully
- diff check passes

The prior post-merge run failed because GitHub downgraded the `pull_request` token to read-only for a fork PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation workflow to run with the appropriate pull request event context.
  * No changes were made to the product experience or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->