### PR TITLE
fix: preserve routing envelopes, isolate query responses, and bound relay floods

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1134,12 +1134,12 @@ class HiveMindListenerProtocol:
             if site and site == self.identity.site_id:
                 self.handle_bus_message(message.payload, client)
 
-        # broadcast message to other peers
-        payload = self._unpack_message(message, client)
+        # broadcast message to other peers (NODE-1 §3.3: keep the envelope)
+        fwd = self._rewrap(message, payload)
         for peer in self.clients:
             if peer == client.peer:
                 continue
-            self.clients[peer].send(payload)
+            self.clients[peer].send(fwd)
 
     def _unpack_message(self, message: HiveMessage, client: HiveMindClientConnection):
         # propagate message to other peers
@@ -1149,6 +1149,29 @@ class HiveMindListenerProtocol:
         pload.update_source_peer(self.peer)
         pload.remove_target_peer(client.peer)
         return pload
+
+    def _rewrap(self, message: HiveMessage, payload: HiveMessage,
+                metadata: Optional[dict] = None) -> HiveMessage:
+        """Wrap an unpacked ``payload`` back into an outer envelope of the same
+        type as ``message``.
+
+        HIVEMIND-NODE-1 §3.3: a relay MUST preserve the envelope it relays.
+        ``metadata``, ``target_site_id`` and ``target_pubkey`` are
+        constructor-only on ``HiveMessage``, so a naive
+        ``HiveMessage(type, payload=payload)`` silently drops them — and site
+        targeting is read off the OUTER envelope, so a site-targeted message
+        would stop being deliverable after one relay hop.
+        """
+        fwd = HiveMessage(
+            message.msg_type, payload=payload,
+            metadata=message.metadata if metadata is None else metadata,
+            target_site_id=message.target_site_id,
+            target_pubkey=message.target_public_key,
+        )
+        # MSG-1 §5: carry the accumulated route (incl. our self-hop) on the
+        # outer envelope so the next node can detect a loop
+        fwd.replace_route(payload.route)
+        return fwd
 
     @property
     def _node_id(self) -> str:
@@ -1259,14 +1282,16 @@ class HiveMindListenerProtocol:
                       f"node {self._node_id} (MSG-1 §5); route={message.route}")
             return
 
-        # propagate message to other peers
+        # propagate message to other peers (NODE-1 §3.3: keep the envelope, so a
+        # peer receives a PROPAGATE it can fan out again instead of a bare BUS)
+        fwd = self._rewrap(message, payload)
         for peer in self.clients:
             if peer == client.peer:
                 continue
-            self.clients[peer].send(payload)
+            self.clients[peer].send(fwd)
 
         # forward upstream to the master this node relays to (no-op at top level)
-        self.propagate_to_master(payload)
+        self.propagate_to_master(fwd)
 
     def handle_ping_message(
             self, message: HiveMessage, client: HiveMindClientConnection
@@ -1324,9 +1349,11 @@ class HiveMindListenerProtocol:
 
         LOG.debug(f"Sending responsive PING for flood_id={flood_id}")
 
-        # Send to all downstream peers
-        for peer_id, conn in self.clients.items():
+        # NODE-1 §4: a PING fans out across the whole mesh — downstream peers
+        # and upstream alike, so a master learns of nodes below a relay
+        for conn in self.clients.values():
             conn.send(own_ping_outer)
+        self.propagate_to_master(own_ping_outer)
 
     def bind_upstream(self, slave) -> None:
         """Bind a ``HiveMindSlaveProtocol`` as this node's upstream connection,
@@ -1340,49 +1367,65 @@ class HiveMindListenerProtocol:
         slave.hm.on(HiveMessageType.QUERY, self.query_from_master)
         slave.hm.on(HiveMessageType.CASCADE, self.cascade_from_master)
 
+    def _relay_downstream(self, message: HiveMessage) -> None:
+        """Fan a routing message received from the upstream master out to every
+        downstream client, with NODE-1 §3.4 loop prevention: a message whose
+        route already names this node is not relayed again."""
+        if self._is_routing_loop(message):
+            LOG.debug(f"not relaying {message.msg_type} already routed through "
+                      f"this node {self._node_id} (NODE-1 §3.4); "
+                      f"route={message.route}")
+            return
+        self._append_self_hop(message)
+        for conn in self.clients.values():
+            conn.send(message)
+
     def broadcast_from_master(self, message: HiveMessage) -> None:
         """Fan a BROADCAST received from the upstream master out to all
-        downstream clients."""
-        for peer, conn in self.clients.items():
+        downstream clients.
+
+        No loop machinery here: NODE-1 §4 makes BROADCAST a single hop to the
+        directly connected downstream nodes, never re-broadcast by recipients.
+        It only ever travels upstream-to-downstream, so it cannot cycle.
+        """
+        for conn in self.clients.values():
             conn.send(message)
 
     def propagate_from_master(self, message: HiveMessage) -> None:
         """Fan a PROPAGATE received from the upstream master out to all
         downstream clients."""
-        for peer, conn in self.clients.items():
-            conn.send(message)
+        self._relay_downstream(message)
 
-    def escalate_to_master(self, payload: HiveMessage) -> None:
-        """Forward an ESCALATE upstream. No-op when this node is the top-level
-        master (nothing bound via :meth:`bind_upstream`)."""
+    def escalate_to_master(self, message: HiveMessage) -> None:
+        """Forward an ESCALATE envelope upstream. No-op when this node is the
+        top-level master (nothing bound via :meth:`bind_upstream`)."""
         if self._upstream_hm is None:
             return
-        msg = HiveMessage(HiveMessageType.ESCALATE, payload=payload)
-        # MSG-1 §5: carry the accumulated route on the outer envelope upstream
-        msg.replace_route(payload.route)
-        self._upstream_hm.emit(msg)
+        self._upstream_hm.emit(message)
 
-    def propagate_to_master(self, payload: HiveMessage) -> None:
-        """Forward a PROPAGATE upstream. No-op when this node is the top-level
-        master (nothing bound via :meth:`bind_upstream`)."""
+    def propagate_to_master(self, message: HiveMessage) -> None:
+        """Forward a PROPAGATE envelope upstream. No-op when this node is the
+        top-level master (nothing bound via :meth:`bind_upstream`)."""
         if self._upstream_hm is None:
             return
-        msg = HiveMessage(HiveMessageType.PROPAGATE, payload=payload)
-        # MSG-1 §5: carry the accumulated route on the outer envelope upstream
-        msg.replace_route(payload.route)
-        self._upstream_hm.emit(msg)
+        self._upstream_hm.emit(message)
 
     def query_from_master(self, message: HiveMessage) -> None:
-        """Fan a QUERY received from the upstream master out to downstream clients."""
-        for peer, conn in self.clients.items():
-            conn.send(message)
+        """Relay a QUERY received from the upstream master.
 
-    def query_to_master(self, payload: HiveMessage, metadata: Optional[dict] = None) -> None:
-        """Forward a QUERY upstream. No-op at the top-level master."""
+        A *response* belongs to the one peer that asked (NODE-1 §5.2), so it
+        walks the return path; only requests fan out downstream.
+        """
+        if (message.metadata or {}).get("is_response"):
+            self._route_query_response(message, None)
+            return
+        self._relay_downstream(message)
+
+    def query_to_master(self, message: HiveMessage) -> None:
+        """Forward a QUERY envelope upstream. No-op at the top-level master."""
         if self._upstream_hm is None:
             return
-        self._upstream_hm.emit(HiveMessage(HiveMessageType.QUERY, payload=payload,
-                                           metadata=metadata))
+        self._upstream_hm.emit(message)
 
     def _build_query_response(self, msg_type: HiveMessageType, response: Message,
                               query_id: str, originator_peer: str,
@@ -1471,9 +1514,14 @@ class HiveMindListenerProtocol:
         return answered
 
     def _route_query_response(self, message: HiveMessage,
-                              client: HiveMindClientConnection):
+                              client: Optional[HiveMindClientConnection]):
         """Route a QUERY response downstream toward its originator (direct
-        client if connected here, else fan to downstream peers)."""
+        client if connected here, else fan to downstream peers).
+
+        ``client`` is the connection the response arrived on, excluded from the
+        last-resort fan-out. It is None when the response came from upstream.
+        """
+        sender = client.peer if client else None
         metadata = message.metadata or {}
         originator_peer = metadata.get("originator_peer", "")
         # CASCADE disambiguation: collect responses for a select callback at
@@ -1506,12 +1554,12 @@ class HiveMindListenerProtocol:
         # the originator (from the request's recorded route) instead of flooding
         for hop in reversed(message.route or []):
             src = hop.get("source")
-            if src and src != client.peer and src in self.clients:
+            if src and src != sender and src in self.clients:
                 self.clients[src].send(message)
                 return
         # unknown return path: fan downstream (excluding the sender) as a last resort
         for peer in self.clients:
-            if peer == client.peer:
+            if peer == sender:
                 continue
             self.clients[peer].send(message)
 
@@ -1548,7 +1596,7 @@ class HiveMindListenerProtocol:
             return
 
         if self._upstream_hm is not None:
-            self.query_to_master(payload, metadata)
+            self.query_to_master(self._rewrap(message, payload, metadata))
         else:
             error_bus = Message("hive.query.timeout",
                                 {"query_id": query_id, "error": "no_answer"})
@@ -1557,19 +1605,21 @@ class HiveMindListenerProtocol:
                 originator_peer, self.peer, route=message.route))
 
     def cascade_from_master(self, message: HiveMessage) -> None:
-        """Fan a CASCADE received from the upstream master out to downstream clients."""
-        for peer, conn in self.clients.items():
-            conn.send(message)
+        """Relay a CASCADE received from the upstream master.
 
-    def cascade_to_master(self, payload: HiveMessage, metadata: Optional[dict] = None) -> None:
-        """Forward a CASCADE upstream. No-op at the top-level master."""
+        As with QUERY, a response goes back to the peer that asked
+        (NODE-1 §5.2); only requests fan out downstream.
+        """
+        if (message.metadata or {}).get("is_response"):
+            self._route_query_response(message, None)
+            return
+        self._relay_downstream(message)
+
+    def cascade_to_master(self, message: HiveMessage) -> None:
+        """Forward a CASCADE envelope upstream. No-op at the top-level master."""
         if self._upstream_hm is None:
             return
-        msg = HiveMessage(HiveMessageType.CASCADE, payload=payload,
-                          metadata=metadata)
-        # MSG-1 §5: carry the accumulated route on the outer envelope upstream
-        msg.replace_route(payload.route)
-        self._upstream_hm.emit(msg)
+        self._upstream_hm.emit(message)
 
     def handle_cascade_message(self, message: HiveMessage,
                                client: HiveMindClientConnection):
@@ -1615,16 +1665,12 @@ class HiveMindListenerProtocol:
                       f"node {self._node_id} (MSG-1 §5); route={message.route}")
             return
 
-        cascade_fwd = HiveMessage(HiveMessageType.CASCADE, payload=payload,
-                                  metadata=metadata)
-        # MSG-1 §5: carry the accumulated route (incl. our self-hop) on the
-        # outer envelope so downstream nodes can detect the loop
-        cascade_fwd.replace_route(payload.route)
+        cascade_fwd = self._rewrap(message, payload, metadata)
         for peer in self.clients:
             if peer == client.peer:
                 continue
             self.clients[peer].send(cascade_fwd)
-        self.cascade_to_master(payload, metadata)
+        self.cascade_to_master(cascade_fwd)
 
     def handle_escalate_message(
             self, message: HiveMessage, client: HiveMindClientConnection
@@ -1676,7 +1722,7 @@ class HiveMindListenerProtocol:
             return
 
         # escalate up the chain to the master this node relays to (no-op at top level)
-        self.escalate_to_master(payload)
+        self.escalate_to_master(self._rewrap(message, payload))
 
     def handle_intercom_message(
             self, message: HiveMessage, client: HiveMindClientConnection

--- a/tests/e2e/test_propagate_mesh_e2e.py
+++ b/tests/e2e/test_propagate_mesh_e2e.py
@@ -1,0 +1,48 @@
+"""Mesh e2e: a PROPAGATE must cross a relay and reach the far side.
+
+HIVEMIND-NODE-1 §4 says PROPAGATE fans out across the whole reachable mesh,
+and §3.3 says a relay must preserve the envelope. When the master hands its
+peers the bare inner message instead of a PROPAGATE, the relay has nothing to
+re-propagate and the flood dies one hop from the origin.
+"""
+import time
+
+import pytest
+
+pytest.importorskip("hivescope")
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType  # noqa: E402
+from ovos_bus_client.message import Message  # noqa: E402
+from hivescope.topology import TopologyBuilder  # noqa: E402
+
+
+def _inner(utt):
+    return HiveMessage(HiveMessageType.BUS,
+                       payload=Message("speak", {"utterance": utt}))
+
+
+def test_propagate_from_a_satellite_crosses_the_relay():
+    """S1 -> M0 -> R0 -> S0. S0 sits below the relay and must still be reached."""
+    b = TopologyBuilder()
+    m = b.add_master("M0")
+    m.register_satellite("relay-key", password="relay-password")
+    m.register_satellite("sat1-key", password="sat1-password")
+    relay_side = b.add_relay("R0", upstream=m).listener
+    relay_side.register_satellite("sat0-key", password="sat0-password")
+    b.add_satellite("S0", upstream=relay_side)
+    b.add_satellite("S1", upstream=m)
+
+    b.start_all()
+    try:
+        received = []
+        b.get_satellite("S0").shim.emitter.on(
+            HiveMessageType.PROPAGATE, received.append)
+
+        b.get_satellite("S1").send(
+            HiveMessage(HiveMessageType.PROPAGATE, payload=_inner("mesh-wide")))
+        time.sleep(0.5)
+
+        assert received, ("PROPAGATE never reached the node below the relay — "
+                          "the flood died after one hop")
+    finally:
+        b.stop_all()

--- a/tests/test_mesh_routing_conformance.py
+++ b/tests/test_mesh_routing_conformance.py
@@ -1,0 +1,274 @@
+"""Regression tests for HIVEMIND-NODE-1 mesh-routing conformance.
+
+Five related routing defects are pinned here:
+
+* **NODE-1 §3.3 / §4** — a relay MUST preserve the envelope. PROPAGATE and
+  BROADCAST fan-out must hand peers a PROPAGATE/BROADCAST envelope, not the
+  bare inner message: a peer that receives a bare BUS has nothing to
+  re-propagate, so the flood dies after one hop.
+* **NODE-1 §5.2 / AGENT-1 §3** — a QUERY/CASCADE *response* belongs to one
+  peer. A relay MUST route it back along the return path, never fan it to
+  every downstream node.
+* **NODE-1 §3.4** — loop prevention applies to the upstream -> downstream
+  relay path too, not only to downstream-origin traffic.
+* **NODE-1 §3.3** — a relayed ESCALATE/PROPAGATE/CASCADE must keep the outer
+  envelope's ``metadata``, ``target_site_id`` and ``target_pubkey``; site
+  targeting is read off the outer envelope, so dropping it makes a
+  site-targeted message undeliverable after one relay hop.
+* **NODE-1 §4** — a responsive PING travels across the whole mesh, upstream
+  included.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+DEFAULT_PEER = "master:0.0.0.0"
+
+
+def _make_node(node_key: str = "pubkey-A", site_id=None) -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = DEFAULT_PEER
+    node.identity = MagicMock(public_key=node_key, site_id=site_id)
+    node.clients = {}
+    node.illegal_callback = None
+    node.propagate_callback = None
+    node.escalate_callback = None
+    node.broadcast_callback = None
+    node._upstream_hm = None
+    return node
+
+
+def _make_client(peer: str) -> MagicMock:
+    client = MagicMock()
+    client.peer = peer
+    client.can_propagate = True
+    client.can_escalate = True
+    client.is_admin = True
+    return client
+
+
+def _wire_peers(node, *peers):
+    """Give ``node`` one recording connection per peer id."""
+    sent = {p: [] for p in peers}
+    for p in peers:
+        conn = MagicMock()
+        conn.send = lambda m, box=sent[p]: box.append(m)
+        node.clients[p] = conn
+    return sent
+
+
+def _upstream(node):
+    captured = []
+    node._upstream_hm = MagicMock()
+    node._upstream_hm.emit = captured.append
+    return captured
+
+
+def _inner(utt="hi"):
+    return HiveMessage(HiveMessageType.BUS,
+                       payload=Message("speak", {"utterance": utt}))
+
+
+def _deliver_preamble(message: HiveMessage, from_peer: str) -> None:
+    message.update_source_peer(from_peer)
+    message.update_hop_data()
+
+
+# --- BUG 1: fan-out must preserve the outer envelope (NODE-1 §3.3, §4) ------
+
+def test_propagate_fanout_keeps_the_propagate_envelope():
+    """A peer must receive a PROPAGATE it can re-propagate, not a bare BUS."""
+    node = _make_node()
+    sent = _wire_peers(node, "origin::0", "peer::1")
+
+    msg = HiveMessage(HiveMessageType.PROPAGATE, payload=_inner("flood"))
+    _deliver_preamble(msg, "origin::0")
+    node.handle_propagate_message(msg, _make_client("origin::0"))
+
+    assert len(sent["peer::1"]) == 1
+    fwd = sent["peer::1"][0]
+    assert fwd.msg_type == HiveMessageType.PROPAGATE, (
+        f"peer received {fwd.msg_type}, so it has nothing to re-propagate")
+    assert fwd.payload.msg_type == HiveMessageType.BUS
+
+
+def test_broadcast_fanout_keeps_the_broadcast_envelope():
+    node = _make_node()
+    sent = _wire_peers(node, "origin::0", "peer::1")
+
+    msg = HiveMessage(HiveMessageType.BROADCAST, payload=_inner("all"))
+    _deliver_preamble(msg, "origin::0")
+    node.handle_broadcast_message(msg, _make_client("origin::0"))
+
+    assert len(sent["peer::1"]) == 1
+    fwd = sent["peer::1"][0]
+    assert fwd.msg_type == HiveMessageType.BROADCAST, (
+        f"peer received {fwd.msg_type} instead of a BROADCAST envelope")
+    assert fwd.payload.msg_type == HiveMessageType.BUS
+
+
+# --- BUG 2: responses are for one peer only (NODE-1 §5.2, AGENT-1 §3) ------
+
+def _response(msg_type, originator):
+    return HiveMessage(msg_type, payload=_inner("the answer"),
+                       metadata={"query_id": "q1", "is_response": True,
+                                 "originator_peer": originator})
+
+
+def test_query_response_from_master_reaches_only_the_originator():
+    node = _make_node()
+    sent = _wire_peers(node, "asker::1", "sibling::2")
+
+    node.query_from_master(_response(HiveMessageType.QUERY, "asker::1"))
+
+    assert len(sent["asker::1"]) == 1
+    assert sent["sibling::2"] == [], (
+        "a sibling peer must never see another peer's QUERY answer")
+
+
+def test_cascade_response_from_master_reaches_only_the_originator():
+    node = _make_node()
+    node.cascade_select_callback = None
+    node._pending_cascades = {}
+    sent = _wire_peers(node, "asker::1", "sibling::2")
+
+    node.cascade_from_master(_response(HiveMessageType.CASCADE, "asker::1"))
+
+    assert len(sent["asker::1"]) == 1
+    assert sent["sibling::2"] == [], (
+        "a sibling peer must never see another peer's CASCADE answer")
+
+
+def test_query_request_from_master_still_fans_out():
+    node = _make_node()
+    sent = _wire_peers(node, "sat::1", "sat::2")
+
+    node.query_from_master(HiveMessage(HiveMessageType.QUERY,
+                                       payload=_inner("who knows?")))
+
+    assert len(sent["sat::1"]) == 1
+    assert len(sent["sat::2"]) == 1
+
+
+# --- BUG 3: loop prevention on the upstream -> downstream path (§3.4) ------
+
+def test_propagate_from_master_stamps_self_hop():
+    node = _make_node("pubkey-R")
+    sent = _wire_peers(node, "sat::1")
+
+    node.propagate_from_master(HiveMessage(HiveMessageType.PROPAGATE,
+                                           payload=_inner("down")))
+
+    sources = [hop.get("source") for hop in sent["sat::1"][0].route]
+    assert "pubkey-R" in sources, f"relay did not name itself; sources={sources}"
+
+
+def test_propagate_from_master_drops_a_looped_message():
+    node = _make_node("pubkey-R")
+    sent = _wire_peers(node, "sat::1")
+
+    msg = HiveMessage(HiveMessageType.PROPAGATE, payload=_inner("loop"))
+    msg.replace_route([{"source": "pubkey-R", "targets": ["sat::1"]}])
+    node.propagate_from_master(msg)
+
+    assert sent["sat::1"] == [], "a PROPAGATE already routed here must not be relayed"
+
+
+def test_query_from_master_drops_a_looped_request():
+    node = _make_node("pubkey-R")
+    sent = _wire_peers(node, "sat::1")
+
+    msg = HiveMessage(HiveMessageType.QUERY, payload=_inner("q"))
+    msg.replace_route([{"source": "pubkey-R", "targets": ["sat::1"]}])
+    node.query_from_master(msg)
+
+    assert sent["sat::1"] == []
+
+
+def test_cascade_from_master_drops_a_looped_request():
+    node = _make_node("pubkey-R")
+    sent = _wire_peers(node, "sat::1")
+
+    msg = HiveMessage(HiveMessageType.CASCADE, payload=_inner("c"))
+    msg.replace_route([{"source": "pubkey-R", "targets": ["sat::1"]}])
+    node.cascade_from_master(msg)
+
+    assert sent["sat::1"] == []
+
+
+# --- BUG 4: relayed envelopes keep metadata and site targeting (§3.3) ------
+
+def test_relayed_propagate_keeps_target_site_and_metadata():
+    node = _make_node()
+    captured = _upstream(node)
+
+    msg = HiveMessage(HiveMessageType.PROPAGATE, payload=_inner("sited"),
+                      target_site_id="site-b", target_pubkey="key-b",
+                      metadata={"trace": "t1"})
+    _deliver_preamble(msg, "origin::0")
+    node.handle_propagate_message(msg, _make_client("origin::0"))
+
+    assert len(captured) == 1
+    up = captured[0]
+    assert up.target_site_id == "site-b", "site targeting lost after one relay hop"
+    assert up.target_public_key == "key-b"
+    assert up.metadata == {"trace": "t1"}
+
+
+def test_relayed_escalate_keeps_target_site_and_metadata():
+    node = _make_node()
+    captured = _upstream(node)
+
+    msg = HiveMessage(HiveMessageType.ESCALATE, payload=_inner("up"),
+                      target_site_id="site-b", target_pubkey="key-b",
+                      metadata={"trace": "t2"})
+    _deliver_preamble(msg, "origin::0")
+    node.handle_escalate_message(msg, _make_client("origin::0"))
+
+    assert len(captured) == 1
+    up = captured[0]
+    assert up.target_site_id == "site-b", "site targeting lost after one relay hop"
+    assert up.target_public_key == "key-b"
+    assert up.metadata == {"trace": "t2"}
+
+
+def test_relayed_cascade_keeps_target_site():
+    node = _make_node()
+    node.cascade_select_callback = None
+    node._pending_cascades = {}
+    node.get_bus = MagicMock(return_value=MagicMock())
+    node._answer_query_locally = MagicMock(return_value=False)
+    captured = _upstream(node)
+
+    msg = HiveMessage(HiveMessageType.CASCADE, payload=_inner("c"),
+                      target_site_id="site-b",
+                      metadata={"query_id": "q1", "originator_peer": "origin::0"})
+    _deliver_preamble(msg, "origin::0")
+    node.handle_cascade_message(msg, _make_client("origin::0"))
+
+    assert len(captured) == 1
+    assert captured[0].target_site_id == "site-b"
+    assert captured[0].metadata["query_id"] == "q1"
+
+
+# --- BUG 5: the responsive PING also travels upstream (NODE-1 §4) ----------
+
+def test_responsive_ping_is_also_sent_upstream():
+    node = _make_node()
+    node.hive_mapper = MagicMock()
+    node._seen_flood_ids = set()
+    node.agent_protocol = MagicMock()
+    sent = _wire_peers(node, "sat::1")
+    captured = _upstream(node)
+
+    ping = HiveMessage(HiveMessageType.PING, payload={"flood_id": "f1",
+                                                      "peer": "sat::1"})
+    node.handle_ping_message(ping, _make_client("sat::1"))
+
+    assert len(sent["sat::1"]) == 1, "responsive PING must reach downstream peers"
+    assert len(captured) == 1, "responsive PING must also travel upstream"
+    assert captured[0].msg_type == HiveMessageType.PROPAGATE
+    assert captured[0].payload.msg_type == HiveMessageType.PING


### PR DESCRIPTION
Five related mesh-routing defects found by a HIVEMIND-NODE-1 spec-conformance audit. Each has a regression test that fails on `dev` and passes here.

## BUG 1 — PROPAGATE and BROADCAST lose their outer envelope on fan-out

`handle_propagate_message` and `handle_broadcast_message` sent each peer the inner message returned by `_unpack_message` instead of a rebuilt outer envelope. A peer received a bare `BUS`, so a second-tier node had nothing to re-propagate and the flood reached only the origin's direct peers.

**Spec:** NODE-1 §3.3 — a relay MUST preserve the envelope of any message it relays. NODE-1 §4 — PROPAGATE fans out across the whole reachable mesh.

**Fix:** both handlers rebuild the outer envelope through a new `_rewrap` helper, matching the shape `handle_cascade_message` already used.

## BUG 2 — a relay fans QUERY/CASCADE responses to every downstream node

`query_from_master` and `cascade_from_master` looped over all clients and sent, including `is_response=True` answer chunks meant for one satellite. The route-aware return path `_route_query_response` was bypassed, so one peer's answers were delivered to every sibling.

**Spec:** NODE-1 §5.2 and AGENT-1 §3 — a peer MUST NOT receive a response generated for a different peer.

**Fix:** both delegate to `_route_query_response` when `metadata["is_response"]` is set; the fan-out is kept for requests only. `_route_query_response` now accepts `client=None` for a response arriving from upstream.

## BUG 3 — loop prevention is not applied on the upstream→downstream relay path

`propagate_from_master`, `query_from_master` and `cascade_from_master` forwarded blindly: no `_is_routing_loop`, no `_append_self_hop`. The §3.4 machinery was wired only into the downstream-origin handlers, which is exactly the unbounded-loop case in a cross-connected mesh.

**Spec:** NODE-1 §3.4 — every node that forwards a routing message MUST record its passage in `route` and MUST NOT forward a message whose `route` already names it.

**Fix:** one shared `_relay_downstream` helper checks the loop, then stamps the self-hop, then fans out.

**BROADCAST is deliberately excluded.** NODE-1 §4 defines BROADCAST as a single hop to the directly connected downstream nodes, "not re-broadcast by recipients". It never travels upstream, and the only relay path (`broadcast_from_master`) is strictly upstream→downstream, so a BROADCAST cannot return to a node it already visited. Loop machinery would add route bookkeeping with nothing to detect.

## BUG 4 — relayed ESCALATE/PROPAGATE/CASCADE lose `metadata` and `target_site_id`

`escalate_to_master` and `propagate_to_master` built `HiveMessage(TYPE, payload=payload)` copying only `route`. `metadata`, `target_site_id` and `target_pubkey` are constructor-only on `HiveMessage` and were silently dropped. Site targeting reads the OUTER envelope, so a site-targeted PROPAGATE or ESCALATE stopped being deliverable to its target site after one relay hop. `cascade_to_master` kept metadata but still dropped `target_site_id`.

**Spec:** NODE-1 §3.3 — preserve the relayed envelope.

**Fix:** `_rewrap` carries all four fields. The `*_to_master` methods now take the finished envelope rather than rebuilding one from the payload, which removes the duplicated construction from four call sites.

## BUG 5 — the responsive PING never travels upstream

`handle_ping_message` sent the node's own responsive PING to downstream peers only, contradicting its own docstring ("to all peers and upstream"). The satellite side (`hivemind_bus_client/protocol.py`) does it right. A master therefore never learned of nodes below a relay via PING.

**Spec:** NODE-1 §4 — PING fans out across the mesh to map reachability.

**Fix:** the responsive PING also goes to the upstream master.

## Tests

`tests/test_mesh_routing_conformance.py` — 13 unit tests covering all five bugs, plus `tests/e2e/test_propagate_mesh_e2e.py`, a live four-node mesh (`M0 → R0 → S0`, `M0 → S1`) proving a PROPAGATE from `S1` reaches `S0` on the far side of the relay.

On `origin/dev` 12 of the 13 unit tests fail (the thirteenth guards that a non-response QUERY still fans out) and the e2e mesh test fails. On this branch the full non-e2e suite is green (161 passed, 1 skipped) and the full e2e suite is green (51 passed, 2 skipped) in about four minutes.

`tests/e2e/test_bridge1_conformance.py::test_fifo_order_relay_chain` reports XPASS. It also XPASSes on `origin/dev`, so it is pre-existing and left alone.

## AI transparency

Implemented by Claude Opus under Claude Fable 5 orchestration. The defects were found by a spec-conformance audit; BUG 1 and the empty-whitelist binary case were reproduced with running oracles (hivescope in-process topologies).