### PR TITLE
fix: enforce min_protocol_version at handshake time

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -108,6 +108,16 @@ def _non_negative_float(value, default: float) -> float:
     return parsed if parsed >= 0 else default
 
 
+def _configured_min_protocol_version() -> ProtocolVersion:
+    """The operator-configured protocol floor (HIVEMIND-WIRE-1 §2); default 2
+    refuses the oldest json-only / no-binary clients. An unparseable config
+    value falls back to that same default."""
+    try:
+        return ProtocolVersion(int(get_server_config().get("min_protocol_version", 2)))
+    except (TypeError, ValueError, KeyError):
+        return ProtocolVersion.TWO
+
+
 class UnencryptedMessageError(ValueError):
     """Raised when a cleartext frame arrives on a connection that requires crypto.
 
@@ -492,14 +502,9 @@ class HiveMindListenerProtocol:
             if client.crypto_key is None and self.require_crypto
             else ProtocolVersion.ZERO
         )
-        # deployment-configured protocol floor (HIVEMIND-WIRE-1 §2); default 2
-        # refuses the oldest json-only / no-binary clients. The advertised
-        # minimum is the stricter of the configured floor and the crypto-derived
-        # minimum.
-        try:
-            cfg_min = ProtocolVersion(int(get_server_config().get("min_protocol_version", 2)))
-        except (ValueError, KeyError):
-            cfg_min = ProtocolVersion.TWO
+        # The advertised minimum is the stricter of the configured floor and
+        # the crypto-derived minimum.
+        cfg_min = _configured_min_protocol_version()
         min_version = ProtocolVersion(max(int(cfg_min), int(crypto_min)))
 
         # protocol v3 (Noise handshake) needs the noise primitive and a shared
@@ -932,10 +937,7 @@ class HiveMindListenerProtocol:
         # handshake instead of Noise, silently ignoring a raised floor. Noise
         # ("noise" in payload) is handled above and always satisfies any
         # floor, so only the legacy branches below need the check.
-        try:
-            cfg_min = ProtocolVersion(int(get_server_config().get("min_protocol_version", 2)))
-        except (ValueError, KeyError):
-            cfg_min = ProtocolVersion.TWO
+        cfg_min = _configured_min_protocol_version()
         if "pubkey" in message.payload and client.handshake is not None:
             attempted_version = ProtocolVersion.ONE
         elif client.pswd_handshake is not None and "envelope" in message.payload:

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -924,6 +924,33 @@ class HiveMindListenerProtocol:
             self.handle_noise_handshake_message(message, client)
             return
 
+        # enforce the operator-configured protocol floor (HIVEMIND-CRYPTO-1
+        # §3.4 fail-closed floor semantics). The v3-capability check at HELLO
+        # time (min_version > max_version) only rejects clients that *cannot*
+        # reach the floor at all; it does not stop a v3-capable client
+        # (password handshake present) from completing a legacy v1/v2
+        # handshake instead of Noise, silently ignoring a raised floor. Noise
+        # ("noise" in payload) is handled above and always satisfies any
+        # floor, so only the legacy branches below need the check.
+        try:
+            cfg_min = ProtocolVersion(int(get_server_config().get("min_protocol_version", 2)))
+        except (ValueError, KeyError):
+            cfg_min = ProtocolVersion.TWO
+        if "pubkey" in message.payload and client.handshake is not None:
+            attempted_version = ProtocolVersion.ONE
+        elif client.pswd_handshake is not None and "envelope" in message.payload:
+            attempted_version = ProtocolVersion.TWO
+        else:
+            attempted_version = None
+        if attempted_version is not None and attempted_version < cfg_min:
+            LOG.warning(
+                f"rejecting {client.peer}: legacy handshake at protocol "
+                f"v{int(attempted_version)} is below the configured minimum "
+                f"v{int(cfg_min)}"
+            )
+            client.disconnect()
+            return
+
         LOG.debug("handshake received, generating session key")
         if "pubkey" in message.payload and client.handshake is not None:
             pub = message.payload.pop("pubkey")

--- a/tests/test_crypto_enforcement.py
+++ b/tests/test_crypto_enforcement.py
@@ -20,7 +20,7 @@ Covers the additive, wire-compatible enforcement paths:
 import json
 import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pybase64
 import pytest
@@ -249,6 +249,47 @@ class TestPasswordHandshakeFailFast(unittest.TestCase):
         proto.handle_handshake_message(msg, client)
         assert client.crypto_key is None
         client.disconnect.assert_called_once()
+
+
+class TestMinProtocolVersionFloor(unittest.TestCase):
+    """Fix for: min_protocol_version was advisory only.
+
+    A hub configured with a raised floor (e.g. 3, Noise-required) must
+    reject a client that completes a legacy v2 password handshake instead
+    of Noise, even though that same client is v3-*capable* (has a
+    pswd_handshake) and so was never caught by the min>max check done at
+    HELLO time. HIVEMIND-CRYPTO-1's floor is fail-closed: the hub MUST NOT
+    let a connection settle below the configured minimum.
+    """
+
+    _PASSWORD = "correct-horse-battery-staple-92"
+
+    def _handshake_msg(self):
+        peer_side = PasswordHandShake(self._PASSWORD)
+        return HiveMessage(HiveMessageType.HANDSHAKE,
+                           payload={"envelope": peer_side.generate_handshake()})
+
+    def test_v2_password_handshake_rejected_when_floor_is_3(self):
+        proto = _make_protocol()
+        client = _make_client(proto)
+        client.pswd_handshake = PasswordHandShake(self._PASSWORD)
+        with patch("hivemind_core.protocol.get_server_config",
+                  return_value={"min_protocol_version": 3}):
+            proto.handle_handshake_message(self._handshake_msg(), client)
+        assert client.crypto_key is None
+        client.disconnect.assert_called_once()
+        client.send_msg.assert_not_called()
+
+    def test_v2_password_handshake_accepted_when_floor_is_2(self):
+        proto = _make_protocol()
+        client = _make_client(proto)
+        client.pswd_handshake = PasswordHandShake(self._PASSWORD)
+        with patch("hivemind_core.protocol.get_server_config",
+                  return_value={"min_protocol_version": 2}):
+            proto.handle_handshake_message(self._handshake_msg(), client)
+        assert client.crypto_key is not None
+        client.disconnect.assert_not_called()
+        client.send_msg.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

---

**Back-compat correction (orchestrator review):** the earlier statement "behavior only changes for hubs explicitly raised to floor 3" undersells one case. The **default** floor is `2`, and this gate also classifies a legacy **v1 pubkey handshake** as below that floor — so a v1 client that previously slipped through (despite the advertised minimum) is now refused at the default configuration. This matches the documented intent of the default (`config` comment: floor 2 "refuses the oldest json-only / no-binary clients") and the HELLO-time capability check already refuses clients that *declare* max < 2; the runtime gate closes the same hole for clients that declare capability but complete a lower handshake anyway. Operators who genuinely need v1 clients can set `min_protocol_version: 1`.
