### PR TITLE
fix: close three admission-control gaps in the policy chain

### DIFF
--- a/docs/policy.md
+++ b/docs/policy.md
@@ -66,7 +66,13 @@ Mutation classes are agent-specific and live with the agent plugin
   whitelist from the database on every admission so
   `hivemind-core allow-msg` takes effect without a reconnect. Caches
   the resolved client row on the connection (`client.resolve_user`) so
-  downstream policies skip a second DB hit.
+  downstream policies skip a second DB hit. A failed database lookup
+  denies with `code="policy_error"`; it never falls back to the
+  whitelist captured when the client connected, because that would keep
+  a revoked grant alive while the database is unreachable. Binary
+  payloads cross the same gate: a client with an empty whitelist is
+  denied binary too. The whitelist holds message types only, so there
+  is no per-`bin_type` granularity yet.
 - **`DenyAllPolicy`**: fail-closed fallback installed when
   `PolicyChain.from_config` raises. Denies every message and binary
   payload with `code="policy_chain_unavailable"`.

--- a/hivemind_core/policy.py
+++ b/hivemind_core/policy.py
@@ -238,9 +238,14 @@ class MessageTypeACLPolicy(PolicyPlugin):
     are not exempt — operators grant the message types they need via
     ``hivemind-core allow-msg`` like any other client.
 
+    Binary payloads cross the same gate: a client with an empty
+    whitelist is denied binary too (see ``review_binary``).
+
     Refreshes ``allowed_types`` from the DB on each admission so
     ``hivemind-core allow-msg`` / ``blacklist-msg`` take effect
-    immediately without forcing a reconnect.
+    immediately without forcing a reconnect. A DB error is a deny, not
+    a fallback to the connection snapshot — otherwise a revocation
+    issued while the DB is down would never take effect.
 
     The resolved DB row is cached on the connection via
     ``client.resolve_user(db)`` so downstream policies in the same chain
@@ -250,25 +255,68 @@ class MessageTypeACLPolicy(PolicyPlugin):
     live in agent policies like ``OVOSAgentPolicy``.
     """
 
+    def _allowed_types(self, client: "HiveMindClientConnection") -> List[str]:
+        """Resolve the whitelist for this admission.
+
+        The DB row wins so a grant or a revocation takes effect without a
+        reconnect; the snapshot taken at connection time is used only when
+        there is no DB at all. DB errors propagate — both callers turn them
+        into a POLICY_ERROR deny, never into a stale allow.
+        """
+        db = self.hm_protocol.db if self.hm_protocol is not None else None
+        if db is None:
+            return list(client.allowed_types or [])
+        user = client.resolve_user(db)
+        if user is None:
+            return list(client.allowed_types or [])
+        return list(user.allowed_types or [])
+
     def review(self, message: Message,
                client: "HiveMindClientConnection") -> Verdict:
-        allowed = list(getattr(client, "allowed_types", []) or [])
-        db = getattr(self.hm_protocol, "db", None)
-        if db is not None:
-            try:
-                user = client.resolve_user(db)
-                if user is not None:
-                    allowed = list(getattr(user, "allowed_types", allowed) or [])
-            except Exception:
-                LOG.warning("MessageTypeACLPolicy: DB refresh failed; using cached value",
-                            exc_info=True)
+        try:
+            allowed = self._allowed_types(client)
+        except Exception as e:
+            LOG.exception("MessageTypeACLPolicy: failed to resolve allowed_types")
+            return Verdict.deny(
+                DenyCodes.POLICY_ERROR,
+                f"MessageTypeACLPolicy: failed to resolve allowed_types: {e}",
+            )
 
-        msg_type = getattr(message, "msg_type", None)
+        msg_type = message.msg_type
         if msg_type not in allowed:
             return Verdict.deny(
                 DenyCodes.ACL_DISALLOWED_TYPE,
                 f"{msg_type} not in allowed_types",
                 msg_type=msg_type,
+                allowed=allowed,
+            )
+        return Verdict.allow()
+
+    def review_binary(self, payload: bytes,
+                      client: "HiveMindClientConnection") -> Verdict:
+        """Binary payloads cross the same gate as bus messages.
+
+        ``allowed_types`` lists message types, and the Client DB row has no
+        per-``bin_type`` grant, so the only decision this policy can make on
+        a binary payload is the deny-by-default one: a client with an empty
+        whitelist is granted nothing and gets nothing. Without this a client
+        that may not emit a single message type could still push RAW_AUDIO
+        into the STT pipeline and FILE payloads to disk.
+        """
+        try:
+            allowed = self._allowed_types(client)
+        except Exception as e:
+            LOG.exception("MessageTypeACLPolicy: failed to resolve allowed_types")
+            return Verdict.deny(
+                DenyCodes.POLICY_ERROR,
+                f"MessageTypeACLPolicy: failed to resolve allowed_types: {e}",
+            )
+
+        if not allowed:
+            return Verdict.deny(
+                DenyCodes.ACL_DISALLOWED_TYPE,
+                "binary payloads are denied for a client with an empty "
+                "allowed_types whitelist",
                 allowed=allowed,
             )
         return Verdict.allow()

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -431,10 +431,10 @@ class HiveMindListenerProtocol:
         else:
             self.binary_data_protocol.hm_protocol = self
         if self.policy_chain is None:
-            from hivemind_core.policy import MessageTypeACLPolicy, DenyAllPolicy
+            from hivemind_core.policy import DenyAllPolicy
             cfg = get_server_config()
             try:
-                chain = PolicyChain.from_config(cfg, hm_protocol=self)
+                self.policy_chain = PolicyChain.from_config(cfg, hm_protocol=self)
             except Exception:
                 LOG.exception(
                     "failed to build policy chain; installing DenyAllPolicy "
@@ -444,24 +444,34 @@ class HiveMindListenerProtocol:
                 self.policy_chain = PolicyChain(
                     policies=[DenyAllPolicy(hm_protocol=self)],
                 )
-            else:
-                # MessageTypeACLPolicy is the canonical allowed_types whitelist
-                # enforcement and is non-removable. Prepend it to the
-                # configured chain (deduping if an operator listed it
-                # explicitly). Always mandatory — _optional[0] = False.
-                configured: List[PolicyPlugin] = []
-                configured_optional: List[bool] = []
-                for i, p in enumerate(chain.policies):
-                    if isinstance(p, MessageTypeACLPolicy):
-                        continue
-                    configured.append(p)
-                    configured_optional.append(
-                        chain._optional[i] if i < len(chain._optional) else False
-                    )
-                self.policy_chain = PolicyChain(
-                    policies=[MessageTypeACLPolicy(hm_protocol=self), *configured],
-                    _optional=[False, *configured_optional],
-                )
+        # every chain is normalized, including one handed to the constructor
+        # by an embedder — the ACL gate is not opt-out
+        self.policy_chain = self._with_acl_gate(self.policy_chain)
+
+    def _with_acl_gate(self, chain: PolicyChain) -> PolicyChain:
+        """Return ``chain`` with MessageTypeACLPolicy in first position.
+
+        MessageTypeACLPolicy is the canonical ``allowed_types`` whitelist
+        enforcement and is non-removable, so it is prepended to whatever
+        chain we were given, deduping an explicitly listed copy so the
+        operator cannot reorder it. Always mandatory — ``_optional[0]``
+        is False, so an exception in the gate fails the chain closed.
+        """
+        from hivemind_core.policy import MessageTypeACLPolicy
+        policies: List[PolicyPlugin] = []
+        optional: List[bool] = []
+        for i, p in enumerate(chain.policies):
+            if isinstance(p, MessageTypeACLPolicy):
+                continue
+            policies.append(p)
+            optional.append(
+                chain._optional[i] if i < len(chain._optional) else False
+            )
+        return PolicyChain(
+            policies=[MessageTypeACLPolicy(hm_protocol=self), *policies],
+            _optional=[False, *optional],
+            on_verdict=chain.on_verdict,
+        )
 
     def get_bus(self, client: HiveMindClientConnection) -> Union[FakeBus, MessageBusClient]:
         # The agent decides which bus a client's messages land on. Default

--- a/tests/test_policy_chain.py
+++ b/tests/test_policy_chain.py
@@ -10,7 +10,10 @@ Covers:
 - observe swallows exceptions.
 - from_config loads plugins via PolicyPluginFactory; unknown entry
   points raise so __post_init__ can install DenyAllPolicy.
-- MessageTypeACLPolicy: allowed_types whitelist (admins are not exempt).
+- MessageTypeACLPolicy: allowed_types whitelist (admins are not exempt),
+  applied to binary payloads too, and denying when the DB lookup fails.
+- The ACL gate is prepended to any chain, including one supplied to the
+  HiveMindListenerProtocol constructor.
 - DenyAllPolicy: rejects every admission with policy_chain_unavailable.
 """
 from __future__ import annotations
@@ -277,9 +280,10 @@ class TestMessageTypeACLPolicy(unittest.TestCase):
         v = p.review(_msg("recognizer_loop:utterance"), client)
         self.assertFalse(v.denied)
 
-    def test_db_failure_falls_back_to_cached_values(self):
-        """If resolve_user raises, MessageTypeACLPolicy uses the cached
-        connection fields (no fail-open exception leak)."""
+    def test_db_failure_denies_with_policy_error(self):
+        """POLICY-1 §5: a DB error is a policy error, so it denies. Falling
+        back to the connection snapshot would keep a revoked client's
+        grants alive for as long as the DB stays unreachable."""
         from types import SimpleNamespace
         client = _FakeClient(allowed_types=["ok"], is_admin=False)
 
@@ -289,7 +293,72 @@ class TestMessageTypeACLPolicy(unittest.TestCase):
         db = MagicMock()
         p = MessageTypeACLPolicy(hm_protocol=SimpleNamespace(db=db))
         v = p.review(_msg("ok"), client)
-        self.assertFalse(v.denied)  # used cached allowed_types
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "policy_error")
+        self.assertIn("MessageTypeACLPolicy", v.reason)
+        self.assertIn("db down", v.reason)
+
+    def test_db_failure_denies_binary_with_policy_error(self):
+        from types import SimpleNamespace
+        client = _FakeClient(allowed_types=["ok"], is_admin=False)
+
+        def boom(db, ttl=5.0, force=False):
+            raise RuntimeError("db down")
+        client.resolve_user = boom
+        p = MessageTypeACLPolicy(hm_protocol=SimpleNamespace(db=MagicMock()))
+        v = p.review_binary(b"\x00" * 10, client)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "policy_error")
+
+
+class TestMessageTypeACLPolicyBinary(unittest.TestCase):
+    """POLICY-1 §2: BINARY payloads cross the same gate as BUS messages.
+    A client whose whitelist grants nothing must not be able to push
+    RAW_AUDIO into the STT pipeline or FILE payloads to disk."""
+
+    def test_empty_allowed_denies_binary(self):
+        p = MessageTypeACLPolicy()
+        client = _FakeClient(allowed_types=[])
+        v = p.review_binary(b"\x00" * 10, client)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "acl_disallowed_type")
+
+    def test_none_allowed_types_denies_binary(self):
+        p = MessageTypeACLPolicy()
+        v = p.review_binary(b"\x00", _FakeClient(allowed_types=None))
+        self.assertTrue(v.denied)
+
+    def test_admins_are_not_exempt_for_binary(self):
+        p = MessageTypeACLPolicy()
+        client = _FakeClient(allowed_types=[], is_admin=True)
+        v = p.review_binary(b"\x00", client)
+        self.assertTrue(v.denied)
+
+    def test_non_empty_allowed_allows_binary(self):
+        """The whitelist has no per-bin_type granularity, so any grant
+        at all admits binary payloads."""
+        p = MessageTypeACLPolicy()
+        client = _FakeClient(allowed_types=["recognizer_loop:utterance"])
+        self.assertFalse(p.review_binary(b"\x00", client).denied)
+
+    def test_db_grant_admits_binary(self):
+        """A grant made mid-session is picked up for binary too."""
+        from types import SimpleNamespace
+        client = _FakeClient(allowed_types=[], is_admin=False)
+        db = MagicMock()
+        db.get_client_by_api_key = MagicMock(
+            return_value=SimpleNamespace(allowed_types=["speak"]))
+        p = MessageTypeACLPolicy(hm_protocol=SimpleNamespace(db=db))
+        self.assertFalse(p.review_binary(b"\x00", client).denied)
+
+    def test_db_revocation_denies_binary(self):
+        from types import SimpleNamespace
+        client = _FakeClient(allowed_types=["speak"], is_admin=False)
+        db = MagicMock()
+        db.get_client_by_api_key = MagicMock(
+            return_value=SimpleNamespace(allowed_types=[]))
+        p = MessageTypeACLPolicy(hm_protocol=SimpleNamespace(db=db))
+        self.assertTrue(p.review_binary(b"\x00", client).denied)
 
 
 class TestChainAdminHandling(unittest.TestCase):
@@ -870,6 +939,52 @@ class TestProtocolWiring(unittest.TestCase):
         sent_hm = client.send.call_args[0][0]
         denied_msg = sent_hm.payload
         self.assertEqual(denied_msg.data["code"], "policy_error")
+
+
+class TestACLGateIsNonRemovable(unittest.TestCase):
+    """POLICY-1 §4: the ACL gate is always present, always first, and
+    cannot be removed or reordered — including by an embedder that
+    hands HiveMindListenerProtocol a ready-made chain."""
+
+    def _make_protocol(self, policy_chain, db=None):
+        from unittest.mock import MagicMock
+        from ovos_utils.fakebus import FakeBus
+        from hivemind_plugin_manager.protocols import AgentProtocol
+        from hivemind_core.protocol import HiveMindListenerProtocol
+
+        agent = MagicMock(spec=AgentProtocol)
+        agent.bus = FakeBus()
+        agent.hm_protocol = None
+        return HiveMindListenerProtocol(
+            agent_protocol=agent,
+            binary_data_protocol=MagicMock(),
+            identity=MagicMock(),
+            db=db,
+            hive_mapper=MagicMock(),
+            policy_chain=policy_chain,
+        )
+
+    def test_supplied_chain_gets_the_acl_gate_prepended(self):
+        supplied = _AllowPolicy()
+        proto = self._make_protocol(PolicyChain(policies=[supplied]))
+        chain = proto.policy_chain
+        self.assertIsInstance(chain.policies[0], MessageTypeACLPolicy)
+        self.assertIs(chain.policies[1], supplied)
+        self.assertFalse(chain._optional[0])
+
+    def test_supplied_chain_cannot_reorder_the_acl_gate(self):
+        supplied = _AllowPolicy()
+        proto = self._make_protocol(
+            PolicyChain(policies=[supplied, MessageTypeACLPolicy()])
+        )
+        kinds = [type(p) for p in proto.policy_chain.policies]
+        self.assertEqual(kinds, [MessageTypeACLPolicy, _AllowPolicy])
+
+    def test_supplied_chain_gate_denies_empty_whitelist(self):
+        proto = self._make_protocol(PolicyChain(policies=[_AllowPolicy()]))
+        v = proto.policy_chain.review(_msg("speak"), _FakeClient(allowed_types=[]))
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "acl_disallowed_type")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A spec-conformance audit against HIVEMIND-POLICY-1 found three gaps in the admission chain. All three touch the same chain, so they ship together. Each fix has a test that fails on `dev`.

## 1. Binary payloads bypassed the ACL gate (security)

`MessageTypeACLPolicy` implemented only `review()`. It never overrode `review_binary()`, so it inherited `PolicyPlugin.review_binary`, which returns `Verdict.allow()`. With an empty `allowed_types`, `review(Message("speak"))` denied with `acl_disallowed_type` but `review_binary(b"\x00" * 10)` allowed. A client that may not emit a single message type could still push RAW_AUDIO into the STT pipeline and FILE payloads to disk.

Violates POLICY-1 §2 (every BUS message and every BINARY payload crosses the full chain) and §4 (the whitelist is deny-by-default).

Fix: `MessageTypeACLPolicy.review_binary` denies with `acl_disallowed_type` when the resolved whitelist is empty. The Client DB row has no binary or `bin_type` grant column, so a per-`bin_type` grant would need a schema change; that is deliberately left as follow-up work. The minimal correct rule today is "an empty whitelist denies binary too".

## 2. A database error kept a revoked client's grants (security)

The DB refresh was wrapped in `try/except Exception`, logged "using cached value", and fell back to `client.allowed_types` — the snapshot taken when the client connected. A revocation issued while the DB was unreachable never took effect.

Violates POLICY-1 §4 (the whitelist is resolved freshly enough that a revocation lands without a reconnect) and §5 (any policy error becomes a deny). `resolve_user`'s own docstring says exceptions propagate and callers fail closed; this caller did the opposite.

Fix: the error path returns `Verdict.deny(DenyCodes.POLICY_ERROR, ...)` naming the policy and the error. The deliberate 5s TTL cache on the connection stays — it is correct and satisfies §4 on the happy path. Only the error path changed.

## 3. The gate was removable by constructor injection (hardening)

`HiveMindListenerProtocol.policy_chain` is an optional constructor field, and the force-prepend and dedupe logic ran only inside the `if self.policy_chain is None` branch. An embedder passing `HiveMindListenerProtocol(policy_chain=PolicyChain(policies=[...]))` got a chain with no ACL gate and no error.

Violates POLICY-1 §4 (the gate is always present, always first, and cannot be removed or reordered).

Fix: the normalization moved into `_with_acl_gate()`, which now runs on every chain — default-constructed, config-built, or supplied by the caller. Nothing in-tree exploits this today, so this one is hardening, not an active vulnerability.

## Back-compat

Fix 1 is a behavior change. Any deployment that relies on binary payloads flowing to a client with an empty `allowed_types` whitelist will start seeing those payloads denied. Grant that client at least one message type (`hivemind-core allow-msg`) to restore the flow. Fixes 2 and 3 change behavior only on the DB-error path and for callers that inject their own chain.

## Tests

New in `tests/test_policy_chain.py`:

- `TestMessageTypeACLPolicyBinary` — 6 tests: empty whitelist denies binary, `None` whitelist denies, admins are not exempt, a non-empty whitelist admits, a mid-session DB grant admits, a mid-session DB revocation denies.
- `TestMessageTypeACLPolicy::test_db_failure_denies_with_policy_error` and `test_db_failure_denies_binary_with_policy_error` — the first replaces `test_db_failure_falls_back_to_cached_values`, which asserted the buggy fallback.
- `TestACLGateIsNonRemovable` — 3 tests: a supplied chain gets the gate prepended, a supplied chain cannot reorder the gate, and the gate in a supplied chain denies an empty whitelist.

All 9 fail on `origin/dev` @ 1d8513c. Full non-e2e suite: 158 passed, 1 skipped.

`docs/policy.md` updated for the new `MessageTypeACLPolicy` behavior.

## AI transparency

Implemented by Claude Opus under Claude Fable 5 orchestration. The three bugs were found by a spec-conformance audit of hivemind-core against HIVEMIND-POLICY-1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened access control for message types and binary payloads.
  * Database permission lookup failures now deny access with a policy error instead of using cached permissions.
  * Administrators are now consistently subject to configured message-type restrictions.
  * Access-control enforcement can no longer be bypassed or reordered when custom policy chains are configured.

* **Documentation**
  * Clarified whitelist behavior for database errors, binary payloads, empty whitelists, and binary type-specific rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->