### PR TITLE
fix: avoid warning on expected cleartext handshake

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -268,6 +268,7 @@ class HiveMindClientConnection:
 
     def decode(self, payload: str) -> HiveMessage:
         encrypted = False
+        cleartext_with_crypto = False
         if self.noise_transport is not None:
             # protocol v3 session: only valid Noise transport messages are
             # accepted; tampering/replay/reordering fails AEAD and is fatal
@@ -297,7 +298,7 @@ class HiveMindClientConnection:
                                             encoding=self.encoding, cipher=self.cipher)
                 encrypted = True
             else:
-                LOG.warning("Message was unencrypted")
+                cleartext_with_crypto = True
 
         if isinstance(payload, bytes):
             message = decode_bitstring(payload)
@@ -305,6 +306,14 @@ class HiveMindClientConnection:
             if isinstance(payload, str):
                 payload = json.loads(payload)
             message = HiveMessage(**payload)
+
+        if (cleartext_with_crypto
+                and message.msg_type in (HiveMessageType.HELLO,
+                                         HiveMessageType.HANDSHAKE)):
+            LOG.debug("Accepted cleartext key-establishment message %s",
+                      message.msg_type)
+        elif cleartext_with_crypto and not self.crypto_required:
+            LOG.warning("Message was unencrypted: %s", message.msg_type)
 
         # HIVEMIND-CRYPTO-1 §4 - when the server requires crypto, drop any
         # cleartext frame that is not part of key establishment. HELLO and

--- a/tests/test_crypto_enforcement.py
+++ b/tests/test_crypto_enforcement.py
@@ -20,7 +20,7 @@ Covers the additive, wire-compatible enforcement paths:
 import json
 import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pybase64
 import pytest
@@ -95,12 +95,16 @@ class TestCryptoRequiredOnReceive(unittest.TestCase):
     def test_cleartext_hello_and_handshake_always_accepted(self):
         proto = _make_protocol(require_crypto=True)
         client = _make_client(proto)
+        client.crypto_key = os.urandom(32)
         hello = HiveMessage(HiveMessageType.HELLO,
                             payload={"pubkey": "xxx"}).serialize()
         shake = HiveMessage(HiveMessageType.HANDSHAKE,
                             payload={"envelope": "yyy"}).serialize()
-        assert client.decode(hello).msg_type == HiveMessageType.HELLO
-        assert client.decode(shake).msg_type == HiveMessageType.HANDSHAKE
+        with patch("hivemind_core.protocol.LOG") as log:
+            assert client.decode(hello).msg_type == HiveMessageType.HELLO
+            assert client.decode(shake).msg_type == HiveMessageType.HANDSHAKE
+        log.warning.assert_not_called()
+        assert log.debug.call_count == 2
         client.disconnect.assert_not_called()
 
     def test_cleartext_bus_accepted_when_crypto_not_required(self):


### PR DESCRIPTION
## Summary
- defer cleartext classification until the Hive message type is decoded
- log expected HELLO/HANDSHAKE key-establishment frames at debug level
- retain warnings for tolerated cleartext application messages and errors for required-crypto violations
- cover post-key-establishment handshake frames without warning noise

## Validation
- `.venv/bin/pytest -q tests/test_crypto_enforcement.py tests/test_policy_chain.py tests/test_last_seen_debounce.py tests/test_update_last_seen.py` (76 passed)