### PR TITLE
fix: refuse unauthenticated INTERCOM when crypto is required

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1742,6 +1742,16 @@ class HiveMindListenerProtocol:
                     return True
                 LOG.debug("failed to decrypt message, not for us")
                 return False
+        elif self.require_crypto:
+            # No signed envelope, so no origin signature to verify: this frame
+            # carries no proof of who sent it. HIVEMIND-CRYPTO-1 §5 requires
+            # the origin signature, and this listener advertises
+            # "crypto_required" to its clients — honour it and drop.
+            # Dropping returns True: consumed here, not relayed nor escalated.
+            LOG.warning(f"INTERCOM from {client.peer} is unencrypted and "
+                        f"unsigned, but this node requires crypto: dropping "
+                        f"unauthenticated message")
+            return True
         elif isinstance(pload, HiveMessage):
             inner = pload
         else:

--- a/tests/test_intercom_requires_crypto.py
+++ b/tests/test_intercom_requires_crypto.py
@@ -1,0 +1,132 @@
+"""Unauthenticated INTERCOM must be refused when the hub requires crypto.
+
+``handle_intercom_message`` verifies the origin RSA signature (CRYPTO-1 §5)
+only on the signed-envelope branch (``{"ciphertext": ...}``). The two sibling
+branches — an inner ``HiveMessage`` payload, and a plain dict payload — used
+to dispatch the inner message to the bus with no origin authentication at
+all, so omitting the ``ciphertext`` field walked straight past the §5 check.
+
+A hub with ``require_crypto=True`` advertises ``crypto_required`` to clients
+and means "unencrypted payloads are not allowed". These tests hold it to
+that: the unauthenticated branches are dropped (and, being dropped, are not
+relayed to peers or escalated upstream). With ``require_crypto=False`` the
+deliberate plaintext INTERCOM feature (issue #117 / PR #123) still works.
+"""
+
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from poorman_handshake.asymmetric.utils import create_RSA_key
+
+from hivemind_bus_client import HiveMessage, HiveMessageType
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+
+def _make_protocol(require_crypto):
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    db = MagicMock()
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=require_crypto)
+
+
+def _real_key_identity(pubkey, privkey_pem):
+    """Identity backed by a real RSA key file.
+
+    ``HiveMindClientConnection`` builds an RSA HandShake from
+    ``identity.private_key`` on construction, so it must be a usable key path.
+    """
+    handle = tempfile.NamedTemporaryFile("w", suffix=".pem", delete=False)
+    handle.write(privkey_pem)
+    handle.close()
+    identity = MagicMock()
+    identity.private_key = handle.name
+    identity.public_key = pubkey
+    return identity
+
+
+def _make_client(protocol):
+    client = HiveMindClientConnection(
+        key="test-key",
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+    )
+    client.name = "test-client"
+    return client
+
+
+def _inner_bus():
+    return HiveMessage(HiveMessageType.BUS,
+                       payload=Message("speak", {"utterance": "hi"}))
+
+
+class TestUnauthenticatedIntercomRefused(unittest.TestCase):
+    """require_crypto=True: no signature, no delivery, no relay."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server_pub, cls.server_priv = create_RSA_key()
+
+    def setUp(self):
+        self.proto = _make_protocol(require_crypto=True)
+        self.proto.identity = _real_key_identity(self.server_pub, self.server_priv)
+        self.proto.handle_bus_message = MagicMock()
+        self.proto._upstream_hm = MagicMock()
+        self.client = _make_client(self.proto)
+        self.peer = MagicMock()
+        self.proto.clients["peer-1"] = self.peer
+
+    def _assert_dropped(self, handled, mock_log):
+        # consumed here: callers must not relay or escalate it
+        assert handled is True
+        self.proto.handle_bus_message.assert_not_called()
+        self.peer.send.assert_not_called()
+        self.proto._upstream_hm.emit.assert_not_called()
+        assert mock_log.warning.called
+        assert self.client.peer in mock_log.warning.call_args[0][0]
+
+    def test_plaintext_dict_intercom_is_dropped(self):
+        frame = HiveMessage(HiveMessageType.INTERCOM,
+                            payload=_inner_bus().serialize())
+        with patch("hivemind_core.protocol.LOG") as mock_log:
+            handled = self.proto.handle_intercom_message(frame, self.client)
+        self._assert_dropped(handled, mock_log)
+
+    def test_hivemessage_payload_intercom_is_dropped(self):
+        frame = HiveMessage(HiveMessageType.INTERCOM, payload=_inner_bus())
+        with patch("hivemind_core.protocol.LOG") as mock_log:
+            handled = self.proto.handle_intercom_message(frame, self.client)
+        self._assert_dropped(handled, mock_log)
+
+
+class TestPlaintextIntercomStillWorksWithoutCrypto(unittest.TestCase):
+    """require_crypto=False: the opt-out deployment keeps issue #117 behavior."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server_pub, cls.server_priv = create_RSA_key()
+
+    def setUp(self):
+        self.proto = _make_protocol(require_crypto=False)
+        self.proto.identity = _real_key_identity(self.server_pub, self.server_priv)
+        self.proto.handle_bus_message = MagicMock()
+        self.client = _make_client(self.proto)
+
+    def test_hivemessage_payload_intercom_is_delivered(self):
+        frame = HiveMessage(HiveMessageType.INTERCOM, payload=_inner_bus())
+        assert self.proto.handle_intercom_message(frame, self.client) is True
+        self.proto.handle_bus_message.assert_called_once()
+
+    def test_plaintext_dict_intercom_is_delivered(self):
+        frame = HiveMessage(HiveMessageType.INTERCOM,
+                            payload=_inner_bus().serialize())
+        assert self.proto.handle_intercom_message(frame, self.client) is True
+        self.proto.handle_bus_message.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_intercom_unencrypted_delivery.py
+++ b/tests/test_intercom_unencrypted_delivery.py
@@ -19,6 +19,10 @@ from hivemind_core.protocol import HiveMindListenerProtocol
 def _make_protocol():
     proto = object.__new__(HiveMindListenerProtocol)
     proto.identity = MagicMock(public_key="OUR_PUBKEY")
+    # Unencrypted INTERCOM carries no origin signature, so a node that
+    # requires crypto drops it (HIVEMIND-CRYPTO-1 §5). This feature is for
+    # deployments that opted out of crypto — say so explicitly.
+    proto.require_crypto = False
     proto.handle_bus_message = MagicMock()
     proto.handle_propagate_message = MagicMock()
     proto.handle_broadcast_message = MagicMock()


### PR DESCRIPTION
## The bypass

`handle_intercom_message` in `hivemind_core/protocol.py` authenticates the origin RSA signature on **one** of its three payload branches:

```python
if isinstance(pload, dict) and "ciphertext" in pload:
    ...  # signature verified here (added by #166)
elif isinstance(pload, HiveMessage):
    inner = pload                          # no authentication
else:
    inner = HiveMessage.deserialize(pload) # no authentication
```

Both sibling branches then dispatch `inner` to `handle_bus_message`, `handle_propagate_message`, `handle_broadcast_message`, `handle_escalate_message`, `handle_binary_message`, or `handle_client_shared_bus`.

So the guard #166 added is reached only if the attacker chooses to send a `ciphertext` field. Omit it, and the same inner message lands on the hub bus with **zero** origin authentication. #166 documented the branches but left them open.

## The spec

HIVEMIND-CRYPTO-1 §5 makes the origin signature on INTERCOM a MUST. A hub cannot enforce a MUST that any peer can skip by dropping a JSON key.

## The fix

`HiveMindListenerProtocol.require_crypto` (default `True`) already means "unencrypted payloads are not allowed", and the hub advertises it to clients as `crypto_required` in the HELLO payload. An operator running the default believes unauthenticated frames cannot reach their bus. This makes that true.

When `require_crypto` is set, the two unsigned branches log a warning naming the peer and the reason, and drop the frame. The drop returns `True` — per the contract #166 established, `True` means "consumed here, do NOT relay to peers or escalate upstream", so refusing a frame cannot amplify it across the mesh.

When `require_crypto` is `False`, behavior is unchanged.

## Back-compat — read this

**This is a behavior change, and it breaks something.** Any client that today sends plaintext INTERCOM to a hub running the default `require_crypto=True` will stop being delivered. Its messages are dropped and logged, not relayed, not escalated.

- **Who it breaks:** deployments using the plaintext INTERCOM feature (issue #117 / PR #123) against a crypto-requiring hub.
- **Why:** that combination is exactly the hole. The hub told those clients `crypto_required: true` and then accepted their unauthenticated frames anyway.
- **Escape hatch:** set `require_crypto=False` on the listener if you genuinely want unauthenticated INTERCOM. The #123 feature keeps working there, unchanged, and the hub now honestly advertises `crypto_required: false` to match.

There is no silent middle ground on purpose. A hub either authenticates INTERCOM origins or it says it does not.

## Tests

New `tests/test_intercom_requires_crypto.py`:

- `TestUnauthenticatedIntercomRefused::test_plaintext_dict_intercom_is_dropped`
- `TestUnauthenticatedIntercomRefused::test_hivemessage_payload_intercom_is_dropped`

Both assert the inner message is not dispatched, a warning naming the peer is logged, and — because a dropped frame must not be fanned out — that peer connections' `send` and `_upstream_hm.emit` were not called (same shape as `TestRejectedIntercomIsNotRelayed` from #166).

- `TestPlaintextIntercomStillWorksWithoutCrypto::test_hivemessage_payload_intercom_is_delivered`
- `TestPlaintextIntercomStillWorksWithoutCrypto::test_plaintext_dict_intercom_is_delivered`

cover the `require_crypto=False` opt-out.

`tests/test_intercom_unencrypted_delivery.py` (the #117 regression suite) builds its protocol with `object.__new__`, so it never set `require_crypto`. It now sets `require_crypto = False` explicitly, with a comment saying why — the feature it tests is the crypto-opt-out feature. No assertion changed.

The signed-envelope path is untouched: `tests/test_crypto_enforcement.py` still passes as-is (valid signature delivers, forged signature rejected).

Proof the tests catch the bug: with the `protocol.py` change stashed, both drop tests fail on `origin/dev` (the inner message is dispatched). Full non-e2e suite after the fix: **148 passed, 1 skipped**.

## AI transparency

Implemented by Claude Opus under Claude Fable 5 orchestration. The gap was found by adversarial validation of #166.