### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,66 +2,66 @@
 
 # HiveMind Core
 
-HiveMind is a flexible [protocol](https://jarbashivemind.github.io/HiveMind-community-docs/04_protocol/) that facilitates communication and collaboration among devices and AI agents within a unified network. 
-It enables lightweight devices, called **satellites**, to connect to a central hub, with customizable permissions and centralized control.
+HiveMind is a [protocol](https://jarbashivemind.github.io/HiveMind-community-docs/04_protocol/) for communication and collaboration between devices and AI agents in one network.
+It lets lightweight devices, called **satellites**, connect to a central HiveMind Core server, with customizable permissions and centralized control.
 
-HiveMind also supports [hierarchical hub-to-hub connections](https://jarbashivemind.github.io/HiveMind-community-docs/15_nested/), creating powerful, scalable smart environments.
+HiveMind also supports [connections between HiveMind Core servers](https://jarbashivemind.github.io/HiveMind-community-docs/15_nested/), so you can build layered, scalable environments.
 
-Initially developed as part of the [OpenVoiceOS (OVOS)](https://github.com/OpenVoiceOS/) ecosystem, HiveMind is adaptable to various AI backend systems.
+HiveMind started as part of the [OpenVoiceOS (OVOS)](https://github.com/OpenVoiceOS/) ecosystem. You can adapt it to other AI backend systems.
 
-For more details and demonstrations, check our [YouTube channel](https://www.youtube.com/channel/UCYoV5kxp2zrH6pnoqVZpKSA/).
+For more details and demonstrations, check the [YouTube channel](https://www.youtube.com/channel/UCYoV5kxp2zrH6pnoqVZpKSA/).
 
 ---
 
 - [HiveMind Core](#hivemind-core)
-   * [Key Features](#-key-features)
-   * [Modular Design with Plugins](#-modular-design-with-plugins)
-   * [Protocol Configuration](#-protocol-configuration)
-   * [Quick Start](#-quick-start)
+   * [Key Features](#key-features)
+   * [Modular Design with Plugins](#modular-design-with-plugins)
+   * [Protocol Configuration](#protocol-configuration)
+   * [Quick Start](#quick-start)
       + [Installation](#installation)
       + [Adding a Satellite](#adding-a-satellite)
       + [Running the Server](#running-the-server)
-   * [Commands Overview](#-commands-overview)
-   * [Plugins Overview](#-plugins-overview)
-   * [Clients Overview](#-clients-overview)
-   * [Next Steps](#-next-steps)
-   * [License](#-license)
+   * [Commands Overview](#commands-overview)
+   * [Plugins Overview](#plugins-overview)
+   * [Clients Overview](#clients-overview)
+   * [Next Steps](#next-steps)
+   * [License](#license)
    * [Trademark](#trademark)
-   * [Contributing](#-contributing)
-  
+   * [Contributing](#contributing)
+
 ---
 
-## 🌟 Key Features
+## Key Features
 
-- **Modular Design**: Easily extend functionality with plugins for different protocols and behaviors.
-- **Protocol Flexibility**: Use HiveMind with different **network**, **agent**, and **binary protocols**.
-- **Customizable Database Options**: Support for JSON, SQLite, and Redis.
-- **Centralized Control**: Manage and monitor devices from a single hub.
-- **[Fine-Grained Permissions](https://jarbashivemind.github.io/HiveMind-community-docs/16_permissions/)**: Control
+- **Modular design**: extend functionality with plugins for different protocols and behaviors.
+- **Protocol flexibility**: use HiveMind with different **network**, **agent**, and **binary protocols**.
+- **Customizable database options**: JSON, SQLite, and Redis.
+- **Centralized control**: manage and monitor devices from one HiveMind Core server.
+- **[Fine-grained permissions](https://jarbashivemind.github.io/HiveMind-community-docs/16_permissions/)**: control
   access to skills, intents, and message types for each satellite.
-- **Multi-Agent Support**: Integrate various AI assistants, such as [OpenVoiceOS](https://github.com/OpenVoiceOS/)
+- **Multi-agent support**: integrate AI assistants such as [OpenVoiceOS](https://github.com/OpenVoiceOS/)
   or [LLMs](https://github.com/OpenVoiceOS/ovos-persona).
 
 ---
 
-## 🔌 Modular Design with Plugins
+## Modular Design with Plugins
 
-HiveMind is designed to be modular, allowing you to customize its behavior through plugins managed by the **HiveMind Plugin Manager**.
+HiveMind is modular. You customize its behavior through plugins managed by the **HiveMind Plugin Manager**.
 
-- **Transport Mechanism** 🚚: The protocol does not specify **how** messages are transported; this is implemented via **network protocol plugins** (e.g., Websockets, HTTP).
-- **Payload Handling** 🤖 : The protocol does not dictate **who** handles the messages; this is implemebted via **agent protocol plugins** (e.g., OVOS, Persona).
-- **Message Format** 📦: The protocol supports **JSON data** modeled after the `Message` [structure from OVOS](https://jarbashivemind.github.io/HiveMind-community-docs/13_mycroft/) and **binary** data; what happens to the received binary data is implemented via **binary data protocol plugins** (e.g., process incoming audio).
-- **Database**: 🗃️ how client credentials are stored is implemented via **database plugins** (e.g., JSON, SQLite, Redis).
+- **Transport mechanism**: the protocol does not specify **how** messages are transported. **Network protocol plugins** implement this (for example, Websockets, HTTP).
+- **Payload handling**: the protocol does not dictate **who** handles the messages. **Agent protocol plugins** implement this (for example, OVOS, Persona).
+- **Message format**: the protocol supports **JSON data** modeled after the `Message` [structure from OVOS](https://jarbashivemind.github.io/HiveMind-community-docs/13_mycroft/), and **binary** data. **Binary data protocol plugins** implement what happens to received binary data (for example, processing incoming audio).
+- **Database**: **database plugins** implement how client credentials are stored (for example, JSON, SQLite, Redis).
 
 ---
 
-## 📖 Protocol Configuration
+## Protocol Configuration
 
-HiveMind Core now supports a configuration file, making it easier for users to define server settings and reduce the need for complex command-line arguments. 
+HiveMind Core supports a configuration file. This lets you define server settings without long command-line arguments.
 
-> 💡 The configuration file is stored at `~/.config/hivemind-core/server.json`
+> The configuration file is stored at `~/.config/hivemind-core/server.json`
 
-The default configuration
+The default configuration:
 
 ```json
 {
@@ -100,21 +100,20 @@ The default configuration
 }
 ```
 
-
-> **Default backend:** fresh installs use **SQLite** (transactional, concurrency-safe, stdlib). An existing JSON deployment (a `clients.json` already on disk) keeps using JSON so upgrades never strand the credentials store. Move an existing store with `hivemind-core migrate-db --to sqlite` (also supports `--from`/`--to` for JSON ⇄ SQLite ⇄ Redis).
+> **Default backend:** fresh installs use **SQLite** (transactional, concurrency-safe, stdlib). An existing JSON deployment (a `clients.json` already on disk) keeps using JSON, so upgrades never strand the credentials store. Move an existing store with `hivemind-core migrate-db --to sqlite` (also supports `--from`/`--to` for JSON ⇄ SQLite ⇄ Redis).
 
 ### Policy Admission Chain
 
-Every inbound message passes through an ordered **policy admission chain** before reaching the agent bus. See [issue #85](https://github.com/JarbasHiveMind/HiveMind-core/issues/85) for the full spec.
+Every inbound message passes through an ordered **policy admission chain** before it reaches the agent bus. See [issue #85](https://github.com/JarbasHiveMind/HiveMind-core/issues/85) for the full spec.
 
 **How it works:**
 
-1. `MessageTypeACLPolicy` is **always prepended** to the chain and cannot be removed by configuration. It enforces the per-client `allowed_types` whitelist: if `message.msg_type` is not in the client's `allowed_types`, the message is denied. `Client.is_admin` is informational and gives no admission bypass — admins are subject to the whitelist like any other client. — `hivemind_core/policy.py:174`
+1. `MessageTypeACLPolicy` is **always prepended** to the chain. Configuration cannot remove it. It enforces the per-client `allowed_types` whitelist: if `message.msg_type` is not in the client's `allowed_types`, the message is denied. `Client.is_admin` is informational and gives no admission bypass. Admins follow the whitelist like any other client (`hivemind_core/policy.py:174`).
 2. Configured plugins in `policy.chain` run after `MessageTypeACLPolicy`, in order. Each plugin can deny the message or contribute mutations applied before the next plugin runs.
-3. The chain is **always fail-closed**. Any unhandled exception in a policy becomes `Verdict.deny("policy_error", ...)`. There is no operator knob to override this. — `hivemind_core/policy.py:36`
-4. If the chain fails to build at startup, a `DenyAllPolicy` fallback is installed, rejecting every message with `code="policy_chain_unavailable"` until configuration is fixed. — `hivemind_core/policy.py:151`
+3. The chain is **always fail-closed**. Any unhandled exception in a policy becomes `Verdict.deny("policy_error", ...)`. There is no operator setting to override this (`hivemind_core/policy.py:36`).
+4. If the chain fails to build at startup, HiveMind installs a `DenyAllPolicy` fallback, which rejects every message with `code="policy_chain_unavailable"` until you fix the configuration (`hivemind_core/policy.py:151`).
 
-**Denied messages** receive a `hive.policy.denied` BUS response with payload:
+**Denied messages** get a `hive.policy.denied` BUS response with this payload:
 
 ```json
 {
@@ -125,12 +124,12 @@ Every inbound message passes through an ordered **policy admission chain** befor
 }
 ```
 
-`handle_inject_agent_msg` runs `policy_chain.review()` then `policy_chain.observe()` for every accepted message. `handle_binary_message` runs `policy_chain.review_binary()`. — `hivemind_core/protocol.py:908`, `hivemind_core/protocol.py:457`
+`handle_inject_agent_msg` runs `policy_chain.review()` then `policy_chain.observe()` for every accepted message. `handle_binary_message` runs `policy_chain.review_binary()` (`hivemind_core/protocol.py:908`, `hivemind_core/protocol.py:457`).
 
-**ACL model — whitelist-only, deny-by-default:**
+**ACL model: whitelist-only, deny-by-default**
 
-- `allowed_types` is the only ACL field on `HiveMindClientConnection`. There is no message blacklist. — `hivemind_core/protocol.py:92`
-- A freshly created client (via `add-client`) has an **empty** `allowed_types` list and will be denied all messages until the operator explicitly grants types with `allow-msg`. This applies to admin clients too — `Client.is_admin` is informational only and gives no admission bypass.
+- `allowed_types` is the only ACL field on `HiveMindClientConnection`. There is no message blacklist (`hivemind_core/protocol.py:92`).
+- A freshly created client (via `add-client`) has an **empty** `allowed_types` list. HiveMind denies it all messages until the operator explicitly grants types with `allow-msg`. This applies to admin clients too. `Client.is_admin` is informational only and gives no admission bypass.
 
 To grant a message type:
 
@@ -139,17 +138,17 @@ $ hivemind-core allow-msg "recognizer_loop:utterance" 1
 $ hivemind-core allow-msg "speak" 1
 ```
 
-**Removing a type** (mutates `allowed_types`; not deprecated):
+**Removing a type** (mutates `allowed_types`, not deprecated):
 
 ```bash
 $ hivemind-core blacklist-msg "speak" 1
 ```
 
-**Skill and intent filtering** are OVOS-specific concerns handled by `OVOSAgentPolicy` (shipped with `hivemind-ovos-agent-plugin`, the default `agent_protocol`). The CLI commands `blacklist-skill`, `allow-skill`, `blacklist-intent`, and `allow-intent` manage the `skill_blacklist` / `intent_blacklist` lists in `Client.metadata`, which `OVOSAgentPolicy` injects into the OVOS session. They take effect only when that policy is configured in `policy.chain`. For any other policy-relevant key, use **`set-metadata`** to write arbitrary `Client.metadata`. — `hivemind_core/scripts.py`
+**Skill and intent filtering** are OVOS-specific concerns handled by `OVOSAgentPolicy` (shipped with `hivemind-ovos-agent-plugin`, the default `agent_protocol`). The CLI commands `blacklist-skill`, `allow-skill`, `blacklist-intent`, and `allow-intent` manage the `skill_blacklist` / `intent_blacklist` lists in `Client.metadata`, which `OVOSAgentPolicy` injects into the OVOS session. They take effect only when you configure that policy in `policy.chain`. For any other policy-relevant key, use **`set-metadata`** to write arbitrary `Client.metadata` (`hivemind_core/scripts.py`).
 
-**On-disk migration of legacy blacklist fields.** Database backends (e.g. `hivemind-sqlite-database`, `hivemind-redis-database`) implement the new `AbstractDB.migrate(from_version)` hook from `hivemind-plugin-manager` and run a one-shot `v1 → v2` migration on first open. The migration folds any legacy top-level `intent_blacklist` / `skill_blacklist` / `message_blacklist` storage (SQLite columns, JSON keys, Redis hash fields) into each row's `metadata` dict via `setdefault` (explicit metadata wins), then clears the legacy storage. Backends track their schema version natively (SQLite `PRAGMA user_version`, Redis sentinel key) so the migration runs exactly once per database. Third-party backends that do not override `migrate()` keep working — the property shims on `Client` ensure read-path code is agnostic to on-disk shape.
+**On-disk migration of legacy blacklist fields.** Database backends (for example, `hivemind-sqlite-database`, `hivemind-redis-database`) implement the `AbstractDB.migrate(from_version)` hook from `hivemind-plugin-manager` and run a one-shot `v1 → v2` migration on first open. The migration folds any legacy top-level `intent_blacklist` / `skill_blacklist` / `message_blacklist` storage (SQLite columns, JSON keys, Redis hash fields) into each row's `metadata` dict via `setdefault` (explicit metadata wins), then clears the legacy storage. Backends track their schema version natively (SQLite `PRAGMA user_version`, Redis sentinel key), so the migration runs exactly once per database. Third-party backends that do not override `migrate()` keep working. The property shims on `Client` keep read-path code agnostic to on-disk shape.
 
-To add additional policies, extend the `policy.chain` list with plugin module names:
+To add more policies, extend the `policy.chain` list with plugin module names:
 
 ```json
 "policy": {
@@ -160,14 +159,13 @@ To add additional policies, extend the `policy.chain` list with plugin module na
 }
 ```
 
-Drop `hivemind-ovos-agent-policy` from the list only if you are running a non-OVOS agent backend.
-
+Drop `hivemind-ovos-agent-policy` from the list only if you run a non-OVOS agent backend.
 
 ---
 
-## 🛰️  Quick Start
+## Quick Start
 
-To get started, HiveMind Core provides a command-line interface (CLI) for managing clients, permissions, and connections.
+HiveMind Core provides a command-line interface (CLI) for managing clients, permissions, and connections.
 
 ### Installation
 
@@ -192,7 +190,7 @@ Encryption Key: f46351c54f61a715
 WARNING: Encryption Key is deprecated, only use if your client does not support password
 ```
 
-**NOTE**: You will need to provide this information on the client devices to connect.
+**NOTE**: You must provide this information on the client devices so they can connect.
 
 ### Running the Server
 
@@ -204,9 +202,9 @@ $ hivemind-core listen
 
 ---
 
-## 🛠️ Commands Overview
+## Commands Overview
 
-HiveMind Core CLI supports the following commands:
+The HiveMind Core CLI supports these commands:
 
 ```bash
 $ hivemind-core --help
@@ -236,9 +234,9 @@ Commands:
   set-metadata         set arbitrary metadata on a client (read by policy plugins)
 ```
 
-For detailed help on each command, use `--help` (e.g., `hivemind-core add-client --help`).
+For detailed help on each command, use `--help` (for example, `hivemind-core add-client --help`).
 
-> 💡 **Tip**: if you don't specify the numeric client_id in your commands you will be prompted for it interactively
+> **Tip**: if you do not specify the numeric client_id in your commands, HiveMind prompts you for it.
 
 <details>
   <summary>Click for more details</summary>
@@ -253,9 +251,8 @@ Add credentials for a new client that will connect to the HiveMind instance.
 $ hivemind-core add-client --name "satellite_1" --access-key "mykey123" --password "mypass"
 ```
 
-- **When to use**:  
-  Use this command when setting up a new HiveMind client (e.g., Raspberry Pi, IoT device). Provide credentials for
-  secure communication with the server.
+- **When to use**:
+  Use this command when you set up a new HiveMind client (for example, a Raspberry Pi or another IoT device). It provides credentials for secure communication with the server.
 - **Optional metadata**:
   Admins can attach plugin-specific client context with `--metadata`:
 
@@ -273,9 +270,8 @@ List all registered clients and their credentials.
 $ hivemind-core list-clients
 ```
 
-- **When to use**:  
-  Use this command to view or inspect all registered clients, helpful for debugging or managing devices connected to
-  HiveMind.
+- **When to use**:
+  Use this command to view or inspect all registered clients. It helps with debugging or managing devices connected to HiveMind.
 
 ---
 
@@ -287,7 +283,7 @@ Rename a registered client.
 $ hivemind-core rename-client "new name" 1
 ```
 
-- **When to use**:  
+- **When to use**:
   Use this command when you need to change the name of an existing client in the database.
 
 ---
@@ -300,22 +296,22 @@ Remove a registered client from the HiveMind instance.
 $ hivemind-core delete-client 1
 ```
 
-- **When to use**:  
-  Use this command to revoke a client’s access, for example, when a device is lost, no longer in use, or compromised.
+- **When to use**:
+  Use this command to revoke a client's access, for example when a device is lost, no longer in use, or compromised.
 
 ---
 
 ### `allow-msg`
 
-Grant a specific message type to a client’s `allowed_types` whitelist. New clients have an **empty** whitelist and are denied all messages until at least one type is granted.
+Grant a specific message type to a client's `allowed_types` whitelist. New clients have an **empty** whitelist and are denied all messages until you grant at least one type.
 
 ```bash
 $ hivemind-core allow-msg "recognizer_loop:utterance" 1
 $ hivemind-core allow-msg "speak" 1
 ```
 
-- **When to use**:  
-  Use this command after `add-client` to grant the message types the client needs. Without any `allow-msg` calls the client is effectively locked out (deny-by-default).
+- **When to use**:
+  Use this command after `add-client` to grant the message types the client needs. Without any `allow-msg` calls, the client is locked out (deny-by-default).
 
 ---
 
@@ -327,15 +323,14 @@ Revoke specific message types from being allowed to be sent by a client.
 $ hivemind-core blacklist-msg "speak"
 ```
 
-- **When to use**:  
-  Use this command to prevent specific message types from being sent by a client, adding a layer of control over
-  communication.
+- **When to use**:
+  Use this command to stop specific message types from being sent by a client. It adds a layer of control over communication.
 
 ---
 
 ### `blacklist-skill` / `allow-skill` / `blacklist-intent` / `allow-intent` (OVOS-policy)
 
-> Skill and intent filtering is an OVOS-specific concern handled by `OVOSAgentPolicy` (shipped with `hivemind-ovos-agent-plugin`). These commands manage the `skill_blacklist` / `intent_blacklist` lists in `Client.metadata`; `OVOSAgentPolicy` injects them into the OVOS session. They take effect only when that policy is configured in `policy.chain`. — `hivemind_core/scripts.py`
+> Skill and intent filtering is an OVOS-specific concern handled by `OVOSAgentPolicy` (shipped with `hivemind-ovos-agent-plugin`). These commands manage the `skill_blacklist` / `intent_blacklist` lists in `Client.metadata`. `OVOSAgentPolicy` injects them into the OVOS session. They take effect only when you configure that policy in `policy.chain` (`hivemind_core/scripts.py`).
 
 ```bash
 $ hivemind-core blacklist-skill "skill-weather" 1   # writes Client.metadata["skill_blacklist"]
@@ -348,7 +343,7 @@ $ hivemind-core allow-intent "intent.check_weather" 1
 
 ### `set-metadata`
 
-Set arbitrary `Client.metadata` on an existing client. Metadata keys are consumed by policy plugins — `OVOSAgentPolicy` reads `skill_blacklist` / `intent_blacklist`; other policies read their own keys. Merge a JSON object, set a single entry, or remove a key:
+Set arbitrary `Client.metadata` on an existing client. Policy plugins consume metadata keys. `OVOSAgentPolicy` reads `skill_blacklist` / `intent_blacklist`. Other policies read their own keys. Merge a JSON object, set a single entry, or remove a key:
 
 ```bash
 $ hivemind-core set-metadata 1 --metadata '{"tier":"pro","region":"eu"}'   # merge
@@ -367,9 +362,8 @@ Start the HiveMind instance to listen for client connections.
 $ hivemind-core listen
 ```
 
-- **When to use**:  
-  Use this command to start the HiveMind instance, enabling it to accept connections from clients (e.g., satellite
-  devices). Configure the host, port, and security options as needed.
+- **When to use**:
+  Use this command to start the HiveMind instance so it accepts connections from clients (for example, satellite devices). Configure the host, port, and security options as needed.
 
 ---
 
@@ -378,63 +372,63 @@ $ hivemind-core listen
 
 ---
 
-## 🧩 Plugins Overview
+## Plugins Overview
 
 | **Category**         | **Plugin**                                                                                   | **Description**                                                                                                                                                                                          |
-|----------------------|----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Network Protocol** | [hivemind-websocket-protocol](https://github.com/JarbasHiveMind/hivemind-websocket-protocol) | Provides WebSocket-based communication for Hivemind, enabling real-time data exchange.                                                                                                                   |
-|   | [hivemind-http-protocol](https://github.com/JarbasHiveMind/hivemind-http-protocol) | Provides HTTP-based communication for Hivemind, ideal for when a persistent connected is undesirable/not-possible                                                                                                                   |
-| **Binary Protocol**  | [hivemind-audio-binary-protocol](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol)                     | Listens for incoming audio and processes it using the [ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager), enabling seamless interaction between Hivemind and audio input systems. |
-| **Agent Protocol**   | [OpenVoiceOS](https://github.com/OpenVoiceOS/ovos-core)                                      | Integration with OpenVoiceOS, facilitated by [ovos-bus-client](https://github.com/OpenVoiceOS/ovos-bus-client/blob/dev/ovos_bus_client/hpm.py), enabling seamless communication with OVOS systems.                                       |
-|                      | [Persona](https://github.com/OpenVoiceOS/ovos-persona)                                | LLM (Large Language Model) integration provided by [ovos-persona](https://github.com/OpenVoiceOS/ovos-persona/blob/dev/ovos_persona/hpm.py), works with all OpenAI server compatible projects.                                         |
-| **Database**         | [hivemind-sqlite-database](https://github.com/JarbasHiveMind/hivemind-sqlite-database)       | SQLite-based database solution for managing local data within Hivemind applications.                                                                                                                     |
-|                      | [hivemind-redis-database](https://github.com/JarbasHiveMind/hivemind-redis-database)         | Redis integration for scalable, in-memory database solutions with fast data access.                                                                                                                      |
-|                      | [hivemind-json-database](https://github.com/TigreGotico/json_database/pull/7)                | A JSON-based database plugin provided by [json-database](https://github.com/TigreGotico/json_database), offering lightweight storage and retrieval using JSON format.                                    |
+|----------------------|----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Network Protocol** | [hivemind-websocket-protocol](https://github.com/JarbasHiveMind/hivemind-websocket-protocol) | Provides WebSocket-based communication for HiveMind, for real-time data exchange.                                                                                                                   |
+|   | [hivemind-http-protocol](https://github.com/JarbasHiveMind/hivemind-http-protocol) | Provides HTTP-based communication for HiveMind, for cases where a persistent connection is undesirable or not possible.                                                                                                                   |
+| **Binary Protocol**  | [hivemind-audio-binary-protocol](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol)                     | Listens for incoming audio and processes it with the [ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager), connecting HiveMind to audio input systems. |
+| **Agent Protocol**   | [OpenVoiceOS](https://github.com/OpenVoiceOS/ovos-core)                                      | Integration with OpenVoiceOS, through [ovos-bus-client](https://github.com/OpenVoiceOS/ovos-bus-client/blob/dev/ovos_bus_client/hpm.py), for communication with OVOS systems.                                       |
+|                      | [Persona](https://github.com/OpenVoiceOS/ovos-persona)                                | LLM (Large Language Model) integration provided by [ovos-persona](https://github.com/OpenVoiceOS/ovos-persona/blob/dev/ovos_persona/hpm.py), which works with all OpenAI server compatible projects.                                         |
+| **Database**         | [hivemind-sqlite-database](https://github.com/JarbasHiveMind/hivemind-sqlite-database)       | SQLite-based database plugin for managing local data in HiveMind.                                                                                                                     |
+|                      | [hivemind-redis-database](https://github.com/JarbasHiveMind/hivemind-redis-database)         | Redis integration for scalable, in-memory database storage with fast data access.                                                                                                                      |
+|                      | [hivemind-json-database](https://github.com/TigreGotico/json_database/pull/7)                | A JSON-based database plugin provided by [json-database](https://github.com/TigreGotico/json_database), for lightweight storage and retrieval using the JSON format.                                    |
 
 ---
 
-## 💬 Clients Overview
+## Clients Overview
 
 | **Category**   | **Client**                                                                      | **Description**                                                                                              |
-|----------------|---------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
-| **Satellites** | [Voice Satellite](https://github.com/OpenJarbas/HiveMind-voice-sat)             | Standalone OVOS *local* audio stack for Hivemind.                                                            |
-|                | [Voice Relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay)           | Lightweight audio satellite, STT/TTS processed *server* side, **requires** `hivemind-audio-binary-protocol`.              |
-|                | [Mic Satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite)       | Only VAD runs on device, audio streamed and fully processed *server* side, **requires** `hivemind-audio-binary-protocol`. |
-|                | [Web Chat](https://github.com/OpenJarbas/HiveMind-webchat)                      | *Client-side* browser Hivemind connection for web-based communication.                                       |
-| **Bridges**    | [Mattermost Bridge](https://github.com/OpenJarbas/HiveMind_mattermost_bridge)   | Bridge for talking to Hivemind via Mattermost                                                                |
-|                | [Matrix Bridge](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge)       | Bridge for talking to Hivemind via Matrix                                                                    |
-|                | [DeltaChat Bridge](https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge) | Bridge for talking to Hivemind via DeltaChat                                                                 |
+|----------------|-----------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| **Satellites** | [Voice Satellite](https://github.com/OpenJarbas/HiveMind-voice-sat)             | Standalone OVOS *local* audio stack for HiveMind.                                                            |
+|                | [Voice Relay](https://github.com/JarbasHiveMind/HiveMind-voice-relay)           | Lightweight audio satellite. STT/TTS runs *server* side. **Requires** `hivemind-audio-binary-protocol`.              |
+|                | [Mic Satellite](https://github.com/JarbasHiveMind/hivemind-mic-satellite)       | Only VAD runs on the device. Audio streams to the server and processes fully *server* side. **Requires** `hivemind-audio-binary-protocol`. |
+|                | [Web Chat](https://github.com/OpenJarbas/HiveMind-webchat)                      | *Client-side* browser HiveMind connection for web-based communication.                                       |
+| **Bridges**    | [Mattermost Bridge](https://github.com/OpenJarbas/HiveMind_mattermost_bridge)   | Bridge for talking to HiveMind through Mattermost.                                                                |
+|                | [Matrix Bridge](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge)       | Bridge for talking to HiveMind through Matrix.                                                                    |
+|                | [DeltaChat Bridge](https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge) | Bridge for talking to HiveMind through DeltaChat.                                                                |
 
 ---
 
-## 🚀 Next Steps
+## Next Steps
 
 - Visit the [documentation](https://jarbashivemind.github.io/HiveMind-community-docs) for detailed guides.
 - Join the [HiveMind Matrix Chat](https://matrix.to/#/#jarbashivemind:matrix.org) for support and updates.
-- Explore additional plugins and expand your HiveMind ecosystem.
+- Explore other plugins and expand your HiveMind setup.
 
 ---
 
-## ⚖️ License
+## License
 
 HiveMind-core is licensed under the **[Apache License 2.0](./LICENSE)**, matching the rest of the HiveMind ecosystem.
 
-> 💡 Releases ≤ **`hivemind-core` 3.4.0** were Apache-2.0. The **4.x** series shipped under AGPL-3.0 as a short-lived experiment; from this release forward HiveMind-core returns to Apache-2.0. Previously published 3.x and 4.x releases on PyPI remain under the licence they were published with.
+> Releases up to **`hivemind-core` 3.4.0** were Apache-2.0. The **4.x** series shipped under AGPL-3.0 as a short-lived experiment. From this release forward, HiveMind-core returns to Apache-2.0. Previously published 3.x and 4.x releases on PyPI stay under the license they were published with.
 
 ### Trademark
 
-The names **HiveMind**, **HiveMind-core**, **HiveMind Protocol**, the HiveMind logos, and any "HiveMind Compatible / Powered by HiveMind" marks are protected trademarks and are **not** licensed under Apache-2.0 (see Apache-2.0 §6). See [TRADEMARK-USAGE.md](./TRADEMARK-USAGE.md) for the brand-use policy. A no-cost trademark grant is available for nonprofits, academic projects, and OSI-licensed downstreams.
+The names **HiveMind**, **HiveMind-core**, **HiveMind Protocol**, the HiveMind logos, and any "HiveMind Compatible / Powered by HiveMind" marks are protected trademarks and are **not** licensed under Apache-2.0 (see Apache-2.0 §6). See [TRADEMARK-USAGE.md](./TRADEMARK-USAGE.md) for the brand-use policy. A no-cost trademark grant is available for nonprofits, academic projects, and OSI-licensed downstream projects.
 
 ### Supporting the project
 
-If your organisation depends on HiveMind-core in production, consider sponsoring the project, contracting paid support / custom integrations, or commissioning proprietary skills. Contact: **[jarbasai@mailfence.com](mailto:jarbasai@mailfence.com)**.
+If your organization depends on HiveMind-core in production, consider sponsoring the project, contracting paid support or custom integrations, or commissioning proprietary skills. Contact: **[jarbasai@mailfence.com](mailto:jarbasai@mailfence.com)**.
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
-HiveMind-core welcomes external contributions. Inbound code is licensed under Apache-2.0 by default (per Apache-2.0 §5 — no separate CLA needed).
+HiveMind-core welcomes external contributions. Inbound code is licensed under Apache-2.0 by default (per Apache-2.0 §5, no separate CLA needed).
 
-- **Bugs & features** — open an issue on GitHub.
-- **Pull requests** — target the `dev` branch. Keep changes focused; follow existing code style.
-- **Discussion** — [Matrix chat](https://matrix.to/#/#jarbashivemind:matrix.org).
+- **Bugs & features**: open an issue on GitHub.
+- **Pull requests**: target the `dev` branch. Keep changes focused and follow the existing code style.
+- **Discussion**: [Matrix chat](https://matrix.to/#/#jarbashivemind:matrix.org).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # HiveMind Core — Documentation
 
-HiveMind Core is the central hub server for the HiveMind mesh. It accepts authenticated,
+HiveMind Core is the central server for the HiveMind network. It accepts authenticated,
 encrypted connections from satellite devices and AI agents, routes HiveMessages between
 them and the agent backend, and enforces per-client permissions through a configurable
 policy chain.
@@ -12,7 +12,7 @@ policy chain.
 | Document | Purpose |
 |---|---|
 | [getting-started.md](getting-started.md) | Install, first satellite, run the server |
-| [architecture.md](architecture.md) | How the hub works end-to-end: message flow, protocol layers, plugin types |
+| [architecture.md](architecture.md) | How the server works end-to-end: message flow, protocol layers, plugin types |
 | [configuration.md](configuration.md) | Full `server.json` reference, all keys and defaults |
 | [cli-reference.md](cli-reference.md) | Every `hivemind-core` subcommand with examples |
 | [policy.md](policy.md) | Policy admission chain: how it works, authoring plugins, deny codes |
@@ -23,7 +23,7 @@ policy chain.
 
 ## Quick Links
 
-- **GitHub**: <https://github.com/JarbasHiveMind/HiveMind-core>
-- **Community docs**: <https://jarbashivemind.github.io/HiveMind-community-docs>
+- **GitHub**: [JarbasHiveMind/HiveMind-core](https://github.com/JarbasHiveMind/HiveMind-core)
+- **Community docs**: [jarbashivemind.github.io/HiveMind-community-docs](https://jarbashivemind.github.io/HiveMind-community-docs)
 - **Plugin manager ABCs**: [hivemind-plugin-manager](https://github.com/JarbasHiveMind/hivemind-plugin-manager)
-- **Matrix chat**: <https://matrix.to/#/#jarbashivemind:matrix.org>
+- **Matrix chat**: [#jarbashivemind:matrix.org](https://matrix.to/#/#jarbashivemind:matrix.org)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,12 +2,12 @@
 
 ## HiveMind in One Paragraph
 
-HiveMind is a protocol and mesh: lightweight **satellite** devices connect to a central
-**hivemind-core** hub over an authenticated, encrypted connection. The hub authenticates
+HiveMind is a protocol and network. Lightweight **satellite** devices connect to a central
+**hivemind-core** server over an authenticated, encrypted connection. The server authenticates
 each satellite against its client database, enforces per-client permissions through a
 policy chain, then routes `HiveMessage` payloads between the satellite and the configured
-AI agent backend. Hubs can themselves connect upstream to other hubs (**relay/nested**
-topologies), creating scalable multi-tier smart environments.
+AI agent backend. A HiveMind Core server can itself connect upstream to another HiveMind Core server (**relay/nested**
+topology), so you can build multi-tier environments.
 
 ---
 
@@ -44,15 +44,15 @@ messages). Responses from the agent travel back through the same path.
 | Type | Direction | Purpose |
 |---|---|---|
 | `HANDSHAKE` | bidirectional | Cipher/key negotiation on connect |
-| `HELLO` | hub → satellite | Hub identity announcement |
+| `HELLO` | server → satellite | Server identity announcement |
 | `BUS` | bidirectional | Wraps an OVOS `Message`; the most common type |
-| `SHARED_BUS` | hub → satellite | Hub-bus event pushed to satellite |
-| `BROADCAST` | satellite → hub | Deliver to all connected satellites |
-| `PROPAGATE` | satellite → hub | Forward upstream to parent hub |
-| `ESCALATE` | satellite → hub | Forward up the relay chain |
+| `SHARED_BUS` | server → satellite | Bus event pushed to satellite |
+| `BROADCAST` | satellite → server | Deliver to all connected satellites |
+| `PROPAGATE` | satellite → server | Forward upstream to the parent server |
+| `ESCALATE` | satellite → server | Forward up the relay chain |
 | `PING` | bidirectional | Keepalive |
-| `QUERY` | satellite → hub | Natural-language query; hub streams answer chunks |
-| `CASCADE` | hub → satellite(s) | Scatter/gather: distributes a query across children |
+| `QUERY` | satellite → server | Natural-language query. The server streams answer chunks |
+| `CASCADE` | server → satellite(s) | Scatter/gather: distributes a query across children |
 | `INTERCOM` | bidirectional | Signed/encrypted end-to-end peer message |
 | `BINARY` | bidirectional | Raw bytes (audio, image, file) |
 
@@ -62,7 +62,7 @@ A `QUERY` message triggers `AgentProtocol.natural_language_query(utterance, lang
 generator that yields string answer chunks followed by a final `None` sentinel.
 Each chunk is forwarded to the satellite as it arrives. A `hive.query.complete` control
 message is sent when the generator exhausts. If the agent yields `None` immediately (no
-answer), the hub escalates the query upstream.
+answer), the server escalates the query upstream.
 
 `CASCADE` scatters the query across child nodes and gathers their streamed responses.
 
@@ -90,7 +90,7 @@ into the policy chain (see [Policy Chain](policy.md)).
 Every `BUS` (and `BINARY`) message crosses the policy admission chain before reaching the
 agent:
 
-1. `MessageTypeACLPolicy` — always first; enforces the per-client `allowed_types`
+1. `MessageTypeACLPolicy` runs first, always. It enforces the per-client `allowed_types`
    whitelist. Deny-by-default: an empty whitelist blocks everything.
 2. Configured plugins in `policy.chain` (e.g. `OVOSAgentPolicy` for skill/intent
    blacklists, custom quota or rate-limit plugins).
@@ -100,19 +100,19 @@ for the full specification.
 
 ---
 
-## Hub-to-Hub Relay (Nested Topology)
+## Server-to-Server Relay (Nested Topology)
 
-A hub can act as a satellite to an upstream hub. In this role it is a **relay node**:
+A HiveMind Core server can act as a satellite to an upstream server. In this role it is a **relay node**:
 it holds its own client database for its downstream satellites and forwards messages
-upstream when needed. This creates hierarchical topologies where a local hub aggregates
-several satellites and delegates to a central hub.
+upstream when needed. This creates layered topologies where a local server aggregates
+several satellites and delegates to a central server.
 
 ```
-Central Hub
-   ├── Local Hub A  (also acts as a satellite to Central Hub)
+Central Server
+   ├── Relay Server A  (also acts as a satellite to the Central Server)
    │     ├── Satellite 1
    │     └── Satellite 2
-   └── Local Hub B
+   └── Relay Server B
          └── Satellite 3
 ```
 
@@ -121,13 +121,13 @@ Central Hub
 ## Horizontal Scaling Status
 
 A single `HiveMindListenerProtocol` instance is currently the authoritative runtime for
-one hub process. The listener keeps live connection state in memory (`clients`,
+one server process. The listener keeps live connection state in memory (`clients`,
 `hive_mapper`, pending cascade collectors, trusted public keys, query callbacks, and the
 agent bus binding). Running two pods behind the same load balancer is therefore safe only
-with sticky websocket routing and an external database; it is not yet active-active
+with sticky websocket routing and an external database. It is not yet active-active
 sharding.
 
-Before HiveMind can scale one logical hub across several listener pods, these pieces need
+Before HiveMind can scale one logical server across several listener pods, these pieces need
 to move out of process-local memory:
 
 - **Client/session registry**: live peers, session ids, node type, capabilities, and
@@ -141,18 +141,18 @@ to move out of process-local memory:
 - **Admission metrics**: policy timing, quota timing, bus emit timing, and agent response
   timing should be recorded separately so operators can see which stage is saturated.
 
-Until those pieces exist, scale by sharding at the hub level: run multiple independent
-hubs, keep websocket stickiness for each hub, and use relay/nested topology for larger
-fleets.
+Until those pieces exist, scale by sharding at the server level: run multiple independent
+servers, keep websocket stickiness for each server, and use relay/nested topology for larger
+deployments.
 
 ### Load-test signal
 
-Recent production-style WSS benchmarks with many independent client identities showed a
-consistent pattern: one logical hub can complete concurrent direct WSS requests, but high
+Production-style WSS benchmarks with many independent client identities showed a
+consistent pattern: one logical server can complete concurrent direct WSS requests, but high
 fan-in increases tail latency inside the listener before OVOS runtime CPU becomes the only
 pressure point.
 
-That pattern means adding OVOS replicas alone does not solve one-hub concurrency. The
+That pattern means adding OVOS replicas alone does not solve one-server concurrency. The
 first pressure point is the websocket/listener process: handshake admission, message
 decode/logging, policy review, and agent-bus injection all pass through one process-local
 router. Runtime replicas help once messages leave the listener, but the listener must
@@ -168,18 +168,18 @@ Near-term mitigations:
 - use direct database lookup for API-key admission instead of full database sync on every
   websocket open;
 - benchmark with independent client identities when measuring user concurrency;
-- shard load across more logical hubs when interactive latency matters.
+- shard load across more logical servers when interactive latency matters.
 
 Active-active listener scale needs a larger change: a shared connection/session registry,
 cross-listener message delivery, and deterministic ownership for query/cascade collectors.
 Without that, multiple listener pods behind one service can only safely work as sticky
-websocket replicas, not as a true shared hub.
+websocket replicas, not as a true shared server.
 
 ---
 
 ## Identity and Encryption
 
-Each hub has a `NodeIdentity` (stored by `hivemind-bus-client`). Satellites and hubs
+Each server has a `NodeIdentity` (stored by `hivemind-bus-client`). Satellites and servers
 negotiate a session cipher during HANDSHAKE. Supported ciphers (order of preference
 in config): `CHACHA20-POLY1305`, `AES-GCM`. Supported encodings: `JSON-B64`,
 `JSON-URLSAFE-B64`, `JSON-B91`, `JSON-Z85B`, `JSON-Z85P`, `JSON-B32`, `JSON-HEX`.
@@ -191,8 +191,11 @@ originating and target peers, opaque to intermediate relay nodes.
 
 ## Discovery
 
-Satellites discover the hivemind-core server via:
+Satellites discover the hivemind-core server through:
 
-- **mDNS / zeroconf** (default) — requires the optional `hivemind-presence` package.
-- **UPnP/SSDP** — optional, provided by `hivemind-presence` (`upnp: true`).
-- Manual — provide host/port directly in the satellite's configuration.
+- **mDNS / zeroconf** (default): requires the optional `hivemind-presence` package.
+- **UPnP/SSDP**: optional, provided by `hivemind-presence` (`upnp: true`).
+- Manual: provide host/port directly in the satellite's configuration.
+
+---
+[← Getting Started](getting-started.md) · [Home](README.md) · [Configuration →](configuration.md)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,6 +1,6 @@
 # Authentication and Client Management
 
-Client management is handled through the `hivemind-core` CLI and the `hivemind_core.database.HiveMindDatabase` interface.
+Client management runs through the `hivemind-core` CLI and the `hivemind_core.database.ClientDatabase` interface.
 
 ## Adding a Client
 
@@ -11,30 +11,41 @@ hivemind-core add-client --name "LivingRoom-Sat"
 ```
 
 This generates:
-- **Node ID**: Unique integer ID.
-- **Access Key**: Public identifier for the client.
-- **Password**: Secret used for the handshake.
+- **Node ID**: a unique integer ID.
+- **Access Key**: a public identifier for the client.
+- **Password**: a secret used for the handshake.
 
 ## Managing Permissions
 
-Permissions are managed by the `HiveMindDatabase` and its associated methods.
+The CLI writes permissions to the client row through `ClientDatabase`.
 
 ### Blacklisting Skills
-To prevent a specific client (ID 1) from using a specific skill:
+
+To stop a specific client (ID 1) from using a specific skill:
+
 ```bash
 hivemind-core blacklist-skill "mycroft-weather.mycroftai" 1
 ```
-- **Source**: `hivemind_core.database.HiveMindDatabase.blacklist_skill`
+
+- **Source**: `hivemind_core.scripts.blacklist_skill`
 
 ### Allowing Messages
-By default, most message types are restricted. To allow a client to receive `speak` messages:
+
+New clients start with an empty `allowed_types` whitelist and are denied all messages. To let a client receive `speak` messages:
+
 ```bash
 hivemind-core allow-msg "speak" 1
 ```
-- **Source**: `hivemind_core.database.HiveMindDatabase.allow_msg`
+
+- **Source**: `hivemind_core.scripts.allow_msg`
 
 ## Database Backends
+
 HiveMind supports multiple database plugins for storing client credentials:
-- **JSON**: `hivemind_core.database.JsonDB` (implemented via `json_database.hpm.JsonDB`).
-- **SQLite**: `hivemind_core.database.SQLiteDB` (implemented via `hivemind_sqlite_database.SQLiteDB`).
-- **Redis**: `hivemind_core.database.RedisDB` (implemented via `hivemind_redis_database.RedisDB`).
+
+- **SQLite** (default for fresh installs): `hivemind_sqlite_database.SQLiteDB`.
+- **JSON** (kept for existing JSON deployments): `json_database.hpm.JsonDB`.
+- **Redis**: `hivemind_redis_database.RedisDB`.
+
+---
+[Home](index.md) · [Installation →](installation.md)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -7,7 +7,7 @@ client ID from any command that requires one, you will be prompted to select int
 Usage: hivemind-core [OPTIONS] COMMAND [ARGS]...
 
 Commands:
-  listen              Start the HiveMind hub server
+  listen              Start the HiveMind Core server
   add-client          Register credentials for a new satellite
   list-clients        Print all registered clients
   rename-client       Rename a registered client
@@ -32,7 +32,7 @@ Commands:
 
 ## `listen`
 
-Start the HiveMind hub server.
+Start the HiveMind Core server.
 
 ```bash
 hivemind-core listen
@@ -65,7 +65,7 @@ Options:
 | `--db-backend TEXT` | from config | Override the database backend for this command |
 | `--metadata JSON` | `{}` | Initial `Client.metadata` as a JSON object |
 
-A freshly created client has an **empty** `allowed_types` whitelist — it is denied all
+A freshly created client has an **empty** `allowed_types` whitelist. It is denied all
 messages until you run `allow-msg`.
 
 ---
@@ -100,7 +100,7 @@ hivemind-core delete-client 1
 
 ## `make-admin` / `revoke-admin`
 
-Set `Client.is_admin`. This is **informational only** — it does not bypass the policy
+Set `Client.is_admin`. This is **informational only**. It does not bypass the policy
 chain or the `allowed_types` whitelist.
 
 ```bash
@@ -170,8 +170,8 @@ hivemind-core allow-intent "skill-weather.WeatherIntent" 1
 
 ## `set-metadata`
 
-Write arbitrary key/value pairs to `Client.metadata`. Metadata is consumed by policy
-plugins — each plugin reads the keys it knows about.
+Write arbitrary key/value pairs to `Client.metadata`. Policy plugins consume metadata.
+Each plugin reads the keys it knows about.
 
 ```bash
 # Merge a JSON object
@@ -204,3 +204,6 @@ hivemind-core migrate-db --from sqlite --to redis \
 ```
 
 Source: `hivemind_core/scripts.py`
+
+---
+[← Configuration](configuration.md) · [Home](README.md) · [Policy Chain →](policy.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -52,7 +52,7 @@ hivemind-core add-client [OPTIONS]
 | `--crypto-key` | `str` | **Deprecated.** Legacy 16-character encryption key. Use `--password` instead |
 | `--admin` | `bool` | Grant administrator privileges (default: `False`) |
 
-**Example — auto-generated credentials:**
+**Example: auto-generated credentials**
 
 ```bash
 $ hivemind-core add-client --name "living-room-pi"
@@ -164,7 +164,7 @@ hivemind-core blacklist-msg MSG_TYPE [NODE_ID]
 
 ### `allow-escalate` / `blacklist-escalate`
 
-Control whether a client may send `ESCALATE` messages (forwarded up the hub hierarchy).
+Control whether a client may send `ESCALATE` messages (forwarded up the server hierarchy).
 
 ```bash
 hivemind-core allow-escalate [NODE_ID]
@@ -173,7 +173,7 @@ hivemind-core blacklist-escalate [NODE_ID]
 
 ### `allow-propagate` / `blacklist-propagate`
 
-Control whether a client may send `PROPAGATE` messages (forwarded to all peers and upstream hubs).
+Control whether a client may send `PROPAGATE` messages (forwarded to all peers and upstream servers).
 
 ```bash
 hivemind-core allow-propagate [NODE_ID]
@@ -211,3 +211,6 @@ hivemind-core allow-intent INTENT_ID [NODE_ID]
 ```bash
 hivemind-core blacklist-intent skill-weather.openvoiceos:WeatherIntent 1
 ```
+
+---
+[← Protocol](protocol.md) · [Home](index.md) · [Plugin Development →](plugin_development.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,3 +224,6 @@ hpm list database
 hpm set database hivemind-redis-db-plugin
 hpm show-config
 ```
+
+---
+[← Architecture](architecture.md) · [Home](README.md) · [CLI Reference →](cli-reference.md)

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -8,12 +8,12 @@ This page maps every repository in the HiveMind ecosystem to its role and links 
 
 | Repo | Role | Docs |
 |---|---|---|
-| **hivemind-core** | Hub server — authenticates clients, routes messages, enforces permissions | [docs](index.md) |
+| **hivemind-core** | Central server. Authenticates clients, routes messages, enforces permissions | [docs](index.md) |
 | **hivemind-plugin-manager** | Plugin discovery and factory system used by hivemind-core | [docs](../../hivemind-plugin-manager/docs/index.md) |
-| **hivemind-websocket-client** | Python client library and CLI for connecting to a hub | [docs](../../hivemind-websocket-client/docs/index.md) |
+| **hivemind-websocket-client** | Python client library and CLI for connecting to a HiveMind Core server | [docs](../../hivemind-websocket-client/docs/index.md) |
 | **poorman_handshake** | RSA + password-based handshake primitives used for key exchange | [docs](../../poorman_handshake/docs/index.md) |
 | **z85base91** | Binary-to-text encoding schemes (Z85B, Z85P, Base91) used for wire efficiency | [docs](../../z85base91/docs/index.md) |
-| **HiveBeacon** | UDP LAN broadcast / discovery — advertises hub presence on the local network | [docs](../../HiveBeacon/docs/index.md) |
+| **HiveBeacon** | UDP LAN broadcast and discovery. Advertises the server's presence on the local network | [docs](../../HiveBeacon/docs/index.md) |
 
 ---
 
@@ -30,7 +30,7 @@ Transport layer plugins loaded by hivemind-core. Multiple can run simultaneously
 
 ## Binary protocol plugins
 
-Handle binary payloads (audio, images, files) arriving at the hub.
+Handle binary payloads (audio, images, files) arriving at the server.
 
 | Repo | Entry-point name | Docs |
 |---|---|---|
@@ -52,20 +52,20 @@ Credential storage backends.
 
 ## Satellite clients
 
-Devices that connect to a hub and provide voice or chat interaction.
+Devices that connect to a HiveMind Core server and provide voice or chat interaction.
 
 | Repo | Processing model | Requires audio binary protocol | Docs |
 |---|---|---|---|
-| **HiveMind-voice-sat** | Wake word + STT + TTS all run **on device** | No | [docs](../../HiveMind-voice-sat/docs/index.md) |
-| **HiveMind-voice-relay** | Wake word on device; STT + TTS offloaded **to hub** | Yes | [docs](../../HiveMind-voice-relay/docs/index.md) |
-| **hivemind-mic-satellite** | Only mic + VAD on device; all audio streamed **to hub** | Yes | [docs](../../hivemind-mic-satellite/docs/index.md) |
-| **hivemind-webspeech** | VAD in browser; audio streamed to hub via JS | Yes | [docs](../../hivemind-webspeech/docs/index.md) |
+| **HiveMind-voice-sat** | Wake word, STT, and TTS all run **on device** | No | [docs](../../HiveMind-voice-sat/docs/index.md) |
+| **HiveMind-voice-relay** | Wake word on device. STT and TTS offloaded **to the server** | Yes | [docs](../../HiveMind-voice-relay/docs/index.md) |
+| **hivemind-mic-satellite** | Only mic and VAD on device. All audio streamed **to the server** | Yes | [docs](../../hivemind-mic-satellite/docs/index.md) |
+| **hivemind-webspeech** | VAD in the browser. Audio streamed to the server through JS | Yes | [docs](../../hivemind-webspeech/docs/index.md) |
 
 ---
 
 ## Bridges
 
-Connect external messaging platforms to a HiveMind hub.
+Connect external messaging platforms to a HiveMind Core server.
 
 | Repo | Platform | Docs |
 |---|---|---|
@@ -77,12 +77,12 @@ Connect external messaging platforms to a HiveMind hub.
 
 ## OVOS-side plugins
 
-Plugins that run inside an OpenVoiceOS instance and connect it outward to a HiveMind hub.
+Plugins that run inside an OpenVoiceOS instance and connect it outward to a HiveMind Core server.
 
 | Repo | Type | Purpose | Docs |
 |---|---|---|---|
-| **ovos-hivemind-pipeline-plugin** | OVOS intent pipeline plugin | Forward unmatched utterances to a remote HiveMind hub | [docs](../../ovos-hivemind-pipeline-plugin/docs/index.md) |
-| **ovos-solver-hivemind-plugin** | OVOS solver plugin | Query a HiveMind hub as a question-answering backend | [docs](../../ovos-solver-hivemind-plugin/docs/index.md) |
+| **ovos-hivemind-pipeline-plugin** | OVOS intent pipeline plugin | Forward unmatched utterances to a remote HiveMind Core server | [docs](../../ovos-hivemind-pipeline-plugin/docs/index.md) |
+| **ovos-solver-hivemind-plugin** | OVOS solver plugin | Query a HiveMind Core server as a question-answering backend | [docs](../../ovos-solver-hivemind-plugin/docs/index.md) |
 
 ---
 
@@ -91,8 +91,8 @@ Plugins that run inside an OpenVoiceOS instance and connect it outward to a Hive
 | Repo | Description | Docs |
 |---|---|---|
 | **hivemind-media-player** | Turn any device into an OCP (OVOS Common Play) media player controlled via HiveMind | [docs](../../hivemind-media-player/docs/index.md) |
-| **hivemind-homeassistant** | Home Assistant custom integration — exposes HiveMind devices as HA media players | [docs](../../hivemind-homeassistant/docs/index.md) |
-| **hivemind-ggwave** | Data-over-sound pairing — provision satellite credentials via audio without a keyboard | [docs](../../hivemind-ggwave/docs/index.md) |
+| **hivemind-homeassistant** | Home Assistant custom integration. Exposes HiveMind devices as HA media players | [docs](../../hivemind-homeassistant/docs/index.md) |
+| **hivemind-ggwave** | Data-over-sound pairing. Provisions satellite credentials over audio, without a keyboard | [docs](../../hivemind-ggwave/docs/index.md) |
 
 ---
 
@@ -102,3 +102,6 @@ Plugins that run inside an OpenVoiceOS instance and connect it outward to a Hive
 |---|---|---|
 | **hivemind-docker** | Docker Compose stacks for running various HiveMind services | [docs](../../hivemind-docker/docs/index.md) |
 | **hivemind-skills-server-docker** | Docker setup for a persona-based HiveMind skills server | [docs](../../hivemind-skills-server-docker/docs/index.md) |
+
+---
+[← Network Map](hive_map.md) · [Home](index.md)

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,13 +1,13 @@
 # Extending HiveMind Core
 
-HiveMind Core is assembled from plugins. Every backend concern — database, transport,
-agent, binary handling, and admission control — is a separate installable Python package
-that registers itself under a setuptools entry-point group. No changes to hivemind-core
-itself are required.
+HiveMind Core is assembled from plugins. Every backend concern (database, transport,
+agent, binary handling, and admission control) is a separate installable Python package
+that registers itself under a setuptools entry-point group. It needs no changes to
+hivemind-core itself.
 
 The abstract base classes are defined in
 [hivemind-plugin-manager](https://github.com/JarbasHiveMind/hivemind-plugin-manager).
-This page summarises how to wire a plugin to hivemind-core; for the full ABC contracts
+This page summarizes how to wire a plugin to hivemind-core. For the full ABC contracts
 and complete walkthroughs, see the
 [plugin-manager docs](https://github.com/JarbasHiveMind/hivemind-plugin-manager/tree/dev/docs).
 
@@ -228,3 +228,6 @@ my-policy = "my_package.policy:MyPolicy"
 `MessageTypeACLPolicy` is implicit and always first. Do not list it.
 Full guide: [docs/policy.md](policy.md) and
 [hivemind-plugin-manager/docs/plugins/policy.md](https://github.com/JarbasHiveMind/hivemind-plugin-manager/blob/dev/docs/plugins/policy.md)
+
+---
+[← Plugins](plugins.md) · [Home](README.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,12 +16,12 @@
 pip install hivemind-core
 ```
 
-This installs the hub server and the `hivemind-core` CLI. The default transport (WebSocket)
+This installs the HiveMind Core server and the `hivemind-core` CLI. The default transport (WebSocket)
 and the default database backend (SQLite) are pulled in automatically.
 
 ---
 
-## Start the Hub
+## Start the Server
 
 ```bash
 hivemind-core listen
@@ -81,7 +81,10 @@ Once the satellite connects, its `last_seen` timestamp updates.
 
 ## Next Steps
 
-- [Architecture](architecture.md) — understand how messages flow through the hub.
-- [Configuration](configuration.md) — change ports, switch database backend, add TLS.
-- [CLI Reference](cli-reference.md) — all available commands.
-- [Policy Chain](policy.md) — fine-grained per-client admission control.
+- [Architecture](architecture.md): understand how messages flow through the server.
+- [Configuration](configuration.md): change ports, switch database backend, add TLS.
+- [CLI Reference](cli-reference.md): all available commands.
+- [Policy Chain](policy.md): fine-grained per-client admission control.
+
+---
+[Home](README.md) · [Architecture →](architecture.md)

--- a/docs/hive_map.md
+++ b/docs/hive_map.md
@@ -1,9 +1,14 @@
 # Hive Map — Topology Discovery and Visualization
 
-`HiveMapper` is the utility class that collects PONG responses from a PING flood and builds a
-directed graph of the reachable hive. It is defined in `hivemind_core.hive_map`.
+`HiveMapper` is the utility class that collects PING-flood responses and builds a
+directed graph of the reachable network. It lives in `hivemind_bus_client.hive_map`
+and the server imports it in `hivemind_core/protocol.py`.
 
-For a conceptual overview of the PING/PONG protocol, see
+Discovery is PING-only. Every node answers an inbound PING by relaying its own PING
+with the same `flood_id`, so all nodes in the network sync in one round. There is
+no separate PONG message. The `flood_id` stops infinite relay loops.
+
+For a conceptual overview of the discovery protocol, see
 [`HiveMind-community-docs: docs/20_network_discovery.md`](../../HiveMind-community-docs/docs/20_network_discovery.md).
 
 ---
@@ -11,21 +16,21 @@ For a conceptual overview of the PING/PONG protocol, see
 ## Design Overview
 
 ```
-Originator sends PING
+Originator sends PING (flood_id)
         │
         ▼
-HiveMapper.start_ping(ping_id)   ← register expected ping_id
+HiveMapper.start_ping(flood_id)   ← register expected flood_id
         │
         ▼
-PONGs arrive (each via PROPAGATE)
+PINGs arrive from other nodes (each via PROPAGATE)
         │
         ▼
-HiveMapper.on_pong(pong_msg)     ← extract route, upsert nodes/edges
+HiveMapper.on_ping(ping_msg)      ← extract route, upsert nodes/edges
         │
         ▼
-HiveMapper.to_ascii()            ← render to terminal
-HiveMapper.to_dict()             ← export as JSON-serialisable dict
-HiveMapper.to_json()             ← export as JSON string
+HiveMapper.to_ascii()             ← render to terminal
+HiveMapper.to_dict()              ← export as a JSON-serializable dict
+HiveMapper.to_json()              ← export as a JSON string
 ```
 
 ---
@@ -38,35 +43,36 @@ HiveMapper.to_json()             ← export as JSON string
 class HiveMapper:
     def __init__(self) -> None:
         """
-        Initialise an empty topology map.
+        Initialize an empty topology map.
 
         Attributes:
-            nodes (Dict[str, NodeInfo]): peer_id → node metadata
-            edges (Dict[str, Set[str]]): peer_id → set of peer_ids it was seen routing to
-            _seen_pongs (Dict[str, Set[str]]): ping_id → set of peer_ids that already responded
+            nodes (Dict[str, NodeInfo]): peer_id -> node metadata
+            edges (Dict[str, Set[str]]): peer_id -> set of peer_ids it was seen routing to
+            _seen_pings (Dict[str, Set[str]]): flood_id -> set of peer_ids that already sent a PING
+            _seen_flood_ids (OrderedDict[str, float]): flood_id -> timestamp, for loop prevention
         """
 ```
 
-### `start_ping(ping_id: str) -> None`
+### `start_ping(flood_id: str) -> None`
 
-Register a new PING session. Clears any stale PONG-deduplication state for the given `ping_id`.
+Register a new PING session. Clears any stale deduplication state for the given `flood_id`.
 
 ```python
 mapper.start_ping("550e8400-e29b-41d4-a716-446655440000")
 ```
 
-### `on_pong(message: HiveMessage) -> bool`
+### `on_ping(message: HiveMessage, received_at: Optional[float] = None) -> bool`
 
-Ingest a received PONG (the inner message of a PROPAGATE wrapper). Extracts the responding node's
-peer, site_id, and pong_timestamp from the payload, then walks the `route` list to upsert directed
-edges into the adjacency graph.
+Ingest a received PING (the inner message of a PROPAGATE wrapper). It reads the sending
+node's peer, site_id, timestamp, public_key, and lang from the payload, then walks the
+`route` list to upsert directed edges into the adjacency graph.
 
-Returns `True` if the PONG was new (not a duplicate), `False` if it was already seen.
+Returns `True` if the PING was new (not a duplicate), `False` if it was already seen.
 
 ```python
 from hivemind_bus_client.message import HiveMessage
 
-handled = mapper.on_pong(pong_msg)
+handled = mapper.on_ping(ping_msg, received_at=time.time())
 ```
 
 **Route extraction logic:**
@@ -75,20 +81,34 @@ handled = mapper.on_pong(pong_msg)
 for hop in message.route:
     source  = hop["source"]       # str peer_id
     targets = hop["targets"]      # List[str] peer_ids
-    # add source → target edges
+    # add source -> target edges
 ```
+
+### `mark_trusted_nodes(trusted_keys: Dict[str, str]) -> None`
+
+Mark each discovered node's `NodeInfo.trusted` flag based on whether its `public_key`
+appears in the given alias-to-public-key mapping (for example, `NodeIdentity.trusted_keys`).
+Call this after PING discovery completes.
+
+### `is_peer_trusted(peer: str) -> bool`
+
+Return `True` if the given peer was discovered by PING and its `trusted` flag is set.
 
 ### `to_dict() -> dict`
 
-Return a JSON-serialisable snapshot of the current topology.
+Return a JSON-serializable snapshot of the current topology.
 
 ```python
 {
     "nodes": [
         {
-            "peer":           "kitchen-node::abc123",
-            "site_id":        "kitchen",
-            "pong_timestamp": 1741478400.456
+            "peer":        "kitchen-node::abc123",
+            "site_id":     "kitchen",
+            "timestamp":   1741478400.456,
+            "latency_ms":  333.0,
+            "public_key":  None,
+            "lang":        "en-us",
+            "trusted":     False
         },
         ...
     ],
@@ -103,34 +123,36 @@ Return a JSON-serialisable snapshot of the current topology.
 
 Return `to_dict()` as a formatted JSON string.
 
-### `to_ascii() -> str`
+### `to_ascii(root_peer: Optional[str] = None) -> str`
 
-Render the topology as a human-readable tree rooted at the local node. Uses the `rich` library when
-available for colour and box-drawing characters; falls back to plain ASCII.
+Render the topology as a human-readable ASCII tree. PING routes flow toward the
+originator, so the mapper stores edges as `relayer -> originator`. Pass `root_peer`
+(the local node) to invert the display so the tree reads top-down from the originator
+to the leaf nodes, labeled `[self]` at the root.
 
-**Example output (plain):**
+**Example output:**
 
 ```
 [self] kitchen-node::abc123
-├── bedroom-node::def456  (site: bedroom)
-│   └── bathroom-node::ghi789  (site: bathroom)
-└── garage-node::jkl012  (site: garage)
+├── bedroom-node::def456  site=bedroom  latency=333ms
+│   └── bathroom-node::ghi789  site=bathroom  latency=511ms
+└── garage-node::jkl012  site=garage  latency=210ms
 ```
 
-**Example output (rich):**
+`latency_ms` on `NodeInfo` is an estimate: receiver clock minus sender clock. It is
+not a true round-trip measurement, and it can read negative or inaccurate on
+unsynchronized clocks.
 
-```
-┌─ [self] kitchen-node::abc123
-├─── bedroom-node::def456        site=bedroom  rtt=333ms
-│    └─── bathroom-node::ghi789  site=bathroom rtt=511ms
-└─── garage-node::jkl012         site=garage   rtt=210ms
-```
+### `check_flood_id(flood_id: str, max_size: int = 1000) -> bool`
 
-RTT (round-trip time) is computed as `pong_timestamp − ping_timestamp` when both are available.
+Check whether `flood_id` was already seen, and register it. The first call for a
+given `flood_id` returns `False` (not seen). Later calls return `True`. When the
+cache passes `max_size`, the oldest entries are evicted first (FIFO).
 
 ### `clear() -> None`
 
-Reset the mapper to an empty state (nodes, edges, seen-pong deduplication).
+Reset the mapper to an empty state (nodes, edges, seen-ping and seen-flood-id
+deduplication).
 
 ---
 
@@ -139,16 +161,19 @@ Reset the mapper to an empty state (nodes, edges, seen-pong deduplication).
 ```python
 @dataclass
 class NodeInfo:
-    peer:           str
-    site_id:        Optional[str]   = None
-    pong_timestamp: Optional[float] = None
-    ping_timestamp: Optional[float] = None
+    peer:        str
+    site_id:     Optional[str]   = None
+    timestamp:   Optional[float] = None    # sender's clock when it created the PING
+    received_at: Optional[float] = None    # local clock when we received it
+    public_key:  Optional[str]   = None    # RSA public key, if provided in the PING
+    lang:        Optional[str]   = None    # locale announced by the node (e.g. "en-us")
+    trusted:     bool            = False   # whether this peer's key is in the trusted list
 
     @property
-    def rtt_ms(self) -> Optional[float]:
-        """Round-trip time in milliseconds, or None if timestamps unavailable."""
-        if self.pong_timestamp is not None and self.ping_timestamp is not None:
-            return (self.pong_timestamp - self.ping_timestamp) * 1000
+    def latency_ms(self) -> Optional[float]:
+        """Estimated one-way latency in milliseconds, or None if timestamps are unavailable."""
+        if self.received_at is not None and self.timestamp is not None:
+            return (self.received_at - self.timestamp) * 1000
         return None
 ```
 
@@ -156,23 +181,23 @@ class NodeInfo:
 
 ## Integration with `HiveMindListenerProtocol`
 
-The server-side protocol creates a `HiveMapper` instance and feeds it PONGs:
+The server-side protocol creates a `HiveMapper` instance and feeds it PINGs:
 
 ```python
-# hivemind_core/protocol.py (planned)
+# hivemind_core/protocol.py
 
-def handle_pong_message(self, message: HiveMessage, client: HiveMindClientConnection) -> None:
+def handle_ping_message(self, message: HiveMessage, client: HiveMindClientConnection) -> None:
     """
-    Relay PONG upstream/downstream via PROPAGATE, then ingest into the local HiveMapper.
-
-    Args:
-        message: The inner PONG HiveMessage (already unwrapped from PROPAGATE).
-        client:  The client connection that delivered this message.
+    Feed the PING into the local HiveMapper, emit hive.ping.received, then,
+    if this flood_id has not been seen before, relay this node's own
+    responsive PING (same flood_id) to all connected peers.
     """
-    self.hive_mapper.on_pong(message)
-    self.agent_bus.emit(Message("hive.pong.received", data=message.payload))
-    # relay onward (PROPAGATE semantics)
-    self._relay_propagate(message, client)
+    self.hive_mapper.on_ping(message, received_at=time.time())
+    self.agent_protocol.bus.emit(Message("hive.ping.received", {...}))
+    if flood_id_already_seen:
+        return
+    for peer_id, conn in self.clients.items():
+        conn.send(own_ping_outer)
 ```
 
 ---
@@ -184,24 +209,25 @@ import time
 import uuid
 from hivemind_bus_client import HiveMessageBusClient
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
-from hivemind_core.hive_map import HiveMapper
+from hivemind_bus_client.hive_map import HiveMapper
 
 client = HiveMessageBusClient()
 client.run_in_thread()
 client.connected_event.wait()
 
-mapper  = HiveMapper()
-ping_id = str(uuid.uuid4())
+mapper    = HiveMapper()
+flood_id  = str(uuid.uuid4())
+mapper.start_ping(flood_id)
 
-def on_pong(message):
-    if message.payload.get("ping_id") == ping_id:
-        mapper.on_pong(message)
+def on_ping(message):
+    if message.payload.get("flood_id") == flood_id:
+        mapper.on_ping(message, received_at=time.time())
 
-client.on(HiveMessageType.PONG, on_pong)
+client.on(HiveMessageType.PING, on_ping)
 
 # Send PING
 ping_payload = {
-    "ping_id":   ping_id,
+    "flood_id":  flood_id,
     "timestamp": time.time(),
     "peer":      client.peer,
     "site_id":   client.site_id,
@@ -213,7 +239,7 @@ client.emit(ping_msg)
 # Collect for 5 seconds
 time.sleep(5)
 
-print(mapper.to_ascii())
+print(mapper.to_ascii(root_peer=client.peer))
 print(mapper.to_json())
 ```
 
@@ -223,13 +249,16 @@ print(mapper.to_json())
 
 | File | Purpose |
 |---|---|
-| `hivemind_core/hive_map.py` | `HiveMapper` and `NodeInfo` implementation |
-| `hivemind_core/protocol.py` | `handle_ping_message()` and `handle_pong_message()` handlers |
+| `hivemind_bus_client/hive_map.py` | `HiveMapper` and `NodeInfo` implementation |
+| `hivemind_core/protocol.py` | `handle_ping_message()` handler that feeds the mapper |
 
 ---
 
 ## Related Documents
 
-- [Protocol Internals](protocol.md) — Handler lifecycle and message routing
-- [`HiveMind-community-docs: 20_network_discovery.md`](../../HiveMind-community-docs/docs/20_network_discovery.md) — Conceptual overview
-- [`hivemind-websocket-client: docs/cli_guide.md`](../../hivemind-websocket-client/docs/cli_guide.md) — `hivemind-client ping` command
+- [Protocol Internals](protocol.md): handler lifecycle and message routing.
+- [`HiveMind-community-docs: 20_network_discovery.md`](../../HiveMind-community-docs/docs/20_network_discovery.md): conceptual overview.
+- [`hivemind-websocket-client: docs/cli_guide.md`](../../hivemind-websocket-client/docs/cli_guide.md): the `hivemind-client ping` command.
+
+---
+[← Plugin Development](plugin_development.md) · [Home](index.md) · [Ecosystem →](ecosystem.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # HiveMind Core
 
-HiveMind Core is the central hub (master node) of the HiveMind network. It accepts connections from satellites and other nodes, authenticates them, enforces per-client permissions, and routes messages to the configured AI agent backend.
+HiveMind Core is the central server of the HiveMind network. It accepts connections from satellites and other nodes, authenticates them, enforces per-client permissions, and routes messages to the configured AI agent backend.
 
 ## Overview
 
@@ -29,18 +29,16 @@ HiveMind Core is fully **plugin-driven**:
 
 ## Documentation
 
-- [Architecture Guide](architecture.md) - Deep dive into Mind, Satellite, and Bridge components.
-- [Security and Encryption](security.md) - Handshakes, AES-256-GCM, and session keys.
-- [Authentication and Client Management](auth.md) - Adding clients and managing permissions.
-- [Installation](installation.md) - Getting started with HiveMind Core.
-- [Configuration](configuration.md) - Configuring protocols and databases.
-- [CLI Reference](cli.md) - Complete command-line reference.
-- [Protocol Internals](protocol.md) - Deep dive into the HiveMind message format.
-- [Plugin System](plugins.md) - Overview of the modular plugin architecture.
-- [Plugin Development](plugin_development.md) - Guide for creating custom plugins.
+- [Architecture Guide](architecture.md): explains the Mind, Satellite, and Bridge components.
+- [Security and Encryption](security.md): covers handshakes, AES-256-GCM, and session keys.
+- [Authentication and Client Management](auth.md): covers adding clients and managing permissions.
+- [Installation](installation.md): gets you started with HiveMind Core.
+- [Configuration](configuration.md): covers configuring protocols and databases.
+- [CLI Reference](cli.md): a complete command-line reference.
+- [Protocol Internals](protocol.md): explains the HiveMind message format.
+- [Plugin System](plugins.md): an overview of the modular plugin architecture.
+- [Plugin Development](plugin_development.md): a guide for creating custom plugins.
 
 ## License
 
-HiveMind Core v4.0+ is licensed under **AGPL-3.0**. Commercial deployments that cannot comply with AGPL disclosure obligations require a separate commercial license. Contact [jarbasai@mailfence.com](mailto:jarbasai@mailfence.com).
-
-The last Apache-2.0 release was `hivemind-core` **3.4.0**.
+HiveMind-core is licensed under **Apache-2.0**. Releases up to `hivemind-core` **3.4.0** were Apache-2.0. The **4.x** series shipped under AGPL-3.0 as a short-lived experiment. From this release forward, HiveMind-core returns to Apache-2.0. Previously published 3.x and 4.x releases on PyPI stay under the license they were published with. Contact [jarbasai@mailfence.com](mailto:jarbasai@mailfence.com) for support or sponsorship.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,14 +15,11 @@ pip install hivemind-core
 ## Install with optional database backends
 
 ```bash
-# SQLite backend
-pip install hivemind-core hivemind-sqlite-database
-
 # Redis backend
 pip install hivemind-core hivemind-redis-database
 ```
 
-The default database backend is JSON (`hivemind-json-db-plugin`), which is installed automatically as a dependency.
+Fresh installs use the SQLite backend (`hivemind-sqlite-database`) by default. It installs automatically as a dependency, along with the JSON backend (`hivemind-json-db-plugin`) for existing JSON deployments.
 
 ## Install network protocol plugins
 
@@ -53,3 +50,6 @@ hivemind-core --help
 ## Next step
 
 After installing, [configure the server](configuration.md) and [add your first client](cli.md#add-client).
+
+---
+[← Authentication](auth.md) · [Home](index.md) · [Security →](security.md)

--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -1,43 +1,53 @@
 # Plugin Development Guide
 
-HiveMind is highly extensible via Python entry points, managed by the `hivemind-plugin-manager`.
+Python entry points make HiveMind highly extensible, managed by `hivemind-plugin-manager`.
 
 ## Plugin Types
 
 ### 1. Network Protocol Plugins
-Define how the Mind listens for connections.
-- **Base Class**: `hivemind_plugin_manager.protocols.NetworkProtocol`
-- **Entry Point**: `hivemind.network.protocol`
-- **Example Implementation**: `hivemind_websocket_protocol.HiveMindWebsocketProtocol`
+
+Define how the server listens for connections.
+
+- **Base class**: `hivemind_plugin_manager.protocols.NetworkProtocol`
+- **Entry point**: `hivemind.network.protocol`
+- **Example implementation**: `hivemind_websocket_protocol.HiveMindWebsocketProtocol`
 
 ### 2. Agent Plugins
+
 Define the AI backend that processes intents.
-- **Base Class**: `hivemind_plugin_manager.protocols.AgentProtocol`
-- **Entry Point**: `hivemind.agent.protocol`
-- **Example Implementation**: `ovos_bus_client.hpm.OVOSProtocol`
+
+- **Base class**: `hivemind_plugin_manager.protocols.AgentProtocol`
+- **Entry point**: `hivemind.agent.protocol`
+- **Example implementation**: `ovos_bus_client.hpm.OVOSProtocol`
 
 ### 3. Binary Plugins
-Define how raw binary data (e.g., audio) is handled.
-- **Base Class**: `hivemind_plugin_manager.protocols.BinaryDataHandlerProtocol`
-- **Entry Point**: `hivemind.binary.protocol`
-- **Example Implementation**: `hivemind_audio_binary_protocol.protocol.AudioBinaryProtocol`
+
+Define how the server handles raw binary data (for example, audio).
+
+- **Base class**: `hivemind_plugin_manager.protocols.BinaryDataHandlerProtocol`
+- **Entry point**: `hivemind.binary.protocol`
+- **Example implementation**: `hivemind_audio_binary_protocol.protocol.AudioBinaryProtocol`
 
 ### 4. Database Plugins
-Define where client credentials and permissions are stored.
-- **Base Class**: `hivemind_plugin_manager.database.AbstractDB`
-- **Entry Point**: `hivemind.database`
-- **Example Implementation**: `hivemind_sqlite_database.SQLiteDB`
+
+Define where the server stores client credentials and permissions.
+
+- **Base class**: `hivemind_plugin_manager.database.AbstractDB`
+- **Entry point**: `hivemind.database`
+- **Example implementation**: `hivemind_sqlite_database.SQLiteDB`
 
 ## Example: Creating a Database Plugin
 
 1. Inherit from `hivemind_plugin_manager.database.AbstractDB`.
-2. Implement methods like `add_client`, `get_client`, and `list_clients`.
-3. Register the entry point in `setup.py`:
-```python
-entry_points={
-    'hivemind.database': [
-        'my-db = my_package.db:MyDatabasePlugin'
-    ]
-}
+2. Implement `add_item`, `get_client_by_id`, `get_client_by_api_key`, `search_by_value`, `__iter__`, and `__len__`.
+3. Register the entry point in `pyproject.toml`:
+
+```toml
+[project.entry-points."hivemind.database"]
+my-db = "my_package.db:MyDatabasePlugin"
 ```
-Once installed, the Mind can use it by setting `"module": "my-db"` in its `server.json` configuration.
+
+Once installed, the server can use it by setting `"module": "my-db"` in its `server.json` configuration.
+
+---
+[← CLI Reference](cli.md) · [Home](index.md) · [Network Map →](hive_map.md)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -11,7 +11,7 @@ Responsible for accepting connections and delivering raw payloads to `HiveMindLi
 | `hivemind-websocket-protocol` | WebSocket-based real-time connections | `pip install hivemind-websocket-protocol` |
 | `hivemind-http-protocol` | HTTP request/response, for clients without persistent connections | `pip install hivemind-http-protocol` |
 
-Multiple network protocols can run simultaneously — each is started in its own daemon thread.
+Multiple network protocols can run at the same time. Each starts in its own daemon thread.
 
 Configuration example (in `server.json`):
 
@@ -73,8 +73,8 @@ Binary payload types dispatched to the plugin:
 
 | Plugin | Description | Install |
 |---|---|---|
-| `hivemind-json-db-plugin` | JSON flat-file storage (default) | bundled |
-| `hivemind-sqlite-database` | SQLite storage for production deployments | `pip install hivemind-sqlite-database` |
+| `hivemind-sqlite-database` | SQLite storage (default for fresh installs) | bundled |
+| `hivemind-json-db-plugin` | JSON flat-file storage (kept for existing JSON deployments) | bundled |
 | `hivemind-redis-database` | Redis storage for distributed deployments | `pip install hivemind-redis-database` |
 
 Configuration example:
@@ -104,3 +104,6 @@ The four base classes are:
 | `AgentProtocol` | `hivemind_plugin_manager.protocols` |
 | `BinaryDataHandlerProtocol` | `hivemind_plugin_manager.protocols` |
 | `AbstractDB` | `hivemind_plugin_manager.database` |
+
+---
+[← Policy Chain](policy.md) · [Home](README.md) · [Extending →](extending.md)

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -10,7 +10,7 @@ before reaching the agent bus.
   `PolicyPlugin` instances and exposes three hooks: `review`,
   `review_binary`, and `observe`.
 - For each `review`, the chain calls every policy in order. A policy
-  returns a `Verdict` — either an allow (optionally carrying typed
+  returns a `Verdict`: either an allow (optionally carrying typed
   `Mutation` objects) or a deny (with a stable `code`, human-readable
   `reason`, and structured `data`).
 - The first deny short-circuits the chain. Mutations from earlier allow
@@ -18,10 +18,10 @@ before reaching the agent bus.
 - **Always fail-closed.** Any exception from a policy or from
   `Mutation.apply` is converted to `Verdict.deny("policy_error", ...)`
   with the offending policy/mutation name in `data`. There is no
-  operator knob to flip this — the bus is unauthenticated and lenient-
-  on-error would be a security footgun.
+  operator knob to flip this. The bus is unauthenticated, so lenient-
+  on-error handling would be a security risk.
 - `is_admin` on a client is **informational only**. The chain runner
-  gives it no special treatment; policies that want admin-exemption
+  gives it no special treatment. Policies that want admin-exemption
   branch on `client.is_admin` themselves.
 - After a successful emit, the chain calls `observe()` on every policy
   for counters / audit logs. `observe` exceptions are swallowed.
@@ -50,7 +50,7 @@ class QuotaPolicy(PolicyPlugin):
 ```
 
 Use stable, machine-readable `code` strings. Common codes are exposed
-as `DenyCodes` members; pick your own for plugin-specific reasons.
+as `DenyCodes` members. Pick your own for plugin-specific reasons.
 
 A policy can return one or more `Mutation` objects on an allow verdict
 to change the message before downstream policies and the bus see it.
@@ -60,17 +60,17 @@ Mutation classes are agent-specific and live with the agent plugin
 
 ## Built-in Policies
 
-- **`MessageTypeACLPolicy`** — always present, non-removable, runs
-  first. Enforces the per-client `allowed_types` whitelist; an empty
+- **`MessageTypeACLPolicy`**: always present, non-removable, runs
+  first. It enforces the per-client `allowed_types` whitelist. An empty
   whitelist denies everything (deny-by-default). Refreshes the
   whitelist from the database on every admission so
   `hivemind-core allow-msg` takes effect without a reconnect. Caches
   the resolved client row on the connection (`client.resolve_user`) so
   downstream policies skip a second DB hit.
-- **`DenyAllPolicy`** — fail-closed fallback installed when
+- **`DenyAllPolicy`**: fail-closed fallback installed when
   `PolicyChain.from_config` raises. Denies every message and binary
   payload with `code="policy_chain_unavailable"`.
-- **`OVOSAgentPolicy`** (in `hivemind-ovos-agent-plugin`) — optional,
+- **`OVOSAgentPolicy`** (in `hivemind-ovos-agent-plugin`): optional,
   OVOS-specific. Enforces skill/intent blacklists, session-id rules,
   and ships agent-specific `Mutation` classes.
 
@@ -87,19 +87,19 @@ policy:
       optional: true
 ```
 
-`MessageTypeACLPolicy` is implicit and always first — do not list it.
+`MessageTypeACLPolicy` is implicit and always first. Do not list it.
 
 ### `optional` flag
 
 Per-chain-entry `optional: true` marks the policy as non-load-bearing:
 if its `review` / `review_binary` raises, the chain logs a warning and
-treats the verdict as allow (no mutations, chain continues). Default
-is `false` — exceptions fail closed with `policy_error`. The implicit
+treats the verdict as allow (no mutations, chain continues). The default
+is `false`, so exceptions fail closed with `policy_error`. The implicit
 `MessageTypeACLPolicy` is always mandatory and ignores this flag.
 
 `allowed_types` is the canonical admission whitelist for a client.
-Grant message types with `hivemind-core allow-msg <msg_type> <node_id>`;
-revoke with `blacklist-msg`. Empty whitelist ⇒ deny everything.
+Grant message types with `hivemind-core allow-msg <msg_type> <node_id>`.
+Revoke with `blacklist-msg`. Empty whitelist ⇒ deny everything.
 
 There is no `policy.fail_open` knob. The chain is fail-closed by
 design: a misbehaving policy denies rather than admits.
@@ -111,18 +111,18 @@ Codes returned by built-in policies and the chain runner:
 | Code | Source | Meaning |
 | --- | --- | --- |
 | `acl_disallowed_type` | `MessageTypeACLPolicy` | `msg_type` not in `allowed_types` |
-| `policy_error` | `PolicyChain` | A policy or mutation raised; data carries `policy`, `error`, and optionally `mutation` |
+| `policy_error` | `PolicyChain` | A policy or mutation raised. Data carries `policy`, `error`, and optionally `mutation` |
 | `policy_chain_unavailable` | `DenyAllPolicy` | Chain construction failed at startup |
 | `session_id_default_forbidden` | `OVOSAgentPolicy` | Client tried to use the reserved `default` session id |
 
-Plugin authors are free to mint their own `code` values; reuse a
+Plugin authors are free to mint their own `code` values. Reuse a
 built-in code only when the semantics match.
 
 ## CLI
 
-- `hivemind-core policy list` — print the loaded chain (built-in first,
+- `hivemind-core policy list`: print the loaded chain (built-in first,
   then configured plugins).
-- `hivemind-core policy test <api_key> <msg_type>` — dry-run a fake
+- `hivemind-core policy test <api_key> <msg_type>`: dry-run a fake
   message through the chain and print the verdict as JSON.
 
 ## Wire Format: `hive.policy.denied`
@@ -140,11 +140,14 @@ payload:
 }
 ```
 
-- `denied_type` — the `msg_type` of the message that was rejected.
-- `code` — stable machine-readable identifier; see the Deny-Code
+- `denied_type`: the `msg_type` of the message that was rejected.
+- `code`: a stable, machine-readable identifier. See the Deny-Code
   Reference above.
-- `reason` — human-readable explanation for logs / UIs.
-- `data` — free-form structured payload set by the policy
-  (`msg_type`, `allowed`, `policy`, `error`, etc. depending on code).
+- `reason`: a human-readable explanation for logs and UIs.
+- `data`: a free-form structured payload set by the policy
+  (`msg_type`, `allowed`, `policy`, `error`, and so on, depending on the code).
 
-Clients SHOULD branch on `code`; `reason` is informational only.
+Clients SHOULD branch on `code`. `reason` is informational only.
+
+---
+[← CLI Reference](cli-reference.md) · [Home](README.md) · [Plugins →](plugins.md)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -91,13 +91,13 @@ from hivemind_core.protocol import HiveMindListenerProtocol
 Called when a PROPAGATE message's inner payload is a PING.
 
 All nodes SHOULD relay the PING to all connected peers (except the sender) and MAY respond with a
-PONG. Whether to respond is a node-level policy decision — for example, a master may be configured
-to act as a discovery boundary and silently drop the PING rather than relaying it further upstream.
+PONG. Whether to respond is a node-level policy decision. For example, a top-level node may be configured
+to act as a discovery boundary and silently drop the PING instead of relaying it further upstream.
 
 ```
 Receive PROPAGATE(PING)
   ├─ relay PROPAGATE(PING) to all connected peers except sender   [SHOULD]
-  └─ build PROPAGATE(PONG) and send back toward originator        [MAY — node policy]
+  └─ build PROPAGATE(PONG) and send back toward originator        [MAY, node policy]
 ```
 
 See [network discovery docs](../../HiveMind-community-docs/docs/20_network_discovery.md) for the
@@ -219,8 +219,11 @@ The context manager (`with ClientDatabase() as db`) commits changes on exit.
 |---|---|
 | `CANDIDATE_NODE` | Connecting but not yet authenticated |
 | `NODE` | Any authenticated connection |
-| `MIND` | A hub listening for connections |
-| `SLAVE` | A node that can be partially controlled by a mind |
+| `MIND` | A server node listening for connections |
+| `SLAVE` | A node that another node can partially control |
 | `TERMINAL` | User-facing endpoint that does not accept connections |
-| `BRIDGE` | Connects an external service to the hive |
-| `FAKECROFT` | A mind using a non-Mycroft AI backend |
+| `BRIDGE` | Connects an external service to the network |
+| `FAKECROFT` | A `MIND` node using a non-Mycroft AI backend |
+
+---
+[← Security](security.md) · [Home](index.md) · [CLI Reference →](cli.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,24 +1,28 @@
 # Security and Encryption
 
-HiveMind prioritizes secure communication between the Mind and its satellites, using the `poorman_handshake` library as its cryptographic foundation.
+HiveMind Core secures communication between the server and its satellites with the `poorman_handshake` library as its cryptographic foundation.
 
 ## Handshake and Key Exchange
 
-HiveMind uses the `poorman_handshake` protocol for initial authentication and session key establishment, managed by the `HiveMindClientConnection` in `hivemind_core.protocol`.
+HiveMind Core uses the `poorman_handshake` protocol for initial authentication and session key setup, managed by `HiveMindClientConnection` in `hivemind_core.protocol`.
 
-1. **Identity**: Every client has an `Access Key` and a `Password` stored in `hivemind_core.database.HiveMindDatabase`.
-2. **Session Key**: During connection, a temporary AES-256-GCM session key is derived using PBKDF2 via `poorman_handshake.PasswordHandShake` or `poorman_handshake.HandShake`.
-3. **Encryption**: All subsequent traffic is encrypted using this session key.
+1. **Identity**: every client has an `Access Key` and a `Password` stored through `hivemind_core.database.ClientDatabase`.
+2. **Session Key**: during connection, the server derives a temporary AES-256-GCM session key with PBKDF2, using `poorman_handshake.PasswordHandShake` or `poorman_handshake.HandShake`.
+3. **Encryption**: this session key encrypts all later traffic.
 
 ## Encryption Standards
 
-- **AES-256-GCM**: Used for transport layer encryption. GCM (Galois/Counter Mode) provides both confidentiality and data integrity (AEAD).
-- **PBKDF2**: Used for deriving keys from passwords, ensuring resistance to brute-force attacks.
-- **PGP (Optional)**: Used for `INTERCOM` messages, allowing end-to-end encrypted secret messages between nodes that the Mind itself cannot decrypt.
+- **AES-256-GCM**: used for transport layer encryption. GCM (Galois/Counter Mode) provides both confidentiality and data integrity (AEAD).
+- **PBKDF2**: used for deriving keys from passwords, resisting brute-force attacks.
+- **PGP (optional)**: used for `INTERCOM` messages, so nodes can exchange end-to-end encrypted secret messages that the server itself cannot decrypt.
 
 ## Permissions and Access Control
 
-The Mind enforces strict access control through the `HiveMindDatabase` and `HiveMindClientConnection`:
-- **Message Blacklisting**: Managed by `HiveMindDatabase.blacklist_msg` and checked during routing in `HiveMindClientConnection.send`.
-- **Skill/Intent Blacklisting**: Restrict which AI skills a specific satellite can trigger via `HiveMindDatabase.blacklist_skill` and `blacklist_intent`.
-- **Node-Level Isolation**: Clients only receive messages intended for them or broadcasted to their permission level, as defined by `HiveMindNodeType` in `hivemind_core.protocol`.
+The server enforces access control through `ClientDatabase` and `HiveMindClientConnection`:
+
+- **Message whitelist**: `MessageTypeACLPolicy` checks each client's `allowed_types` whitelist during routing. See [Policy Admission Chain](policy.md).
+- **Skill/intent blacklisting**: restrict which AI skills a specific satellite can trigger with `hivemind-core blacklist-skill` and `blacklist-intent` (`hivemind_core.scripts`).
+- **Node-level isolation**: clients only receive messages meant for them, or broadcast to their permission level, as defined by `HiveMindNodeType` in `hivemind_core.protocol`.
+
+---
+[← Installation](installation.md) · [Home](index.md) · [Protocol →](protocol.md)


### PR DESCRIPTION
Rewrites README.md and all docs/*.md pages in Simplified Technical English (STE-flavored): shorter sentences, active voice, no marketing language, no emoji, and no em dashes/semicolons where a plain period works. Adds the standard navigation footer (relative links, prev/Home/next) to every non-index docs page, and fixes a few stale/incorrect facts found while cross-checking claims against the current source (default database backend, license history, and the `HiveMapper` PING-flood API which had drifted from an older PONG-based design in `docs/hive_map.md`). No features, benchmarks, or claims were added; every fact was verified against `hivemind_core/` and `hivemind_plugin_manager` source before being kept.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified HiveMind Core architecture, protocol behavior, server and satellite roles, routing, discovery, and scaling.
  * Updated authentication, security, policy, permissions, whitelisting, and metadata filtering guidance.
  * Documented SQLite as the default backend, JSON compatibility, and migration support.
  * Refreshed installation, CLI, configuration, plugin development, and ecosystem instructions with updated examples.
  * Revised topology discovery documentation to describe PING-based mapping, latency estimates, trusted nodes, and optional ASCII rendering.
  * Added navigation links, corrected terminology, and updated licensing and contribution information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->