### PR TITLE
fix: require a verifiable origin on signed INTERCOM, and drop rejected frames

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1652,11 +1652,20 @@ class HiveMindListenerProtocol:
     def handle_intercom_message(
             self, message: HiveMessage, client: HiveMindClientConnection
     ) -> bool:
+        """Handle an INTERCOM frame.
 
+        Returns True when the frame is consumed by this node and MUST NOT be
+        relayed any further - either because the inner message was dispatched
+        locally, or because the frame was rejected (a refused message is
+        dropped, never forwarded to peers or escalated upstream).
+
+        Returns False only when the frame is not ours to consume and the
+        caller should keep relaying it.
+        """
         # if the message targets us, send it to internal bus
         k = message.target_public_key
         if k and k != self.identity.public_key:
-            # not for us
+            # not for us, keep relaying
             return False
 
         pload = message.payload
@@ -1669,26 +1678,27 @@ class HiveMindListenerProtocol:
                 # against the TOFU-pinned public key (pinned from the
                 # client's HELLO). Without a pinned/known pubkey, or without
                 # a signature, the origin cannot be authenticated at all -
-                # fail closed and reject rather than dispatch unverified.
+                # fail closed and drop rather than dispatch unverified.
+                # A rejection returns True: the frame is consumed here, it is
+                # not relayed to peers nor escalated upstream.
                 pub = self.trusted_pubkeys.get(client.key) or client.pub_key
                 if not pub:
                     LOG.warning(f"INTERCOM from {client.peer} has no pinned/known "
-                                f"public key: rejecting unverifiable origin")
-                    return False
+                                f"public key: dropping unverifiable origin")
+                    return True
                 if not signature:
                     LOG.warning(f"INTERCOM from {client.peer} has no signature: "
-                                f"rejecting unverifiable origin")
-                    return False
+                                f"dropping unverifiable origin")
+                    return True
 
-                signature = pybase64.b64decode(signature)
                 try:
-                    verified = verify_RSA(pub, ciphertext, signature)
+                    verified = verify_RSA(pub, ciphertext, pybase64.b64decode(signature))
                 except Exception:
                     verified = False
                 if not verified:
                     LOG.error(f"INTERCOM signature verification failed for "
-                              f"{client.peer}: rejecting forged/mismatched message")
-                    return False
+                              f"{client.peer}: dropping forged/mismatched message")
+                    return True
                 # first verified sighting pins the key for this listener's lifetime
                 self.trusted_pubkeys.setdefault(client.key, pub)
 
@@ -1698,9 +1708,10 @@ class HiveMindListenerProtocol:
                 inner = HiveMessage.deserialize(decrypted)
             except:
                 if k:
+                    # explicitly addressed to us and undecryptable: drop it
                     LOG.error("failed to decrypt message!")
-                else:
-                    LOG.debug("failed to decrypt message, not for us")
+                    return True
+                LOG.debug("failed to decrypt message, not for us")
                 return False
         elif isinstance(pload, HiveMessage):
             inner = pload

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1663,28 +1663,34 @@ class HiveMindListenerProtocol:
         if isinstance(pload, dict) and "ciphertext" in pload:
             try:
                 ciphertext = pybase64.b64decode(pload["ciphertext"])
-                signature = pybase64.b64decode(pload["signature"])
+                signature = pload.get("signature")
 
-                # HIVEMIND-CRYPTO-1 §5 - verify the origin signature against
-                # the TOFU-pinned public key (pinned from the client's HELLO).
-                # A signature that fails against a known key means a forged
-                # origin — reject. If no pubkey was ever presented we cannot
-                # authenticate the origin; keep permissive behavior but say so.
+                # HIVEMIND-CRYPTO-1 §5 - the origin signature MUST verify
+                # against the TOFU-pinned public key (pinned from the
+                # client's HELLO). Without a pinned/known pubkey, or without
+                # a signature, the origin cannot be authenticated at all -
+                # fail closed and reject rather than dispatch unverified.
                 pub = self.trusted_pubkeys.get(client.key) or client.pub_key
-                if pub:
-                    try:
-                        verified = verify_RSA(pub, ciphertext, signature)
-                    except Exception:
-                        verified = False
-                    if not verified:
-                        LOG.error(f"INTERCOM signature verification failed for "
-                                  f"{client.peer}: rejecting forged/mismatched message")
-                        return False
-                    # first verified sighting pins the key for this listener's lifetime
-                    self.trusted_pubkeys.setdefault(client.key, pub)
-                else:
+                if not pub:
                     LOG.warning(f"INTERCOM from {client.peer} has no pinned/known "
-                                f"public key: origin authenticity is unverified")
+                                f"public key: rejecting unverifiable origin")
+                    return False
+                if not signature:
+                    LOG.warning(f"INTERCOM from {client.peer} has no signature: "
+                                f"rejecting unverifiable origin")
+                    return False
+
+                signature = pybase64.b64decode(signature)
+                try:
+                    verified = verify_RSA(pub, ciphertext, signature)
+                except Exception:
+                    verified = False
+                if not verified:
+                    LOG.error(f"INTERCOM signature verification failed for "
+                              f"{client.peer}: rejecting forged/mismatched message")
+                    return False
+                # first verified sighting pins the key for this listener's lifetime
+                self.trusted_pubkeys.setdefault(client.key, pub)
 
                 private_key = load_RSA_key(self.identity.private_key)
 

--- a/tests/test_crypto_enforcement.py
+++ b/tests/test_crypto_enforcement.py
@@ -10,8 +10,8 @@ Covers the additive, wire-compatible enforcement paths:
 - INTERCOM origin authentication (§5): signatures are verified against a
   TOFU-pinned public key (pin source = the pubkey presented in HELLO); a
   forged/mismatched signature after pinning is rejected; when no pubkey was
-  ever presented the message is still processed (permissive fallback) but
-  origin authenticity is unverified.
+  ever presented, or no signature is carried, the origin cannot be
+  authenticated and the message is rejected (fail closed).
 - Password handshake fail-fast (§3.2): a client envelope built with the
   wrong password is rejected at handshake time instead of only failing to
   decrypt the first encrypted frame.
@@ -20,7 +20,7 @@ Covers the additive, wire-compatible enforcement paths:
 import json
 import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pybase64
 import pytest
@@ -185,11 +185,26 @@ class TestIntercomSignatureVerification(unittest.TestCase):
         assert self.proto.handle_intercom_message(
             self._intercom(self.forger_priv), self.client) is False
 
-    def test_no_pubkey_falls_back_to_unverified_processing(self):
-        # peer never presented a pubkey: keep permissive (additive) behavior
+    def test_no_pubkey_rejects_unverifiable_origin(self):
+        # peer never presented a pubkey: origin cannot be authenticated,
+        # fail closed rather than dispatch unverified (CRYPTO-1 §5 MUST)
         self.client.pub_key = None
-        assert self.proto.handle_intercom_message(
-            self._intercom(self.forger_priv), self.client) is True
+        with patch("hivemind_core.protocol.LOG") as mock_log:
+            assert self.proto.handle_intercom_message(
+                self._intercom(self.forger_priv), self.client) is False
+        assert mock_log.warning.called
+        assert self.client.peer in mock_log.warning.call_args[0][0]
+
+    def test_missing_signature_rejected_even_with_pinned_key(self):
+        # pubkey is pinned, but the frame carries no signature at all:
+        # nothing to verify against, reject rather than trust blindly
+        self.proto.trusted_pubkeys["test-key"] = self.client_pub
+        frame = self._intercom(self.client_priv)
+        frame.payload.pop("signature")
+        with patch("hivemind_core.protocol.LOG") as mock_log:
+            assert self.proto.handle_intercom_message(frame, self.client) is False
+        assert mock_log.warning.called
+        assert "no signature" in mock_log.warning.call_args[0][0]
 
     def test_hello_pins_pubkey_and_keeps_first_pin(self):
         hello = HiveMessage(HiveMessageType.HELLO,

--- a/tests/test_crypto_enforcement.py
+++ b/tests/test_crypto_enforcement.py
@@ -11,7 +11,9 @@ Covers the additive, wire-compatible enforcement paths:
   TOFU-pinned public key (pin source = the pubkey presented in HELLO); a
   forged/mismatched signature after pinning is rejected; when no pubkey was
   ever presented, or no signature is carried, the origin cannot be
-  authenticated and the message is rejected (fail closed).
+  authenticated and the message is rejected (fail closed). A rejected
+  INTERCOM is dropped at this node: it is not relayed to peers and not
+  escalated to the upstream master.
 - Password handshake fail-fast (§3.2): a client envelope built with the
   wrong password is rejected at handshake time instead of only failing to
   decrypt the first encrypted frame.
@@ -175,34 +177,37 @@ class TestIntercomSignatureVerification(unittest.TestCase):
 
     def test_forged_signature_rejected_after_pinning(self):
         self.proto.trusted_pubkeys["test-key"] = self.client_pub
+        self.proto.handle_client_shared_bus = MagicMock()
+        # True == "consumed: dropped here", so callers stop relaying it
         assert self.proto.handle_intercom_message(
-            self._intercom(self.forger_priv), self.client) is False
+            self._intercom(self.forger_priv), self.client) is True
+        self.proto.handle_client_shared_bus.assert_not_called()
 
     def test_pinned_key_wins_over_hello_key(self):
         # attacker re-HELLOs with its own pubkey but the pin is authoritative
         self.proto.trusted_pubkeys["test-key"] = self.client_pub
         self.client.pub_key = self.forger_pub
         assert self.proto.handle_intercom_message(
-            self._intercom(self.forger_priv), self.client) is False
+            self._intercom(self.forger_priv), self.client) is True
 
     def test_no_pubkey_rejects_unverifiable_origin(self):
         # peer never presented a pubkey: origin cannot be authenticated,
-        # fail closed rather than dispatch unverified (CRYPTO-1 §5 MUST)
+        # fail closed and drop rather than dispatch unverified (CRYPTO-1 §5)
         self.client.pub_key = None
         with patch("hivemind_core.protocol.LOG") as mock_log:
             assert self.proto.handle_intercom_message(
-                self._intercom(self.forger_priv), self.client) is False
+                self._intercom(self.forger_priv), self.client) is True
         assert mock_log.warning.called
         assert self.client.peer in mock_log.warning.call_args[0][0]
 
     def test_missing_signature_rejected_even_with_pinned_key(self):
         # pubkey is pinned, but the frame carries no signature at all:
-        # nothing to verify against, reject rather than trust blindly
+        # nothing to verify against, drop rather than trust blindly
         self.proto.trusted_pubkeys["test-key"] = self.client_pub
         frame = self._intercom(self.client_priv)
         frame.payload.pop("signature")
         with patch("hivemind_core.protocol.LOG") as mock_log:
-            assert self.proto.handle_intercom_message(frame, self.client) is False
+            assert self.proto.handle_intercom_message(frame, self.client) is True
         assert mock_log.warning.called
         assert "no signature" in mock_log.warning.call_args[0][0]
 
@@ -268,3 +273,77 @@ class TestPasswordHandshakeFailFast(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRejectedIntercomIsNotRelayed(unittest.TestCase):
+    """A refused INTERCOM must be dropped, never fanned out or escalated.
+
+    ``handle_intercom_message`` returning False means "not addressed to me,
+    keep relaying"; every caller does ``if handle_intercom_message(...):
+    return``. So an authentication failure has to be reported as consumed
+    (True), otherwise rejecting a frame would *amplify* it to every peer and
+    to the upstream master.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server_pub, cls.server_priv = create_RSA_key()
+        cls.client_pub, cls.client_priv = create_RSA_key()
+        cls.forger_pub, cls.forger_priv = create_RSA_key()
+
+    def setUp(self):
+        import tempfile
+        self.proto = _make_protocol()
+        self._priv_file = tempfile.NamedTemporaryFile(
+            "w", suffix=".pem", delete=False)
+        self._priv_file.write(self.server_priv)
+        self._priv_file.close()
+        self.proto.identity = MagicMock()
+        self.proto.identity.private_key = self._priv_file.name
+        self.proto.identity.public_key = self.server_pub
+        self.proto._upstream_hm = MagicMock()
+
+        self.client = _make_client(self.proto)
+        # pinned pubkey, but the frame will be signed by the forger
+        self.proto.trusted_pubkeys["test-key"] = self.client_pub
+
+        self.peer = MagicMock()
+        self.proto.clients["peer-1"] = self.peer
+
+    def tearDown(self):
+        os.unlink(self._priv_file.name)
+
+    def _forged_intercom(self):
+        inner = HiveMessage(HiveMessageType.SHARED_BUS,
+                            payload=Message("speak", {"utterance": "hi"}))
+        ciphertext = encrypt_RSA(self.server_pub, inner.serialize())
+        signature = sign_RSA(self.forger_priv, ciphertext)
+        return HiveMessage(
+            HiveMessageType.INTERCOM,
+            payload={"ciphertext": pybase64.b64encode(ciphertext).decode(),
+                     "signature": pybase64.b64encode(signature).decode()})
+
+    def _assert_dropped(self):
+        self.peer.send.assert_not_called()
+        self.proto._upstream_hm.emit.assert_not_called()
+
+    def test_rejected_intercom_not_broadcast_to_peers(self):
+        self.client.is_admin = True
+        self.proto.handle_broadcast_message(
+            HiveMessage(HiveMessageType.BROADCAST,
+                        payload=self._forged_intercom()), self.client)
+        self._assert_dropped()
+
+    def test_rejected_intercom_not_propagated_to_peers_or_master(self):
+        self.client.can_propagate = True
+        self.proto.handle_propagate_message(
+            HiveMessage(HiveMessageType.PROPAGATE,
+                        payload=self._forged_intercom()), self.client)
+        self._assert_dropped()
+
+    def test_rejected_intercom_not_escalated_to_master(self):
+        self.client.can_escalate = True
+        self.proto.handle_escalate_message(
+            HiveMessage(HiveMessageType.ESCALATE,
+                        payload=self._forged_intercom()), self.client)
+        self._assert_dropped()


### PR DESCRIPTION
## Bug

`handle_intercom_message` in `hivemind_core/protocol.py` verified the INTERCOM origin RSA signature against the TOFU-pinned pubkey **only when a pubkey happened to be available**. When no pubkey was ever pinned or presented (`self.trusted_pubkeys.get(client.key) or client.pub_key` both empty), the code logged a warning and still decrypted and dispatched the inner message. An attacker bypassed origin verification simply by never sending a pubkey in HELLO, which turned the CRYPTO-1 §5 signature requirement into an opt-in.

## Spec

HIVEMIND-CRYPTO-1 §5: the INTERCOM origin signature MUST verify against the TOFU-pinned public key. Fail closed is the rule — an unverifiable origin must not be dispatched.

## Scope

This PR covers the **signed-envelope INTERCOM path** — the `{"ciphertext": ..., "signature": ...}` payload. See "Known remaining work" below for the plaintext path, which this PR deliberately does not change.

## Fix

`handle_intercom_message` now rejects the INTERCOM (logs a warning naming the peer and the reason, does not decrypt or dispatch the inner message) when:

- no pubkey is pinned and none is available on the connection, or
- the frame carries no signature at all, even if a pubkey *is* pinned.

This matches the existing behavior for a signature that fails against a known key.

### A rejected INTERCOM is dropped, not relayed

The return value of `handle_intercom_message` is read by the BROADCAST, PROPAGATE and ESCALATE handlers as "consumed, stop processing"; `False` means "not addressed to me, keep relaying". Returning `False` on a rejection made the callers fall through into the peer fan-out and `escalate_to_master`, so a frame this node refused to authenticate was rebroadcast to every peer and pushed upstream — rejecting a frame amplified it.

Authentication failures now return `True`: the frame was handled here, by dropping it. The docstring states what each return value means. The "not for us" early return and the undecryptable-but-not-addressed-to-us path still return `False`, because those frames really do belong to someone else.

An invalid base64 signature is now reported as a signature verification failure instead of the misleading "failed to decrypt message!".

## What the TOFU pin does and does not give you

`handle_hello_message` pins `client.pub_key` from the first HELLO that carries one, with no proof of possession of the matching private key. The property is therefore:

- **After the pin exists**, every INTERCOM on that access key must carry a signature that verifies against the pinned key. A second party who steals or shares the access key cannot forge an origin, and a later HELLO presenting a different key does not move the pin.
- **Before the pin exists**, whoever completes the first HELLO on an access key chooses the anchor, and they only have to *assert* a pubkey, not prove they hold its private key. An attacker who reaches the listener first with a stolen access key owns the pin for that listener's lifetime.
- The pin lives in memory, so it is re-established on every restart.

The pin binds an access key to one origin key over a listener lifetime. It is not an identity proof, and it does not upgrade a compromised access key.

## Known remaining work: the plaintext INTERCOM path

The guard added here sits in the ciphertext branch only. The two sibling branches — `elif isinstance(pload, HiveMessage)` and the plaintext `else: inner = HiveMessage.deserialize(pload)` — still dispatch to `handle_bus_message` / propagate / broadcast / escalate / shared_bus with no origin authentication. An attacker who omits `"ciphertext"` is not covered by this PR.

Unencrypted INTERCOM delivery is an intentional feature, added in #123 to fix #117, and `tests/test_intercom_unencrypted_delivery.py` asserts it. Authenticating those branches means deciding whether plaintext INTERCOM should carry a signature at all, or be gated on `require_crypto`. That is a wire-visible decision, so it belongs in its own PR rather than being folded into this one.

## Back-compat

The shipped `hivemind_bus_client` always sends its pubkey in HELLO (`hivemind_bus_client/protocol.py` ~line 484), so an up-to-date client is unaffected. Only a client that omits its pubkey — previously the only way to bypass origin verification — is now rejected.

## Tests

- `tests/test_crypto_enforcement.py::TestIntercomSignatureVerification::test_no_pubkey_rejects_unverifiable_origin` (was `test_no_pubkey_falls_back_to_unverified_processing`, which asserted the bug's permissive behavior)
- `tests/test_crypto_enforcement.py::TestIntercomSignatureVerification::test_missing_signature_rejected_even_with_pinned_key`
- `tests/test_crypto_enforcement.py::TestRejectedIntercomIsNotRelayed::test_rejected_intercom_not_broadcast_to_peers`
- `tests/test_crypto_enforcement.py::TestRejectedIntercomIsNotRelayed::test_rejected_intercom_not_propagated_to_peers_or_master`
- `tests/test_crypto_enforcement.py::TestRejectedIntercomIsNotRelayed::test_rejected_intercom_not_escalated_to_master`

The three `TestRejectedIntercomIsNotRelayed` tests fail on the previous commit and pass now.

Full suite: `pytest tests/ --ignore=tests/e2e -q` → 142 passed, 1 skipped.

## AI transparency

Implemented by Claude Sonnet and Claude Opus 4.8 under Claude Opus 4.8 orchestration.
