### PR TITLE
fix: isolate peer sessions and surface backend failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,10 @@ Every inbound message passes through an ordered **policy admission chain** befor
 **How it works:**
 
 1. `MessageTypeACLPolicy` is **always prepended** to the chain. Configuration cannot remove it. It enforces the per-client `allowed_types` whitelist: if `message.msg_type` is not in the client's `allowed_types`, the message is denied. `Client.is_admin` is informational and gives no admission bypass. Admins follow the whitelist like any other client (`hivemind_core/policy.py:174`).
-2. Configured plugins in `policy.chain` run after `MessageTypeACLPolicy`, in order. Each plugin can deny the message or contribute mutations applied before the next plugin runs.
-3. The chain is **always fail-closed**. Any unhandled exception in a policy becomes `Verdict.deny("policy_error", ...)`. There is no operator setting to override this (`hivemind_core/policy.py:36`).
-4. If the chain fails to build at startup, HiveMind installs a `DenyAllPolicy` fallback, which rejects every message with `code="policy_chain_unavailable"` until you fix the configuration (`hivemind_core/policy.py:151`).
+2. `DefaultSessionPolicy` is **always prepended** too, right after it. Configuration cannot remove it. It denies any non-admin client that puts the reserved `default` session id in `message.context["session"]`: that id addresses the host's own device-local session, so a peer must not write into it.
+3. Configured plugins in `policy.chain` run after the built-ins, in order. Each plugin can deny the message or contribute mutations applied before the next plugin runs.
+4. The chain is **always fail-closed**. Any unhandled exception in a policy becomes `Verdict.deny("policy_error", ...)`. There is no operator setting to override this (`hivemind_core/policy.py:36`).
+5. If the chain fails to build at startup, HiveMind installs a `DenyAllPolicy` fallback, which rejects every message with `code="policy_chain_unavailable"` until you fix the configuration (`hivemind_core/policy.py:151`).
 
 **Denied messages** get a `hive.policy.denied` BUS response with this payload:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,8 @@ HiveMindListenerProtocol   ← core router (hivemind_core/protocol.py)
    |
    +-- Auth / Handshake
    |
-   +-- PolicyChain.review()   ← MessageTypeACLPolicy (always first)
+   +-- PolicyChain.review()   ← MessageTypeACLPolicy, DefaultSessionPolicy
+   |                            (built-in, always first)
    |                          ← configured plugins (OVOSAgentPolicy, …)
    |
    +-- AgentProtocol          ← agent plugin (OVOS bus, Persona/LLM, …)
@@ -92,7 +93,9 @@ agent:
 
 1. `MessageTypeACLPolicy` runs first, always. It enforces the per-client `allowed_types`
    whitelist. Deny-by-default: an empty whitelist blocks everything.
-2. Configured plugins in `policy.chain` (e.g. `OVOSAgentPolicy` for skill/intent
+2. `DefaultSessionPolicy` runs second, always. It denies non-admin clients that inject
+   the reserved `default` session id.
+3. Configured plugins in `policy.chain` (e.g. `OVOSAgentPolicy` for skill/intent
    blacklists, custom quota or rate-limit plugins).
 
 The chain is fail-closed: any exception in a policy becomes a deny. See [policy.md](policy.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,8 +184,8 @@ Available backends:
 
 ## `policy`
 
-Configures the admission-control chain. `MessageTypeACLPolicy` is always prepended and
-cannot be removed. See [policy.md](policy.md) for the full policy chain specification.
+Configures the admission-control chain. `MessageTypeACLPolicy` and
+`DefaultSessionPolicy` are always prepended and cannot be removed. See [policy.md](policy.md) for the full policy chain specification.
 
 ```json
 "policy": {

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -225,7 +225,8 @@ my-policy = "my_package.policy:MyPolicy"
 }
 ```
 
-`MessageTypeACLPolicy` is implicit and always first. Do not list it.
+`MessageTypeACLPolicy` and `DefaultSessionPolicy` are implicit and
+always first. Do not list them.
 Full guide: [docs/policy.md](policy.md) and
 [hivemind-plugin-manager/docs/plugins/policy.md](https://github.com/JarbasHiveMind/hivemind-plugin-manager/blob/dev/docs/plugins/policy.md)
 

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -73,6 +73,11 @@ Mutation classes are agent-specific and live with the agent plugin
   payloads cross the same gate: a client with an empty whitelist is
   denied binary too. The whitelist holds message types only, so there
   is no per-`bin_type` granularity yet.
+- **`DefaultSessionPolicy`**: always present, non-removable, runs
+  second. It denies any message from a non-admin client whose
+  `context["session"]["session_id"]` is the reserved `default`. That id
+  addresses the host's own device-local session, so a peer must not be
+  able to write into it. Admins are exempt.
 - **`DenyAllPolicy`**: fail-closed fallback installed when
   `PolicyChain.from_config` raises. Denies every message and binary
   payload with `code="policy_chain_unavailable"`.
@@ -93,15 +98,16 @@ policy:
       optional: true
 ```
 
-`MessageTypeACLPolicy` is implicit and always first. Do not list it.
+`MessageTypeACLPolicy` and `DefaultSessionPolicy` are implicit and
+always first. Do not list them.
 
 ### `optional` flag
 
 Per-chain-entry `optional: true` marks the policy as non-load-bearing:
 if its `review` / `review_binary` raises, the chain logs a warning and
 treats the verdict as allow (no mutations, chain continues). The default
-is `false`, so exceptions fail closed with `policy_error`. The implicit
-`MessageTypeACLPolicy` is always mandatory and ignores this flag.
+is `false`, so exceptions fail closed with `policy_error`. The implicit built-in
+policies are always mandatory and ignore this flag.
 
 `allowed_types` is the canonical admission whitelist for a client.
 Grant message types with `hivemind-core allow-msg <msg_type> <node_id>`.
@@ -119,7 +125,8 @@ Codes returned by built-in policies and the chain runner:
 | `acl_disallowed_type` | `MessageTypeACLPolicy` | `msg_type` not in `allowed_types` |
 | `policy_error` | `PolicyChain` | A policy or mutation raised. Data carries `policy`, `error`, and optionally `mutation` |
 | `policy_chain_unavailable` | `DenyAllPolicy` | Chain construction failed at startup |
-| `session_id_default_forbidden` | `OVOSAgentPolicy` | Client tried to use the reserved `default` session id |
+| `session_id_default_forbidden` | `DefaultSessionPolicy` | Client tried to use the reserved `default` session id |
+| `backend_unavailable` | `HiveMindListenerProtocol` | The message passed admission, but the agent bus is unreachable, so nothing was forwarded. Not a policy decision — retry later |
 
 Plugin authors are free to mint their own `code` values. Reuse a
 built-in code only when the semantics match.

--- a/hivemind_core/policy.py
+++ b/hivemind_core/policy.py
@@ -23,6 +23,11 @@ from ovos_utils.log import LOG
 if TYPE_CHECKING:
     from hivemind_core.protocol import HiveMindClientConnection
 
+#: Reported to the client when a message passed admission but the agent bus
+#: behind this node is unreachable, so nothing was forwarded. Not a policy
+#: decision — the message is lost and the client should retry.
+BACKEND_UNAVAILABLE = "backend_unavailable"
+
 
 @dataclass
 class PolicyChain:
@@ -226,6 +231,35 @@ class DenyAllPolicy(PolicyPlugin):
     def review_binary(self, payload: bytes,
                        client: "HiveMindClientConnection") -> Verdict:
         return Verdict.deny(DenyCodes.POLICY_CHAIN_UNAVAILABLE, self.REASON)
+
+
+class DefaultSessionPolicy(PolicyPlugin):
+    """Built-in admission policy protecting the reserved ``"default"``
+    session. Always present in the chain — non-removable.
+
+    Every OVOS message that carries ``session_id == "default"`` updates the
+    device-local default session of the host (OVOS-SESSION-2 §5), which the
+    orchestrator owns. HIVEMIND-BRIDGE-1 §4.1 requires the bridge to deny an
+    unauthorized peer the use of that id, so non-admin clients are denied
+    here. Admins are exempt.
+
+    ``OVOSAgentPolicy`` performs the same check, but operators remove it
+    whenever they run a non-OVOS backend. The reserved id is a property of
+    the bridge, not of one agent, so the gate belongs in core.
+    """
+
+    def review(self, message: Message,
+               client: "HiveMindClientConnection") -> Verdict:
+        if client.is_admin:
+            return Verdict.allow()
+        session = (message.context or {}).get("session") or {}
+        if isinstance(session, dict) and session.get("session_id") == "default":
+            return Verdict.deny(
+                DenyCodes.SESSION_ID_DEFAULT_FORBIDDEN,
+                "non-admin clients may not inject 'default' session payloads",
+                session_id="default",
+            )
+        return Verdict.allow()
 
 
 class MessageTypeACLPolicy(PolicyPlugin):

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -63,7 +63,7 @@ from hivemind_bus_client.hive_map import HiveMapper
 from hivemind_plugin_manager.protocols import AgentProtocol, BinaryDataHandlerProtocol, ClientCallbacks
 from hivemind_plugin_manager.database import Client
 from hivemind_plugin_manager.policy import PolicyPlugin
-from hivemind_core.policy import PolicyChain
+from hivemind_core.policy import BACKEND_UNAVAILABLE, PolicyChain
 from poorman_handshake import HandShake, PasswordHandShake
 from poorman_handshake.asymmetric.utils import decrypt_RSA, load_RSA_key, verify_RSA
 
@@ -179,6 +179,10 @@ class HiveMindClientConnection:
     _resolved_user: Optional[Client] = field(default=None, init=False, repr=False)
     _resolved_user_ts: float = field(default=0.0, init=False, repr=False)
 
+    # Appended to ``peer`` when another live connection already owns the same
+    # ``name::session_id`` string. See ``handle_hello_message``.
+    _peer_suffix: str = field(default="", init=False, repr=False)
+
     def resolve_user(self, db, ttl: float = 5.0,
                      force: bool = False) -> Optional[Client]:
         """Return the cached DB row for this connection, refetching at
@@ -214,7 +218,7 @@ class HiveMindClientConnection:
     def peer(self) -> str:
         # friendly id that ovos components can use to refer to this connection
         # this is how ovos refers to connected nodes in message.context
-        return f"{self.name}::{self.sess.session_id}"
+        return f"{self.name}::{self.sess.session_id}{self._peer_suffix}"
 
     def send(self, message: HiveMessage):
         is_bin = message.msg_type == HiveMessageType.BINARY
@@ -438,38 +442,43 @@ class HiveMindListenerProtocol:
             except Exception:
                 LOG.exception(
                     "failed to build policy chain; installing DenyAllPolicy "
-                    "fallback — every admission will be rejected until "
+                    "fallback \u2014 every admission will be rejected until "
                     "configuration is fixed"
                 )
                 self.policy_chain = PolicyChain(
                     policies=[DenyAllPolicy(hm_protocol=self)],
                 )
         # every chain is normalized, including one handed to the constructor
-        # by an embedder — the ACL gate is not opt-out
-        self.policy_chain = self._with_acl_gate(self.policy_chain)
+        # by an embedder \u2014 the builtin gates are not opt-out
+        self.policy_chain = self._with_builtin_policies(self.policy_chain)
 
-    def _with_acl_gate(self, chain: PolicyChain) -> PolicyChain:
-        """Return ``chain`` with MessageTypeACLPolicy in first position.
+    def _with_builtin_policies(self, chain: PolicyChain) -> PolicyChain:
+        """Return ``chain`` with the non-removable builtin policies first.
 
         MessageTypeACLPolicy is the canonical ``allowed_types`` whitelist
-        enforcement and is non-removable, so it is prepended to whatever
-        chain we were given, deduping an explicitly listed copy so the
-        operator cannot reorder it. Always mandatory — ``_optional[0]``
-        is False, so an exception in the gate fails the chain closed.
+        enforcement; DefaultSessionPolicy protects the reserved "default"
+        session. Both are prepended to whatever chain we were given,
+        deduping an explicitly listed copy so the operator cannot reorder
+        or drop them. Always mandatory \u2014 their ``_optional`` entries are
+        False, so an exception in a gate fails the chain closed.
         """
-        from hivemind_core.policy import MessageTypeACLPolicy
+        from hivemind_core.policy import (DefaultSessionPolicy,
+                                          MessageTypeACLPolicy)
+        builtins = (MessageTypeACLPolicy, DefaultSessionPolicy)
         policies: List[PolicyPlugin] = []
         optional: List[bool] = []
         for i, p in enumerate(chain.policies):
-            if isinstance(p, MessageTypeACLPolicy):
+            if isinstance(p, builtins):
                 continue
             policies.append(p)
             optional.append(
                 chain._optional[i] if i < len(chain._optional) else False
             )
+        mandatory = [MessageTypeACLPolicy(hm_protocol=self),
+                     DefaultSessionPolicy(hm_protocol=self)]
         return PolicyChain(
-            policies=[MessageTypeACLPolicy(hm_protocol=self), *policies],
-            _optional=[False, *optional],
+            policies=[*mandatory, *policies],
+            _optional=[*[False] * len(mandatory), *optional],
             on_verdict=chain.on_verdict,
         )
 
@@ -480,7 +489,34 @@ class HiveMindListenerProtocol:
         # routing on the inject path stays transparent here.
         return self.agent_protocol.get_bus(client)
 
+    def _emit_lifecycle(self, client: HiveMindClientConnection,
+                        message: Message) -> None:
+        """Emit a connect/disconnect/error notification on the agent bus.
+
+        These are notifications about the connection, not client traffic. An
+        unreachable agent bus must not abort the handler that reports them:
+        the connection still has to be accepted, cleaned up or rejected, and
+        the peer has nothing to act on. So log and continue.
+        """
+        try:
+            self.get_bus(client).emit(message)
+        except ConnectionError as e:
+            LOG.error(f"can not emit '{message.msg_type}' for {client.peer}, "
+                      f"the agent bus is unreachable: {e}")
+
     def handle_new_client(self, client: HiveMindClientConnection):
+        # "default" is the reserved device-local session: every OVOS message
+        # carrying it writes into the orchestrator's own session store
+        # (OVOS-SESSION-2 §5). A connection is not allowed to be born in it —
+        # hivemind-websocket-protocol mints one that way as a placeholder, and
+        # HELLO is not mandatory, so without this the placeholder can reach the
+        # OVOS bus untouched (HIVEMIND-BRIDGE-1 §4.1). Admins that really want
+        # the reserved session still get it by asking for it in HELLO.
+        if client.sess.session_id == "default":
+            client.sess = Session()
+            LOG.debug(f"moved new connection off the reserved 'default' "
+                      f"session to {client.sess.session_id}")
+
         try:
             self.callbacks.on_connect(client)
         except:
@@ -504,8 +540,7 @@ class HiveMindListenerProtocol:
             {"source": client.peer},
         )
 
-        bus = self.get_bus(client)
-        bus.emit(message)
+        self._emit_lifecycle(client, message)
 
         crypto_min = (
             ProtocolVersion.ONE
@@ -626,13 +661,18 @@ class HiveMindListenerProtocol:
         if not any(conn.key == client.key for conn in self.clients.values()):
             self._last_seen_updates.pop(client.key, None)
         client.disconnect()
-        message = Message(
-            "hive.client.disconnect",
-            {"key": client.key},
-            {"source": client.peer, "session": client.sess.serialize()},
-        )
-        bus = self.get_bus(client)
-        bus.emit(message)
+        context = {"source": client.peer}
+        # never hand the reserved session of a non-admin to the OVOS bus: it
+        # would update the device-local default session (OVOS-SESSION-2 §5)
+        # on behalf of a peer that is not allowed to touch it
+        # (HIVEMIND-BRIDGE-1 §4.1). This emit is outside the policy chain.
+        if client.sess.session_id != "default" or client.is_admin:
+            context["session"] = client.sess.serialize()
+        else:
+            LOG.warning(f"not reporting the 'default' session of non-admin "
+                        f"{client.peer} on disconnect")
+        message = Message("hive.client.disconnect", {"key": client.key}, context)
+        self._emit_lifecycle(client, message)
 
     def handle_invalid_key_connected(self, client: HiveMindClientConnection):
         try:
@@ -656,8 +696,7 @@ class HiveMindListenerProtocol:
             {"error": "invalid access key", "peer": client.peer},
             {"source": client.peer},
         )
-        bus = self.get_bus(client)
-        bus.emit(message)
+        self._emit_lifecycle(client, message)
 
     def handle_invalid_protocol_version(self, client: HiveMindClientConnection):
         try:
@@ -681,8 +720,7 @@ class HiveMindListenerProtocol:
             {"error": "protocol error", "peer": client.peer},
             {"source": client.peer},
         )
-        bus = self.get_bus(client)
-        bus.emit(message)
+        self._emit_lifecycle(client, message)
 
     def handle_message(self, message: HiveMessage, client: HiveMindClientConnection):
         """
@@ -1073,6 +1111,25 @@ class HiveMindListenerProtocol:
             LOG.warning("Client requested 'default' session, but is not an administrator")
             client.disconnect()
         else:
+            # a client that HELLOs again with a different session_id leaves a
+            # stale entry behind under its old peer id — drop it, or a later
+            # connection collides with a peer that no longer exists.
+            for peer, conn in list(self.clients.items()):
+                if conn is client and peer != client.peer:
+                    self.clients.pop(peer)
+
+            # HIVEMIND-BRIDGE-1 §3: every peer needs a distinct ``source``.
+            # ``name`` comes from the access key and ``session_id`` comes from
+            # this HELLO, so two connections that share an access key can ask
+            # for the same peer string. The second one would evict the first
+            # from ``self.clients`` and then receive its responses
+            # (HIVEMIND-AGENT-1 §3). Give the newcomer a server-generated
+            # suffix instead — BRIDGE-1 §3.1 allows exactly this.
+            other = self.clients.get(client.peer)
+            if other is not None and other is not client:
+                client._peer_suffix = f"::{uuid.uuid4().hex[:8]}"
+                LOG.warning(f"peer id collision on '{other.peer}'; the new "
+                            f"connection is now known as '{client.peer}'")
             self.clients[client.peer] = client
 
     def handle_bus_message(
@@ -1547,7 +1604,15 @@ class HiveMindListenerProtocol:
                     query_id=query_id, originator_peer=originator_peer)
             collector = self._pending_cascades[query_id]
             collector.add_response(message)
-            bus = self.get_bus(self.clients[originator_peer])
+            try:
+                bus = self.get_bus(self.clients[originator_peer])
+            except ConnectionError as e:
+                # keep the collector: the responses stay queued and the next
+                # one retries once the agent bus is back
+                LOG.error(f"can not run the cascade select callback for "
+                          f"query_id={query_id}, the agent bus is "
+                          f"unreachable: {e}")
+                return
             try:
                 selected = self.cascade_select_callback(query_id, collector.responses)
                 if selected is not None:
@@ -1595,7 +1660,13 @@ class HiveMindListenerProtocol:
 
         query_id = metadata.get("query_id", str(uuid.uuid4()))
         originator_peer = metadata.get("originator_peer", client.peer)
-        bus = self.get_bus(client)
+        try:
+            bus = self.get_bus(client)
+        except ConnectionError as e:
+            # without the agent bus this node can not answer the query at
+            # all; tell the originator instead of dropping it in silence
+            self._send_backend_unavailable(client, message, e)
+            return
         bus.emit(Message("hive.query.received",
                          {"query_id": query_id, "originator_peer": originator_peer},
                          {"source": client.peer}))
@@ -1659,7 +1730,11 @@ class HiveMindListenerProtocol:
 
         query_id = metadata.get("query_id", str(uuid.uuid4()))
         originator_peer = metadata.get("originator_peer", client.peer)
-        bus = self.get_bus(client)
+        try:
+            bus = self.get_bus(client)
+        except ConnectionError as e:
+            self._send_backend_unavailable(client, message, e)
+            return
         bus.emit(Message("hive.cascade.received",
                          {"query_id": query_id, "originator_peer": originator_peer},
                          {"source": client.peer}))
@@ -1906,7 +1981,15 @@ class HiveMindListenerProtocol:
         message.context["peer"] = message.context["source"] = client.peer
         message.context["source"] = client.peer
 
-        bus = self.get_bus(client)
+        try:
+            bus = self.get_bus(client)
+        except ConnectionError as e:
+            # the chain already admitted this message — the peer must hear
+            # that it was not delivered instead of waiting for an answer
+            # that will never come. observe() stays unrun: nothing was
+            # forwarded, so there is nothing to observe.
+            self._send_backend_unavailable(client, message, e)
+            return
         bus.emit(message)
 
         self.policy_chain.observe(message, client)
@@ -1917,13 +2000,29 @@ class HiveMindListenerProtocol:
     def _send_policy_denied(self, client: HiveMindClientConnection,
                              message: Message, verdict) -> None:
         """Inform a client that an admission policy denied their message."""
+        self._send_denied(client, getattr(message, "msg_type", None),
+                          verdict.code, verdict.reason, verdict.data)
+
+    def _send_backend_unavailable(self, client: HiveMindClientConnection,
+                                  message: Union[Message, HiveMessage],
+                                  error: Exception) -> None:
+        """Inform a client that its message was admitted but could not be
+        delivered, because the agent bus behind this node is unreachable."""
+        msg_type = str(message.msg_type)
+        LOG.error(f"can not forward '{msg_type}' from {client.peer}, "
+                  f"the agent bus is unreachable: {error}")
+        self._send_denied(client, msg_type, BACKEND_UNAVAILABLE, str(error), {})
+
+    def _send_denied(self, client: HiveMindClientConnection,
+                     denied_type: Optional[str], code: str, reason: str,
+                     data: dict) -> None:
         payload = Message(
             "hive.policy.denied",
             {
-                "denied_type": getattr(message, "msg_type", None),
-                "code": verdict.code,
-                "reason": verdict.reason,
-                "data": verdict.data,
+                "denied_type": denied_type,
+                "code": code,
+                "reason": reason,
+                "data": data,
             },
             {"source": "hivemind-core", "destination": client.peer},
         )

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -647,11 +647,12 @@ def policy_group():
 
 @policy_group.command(name="list", help="Print the loaded policy chain.")
 def policy_list():
-    """List ``MessageTypeACLPolicy`` (always first, non-removable) followed
+    """List the built-in policies (always first, non-removable) followed
     by every plugin built from ``policy.chain`` in server config."""
-    from hivemind_core.policy import MessageTypeACLPolicy, PolicyChain
+    from hivemind_core.policy import (DefaultSessionPolicy,
+                                      MessageTypeACLPolicy, PolicyChain)
     cfg = get_server_config()
-    builtin = MessageTypeACLPolicy()
+    builtins = [MessageTypeACLPolicy(), DefaultSessionPolicy()]
     try:
         chain = PolicyChain.from_config(cfg)
     except Exception as e:
@@ -661,8 +662,9 @@ def policy_list():
     table.add_column("Position", justify="right", style="cyan")
     table.add_column("Plugin", style="magenta")
     table.add_column("Source", style="yellow")
-    table.add_row("0", type(builtin).__name__, "builtin")
-    for i, plug in enumerate(chain.policies, start=1):
+    for i, plug in enumerate(builtins):
+        table.add_row(str(i), type(plug).__name__, "builtin")
+    for i, plug in enumerate(chain.policies, start=len(builtins)):
         table.add_row(str(i), type(plug).__name__, "config")
     Console().print(table)
 
@@ -672,17 +674,18 @@ def policy_list():
 @click.argument("msg_type", required=True, type=str)
 def policy_test(api_key, msg_type):
     """Construct a fake ``Message`` of ``msg_type``, look up the client by
-    ``api_key``, run the full chain (MessageTypeACLPolicy + configured
+    ``api_key``, run the full chain (built-in policies + configured
     plugins), and print the verdict."""
     from ovos_bus_client.message import Message
-    from hivemind_core.policy import MessageTypeACLPolicy, PolicyChain
+    from hivemind_core.policy import (DefaultSessionPolicy,
+                                      MessageTypeACLPolicy, PolicyChain)
     db = ClientDatabase()
     client = db.get_client_by_api_key(api_key)
     if client is None:
         click.echo(f"no client found for api_key={api_key!r}", err=True)
         raise click.Abort()
     cfg = get_server_config()
-    policies = [MessageTypeACLPolicy()]
+    policies = [MessageTypeACLPolicy(), DefaultSessionPolicy()]
     try:
         chain = PolicyChain.from_config(cfg)
         policies.extend(chain.policies)

--- a/tests/e2e/test_policy_admission.py
+++ b/tests/e2e/test_policy_admission.py
@@ -75,18 +75,22 @@ def _swap_chain(master, configured_entries):
     """Replace the in-memory policy chain on an already-built master.
 
     Mirrors ``HiveMindListenerProtocol.__post_init__`` semantics:
-    always prepends a ``MessageTypeACLPolicy`` to the configured chain so
-    the allowed_types whitelist is never bypassable.
+    always prepends the non-removable built-ins (MessageTypeACLPolicy,
+    DefaultSessionPolicy) to the configured chain, so the allowed_types
+    whitelist and the reserved-session gate are never bypassable.
     """
-    from hivemind_core.policy import MessageTypeACLPolicy, PolicyChain
+    from hivemind_core.policy import (DefaultSessionPolicy,
+                                      MessageTypeACLPolicy, PolicyChain)
     chain = PolicyChain.from_config(
         {"policy": {"chain": configured_entries}},
         hm_protocol=master.hm_protocol,
     )
-    configured = [p for p in chain.policies
-                  if not isinstance(p, MessageTypeACLPolicy)]
+    builtins = (MessageTypeACLPolicy, DefaultSessionPolicy)
+    configured = [p for p in chain.policies if not isinstance(p, builtins)]
     master.hm_protocol.policy_chain = PolicyChain(
-        policies=[MessageTypeACLPolicy(hm_protocol=master.hm_protocol), *configured],
+        policies=[MessageTypeACLPolicy(hm_protocol=master.hm_protocol),
+                  DefaultSessionPolicy(hm_protocol=master.hm_protocol),
+                  *configured],
     )
 
 

--- a/tests/test_backend_unavailable.py
+++ b/tests/test_backend_unavailable.py
@@ -1,0 +1,131 @@
+"""The agent bus can be unreachable: ``get_bus`` raises ``ConnectionError``.
+
+A message that the policy chain already admitted must never disappear in
+silence — the originating peer gets an explicit ``backend_unavailable``
+denial. Lifecycle handlers log and continue instead, so a dead OVOS bus
+does not break connect/disconnect bookkeeping.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivemind_bus_client import HiveMessage, HiveMessageType
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+
+def _make_protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.side_effect = ConnectionError("no OVOS messagebus")
+    agent.callbacks = MagicMock()
+
+    db_user = MagicMock()
+    db_user.allowed_types = ["recognizer_loop:utterance"]
+    db_user.is_admin = False
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+
+
+def _make_client(protocol):
+    client = HiveMindClientConnection(
+        key="test-key",
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+        sess=Session("a-session"),
+    )
+    client.name = "test-client"
+    client.allowed_types = ["recognizer_loop:utterance"]
+    client.crypto_key = None
+    return client
+
+
+def _sent_denials(client):
+    return [c.args[0] for c in client.send_msg.call_args_list]
+
+
+def _denial_codes(client):
+    codes = []
+    for raw in _sent_denials(client):
+        if "hive.policy.denied" in str(raw):
+            codes.append(raw)
+    return codes
+
+
+class TestBackendUnavailable(unittest.TestCase):
+    def test_inject_tells_the_peer_the_backend_is_down(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+        message = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
+                          {"session": {"session_id": "a-session"}})
+
+        protocol.handle_inject_agent_msg(message, client)
+
+        sent = "".join(str(c.args[0]) for c in client.send_msg.call_args_list)
+        self.assertIn("hive.policy.denied", sent)
+        self.assertIn("backend_unavailable", sent)
+
+    def test_query_tells_the_peer_the_backend_is_down(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+        bus_msg = Message("recognizer_loop:utterance", {"utterances": ["hi"]})
+        message = HiveMessage(HiveMessageType.QUERY,
+                              payload=HiveMessage(HiveMessageType.BUS, bus_msg))
+
+        protocol.handle_query_message(message, client)
+
+        sent = "".join(str(c.args[0]) for c in client.send_msg.call_args_list)
+        self.assertIn("backend_unavailable", sent)
+
+    def test_cascade_tells_the_peer_the_backend_is_down(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+        bus_msg = Message("recognizer_loop:utterance", {"utterances": ["hi"]})
+        message = HiveMessage(HiveMessageType.CASCADE,
+                              payload=HiveMessage(HiveMessageType.BUS, bus_msg))
+
+        protocol.handle_cascade_message(message, client)
+
+        sent = "".join(str(c.args[0]) for c in client.send_msg.call_args_list)
+        self.assertIn("backend_unavailable", sent)
+
+    def test_disconnect_survives_a_dead_backend(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+
+        protocol.handle_client_disconnected(client)  # must not raise
+
+        client.disconnect.assert_called_once()
+
+    def test_new_client_survives_a_dead_backend(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+
+        protocol.handle_new_client(client)  # must not raise
+
+        # the unreachable bus was tried, and the handler carried on
+        protocol.agent_protocol.get_bus.assert_called_once_with(client)
+
+    def test_invalid_key_survives_a_dead_backend(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+
+        protocol.handle_invalid_key_connected(client)  # must not raise
+
+    def test_invalid_protocol_survives_a_dead_backend(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+
+        protocol.handle_invalid_protocol_version(client)  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_last_seen_debounce.py
+++ b/tests/test_last_seen_debounce.py
@@ -46,7 +46,9 @@ def _client(peer="peer", key="access-key"):
         disconnect=MagicMock(),
         key=key,
         peer=peer,
-        sess=SimpleNamespace(serialize=MagicMock(return_value={})),
+        is_admin=False,
+        sess=SimpleNamespace(session_id="a-session",
+                             serialize=MagicMock(return_value={})),
     )
 
 

--- a/tests/test_policy_chain.py
+++ b/tests/test_policy_chain.py
@@ -24,7 +24,8 @@ from unittest.mock import MagicMock, patch
 from hivemind_plugin_manager import Mutation, PolicyPlugin, Verdict
 from ovos_bus_client.message import Message
 
-from hivemind_core.policy import MessageTypeACLPolicy, DenyAllPolicy, PolicyChain
+from hivemind_core.policy import (MessageTypeACLPolicy, DefaultSessionPolicy,
+                                  DenyAllPolicy, PolicyChain)
 
 
 class AddBlacklistedSkill(Mutation):
@@ -942,9 +943,12 @@ class TestProtocolWiring(unittest.TestCase):
 
 
 class TestACLGateIsNonRemovable(unittest.TestCase):
-    """POLICY-1 §4: the ACL gate is always present, always first, and
-    cannot be removed or reordered — including by an embedder that
-    hands HiveMindListenerProtocol a ready-made chain."""
+    """POLICY-1 §4: the built-in gates are always present, always first,
+    and cannot be removed or reordered — including by an embedder that
+    hands HiveMindListenerProtocol a ready-made chain.
+
+    The built-ins are MessageTypeACLPolicy (allowed_types whitelist) and
+    DefaultSessionPolicy (reserved "default" session), in that order."""
 
     def _make_protocol(self, policy_chain, db=None):
         from unittest.mock import MagicMock
@@ -969,16 +973,21 @@ class TestACLGateIsNonRemovable(unittest.TestCase):
         proto = self._make_protocol(PolicyChain(policies=[supplied]))
         chain = proto.policy_chain
         self.assertIsInstance(chain.policies[0], MessageTypeACLPolicy)
-        self.assertIs(chain.policies[1], supplied)
+        self.assertIsInstance(chain.policies[1], DefaultSessionPolicy)
+        self.assertIs(chain.policies[2], supplied)
         self.assertFalse(chain._optional[0])
+        self.assertFalse(chain._optional[1])
 
     def test_supplied_chain_cannot_reorder_the_acl_gate(self):
         supplied = _AllowPolicy()
         proto = self._make_protocol(
-            PolicyChain(policies=[supplied, MessageTypeACLPolicy()])
+            PolicyChain(policies=[DefaultSessionPolicy(), supplied,
+                                  MessageTypeACLPolicy()])
         )
         kinds = [type(p) for p in proto.policy_chain.policies]
-        self.assertEqual(kinds, [MessageTypeACLPolicy, _AllowPolicy])
+        self.assertEqual(
+            kinds, [MessageTypeACLPolicy, DefaultSessionPolicy, _AllowPolicy]
+        )
 
     def test_supplied_chain_gate_denies_empty_whitelist(self):
         proto = self._make_protocol(PolicyChain(policies=[_AllowPolicy()]))

--- a/tests/test_session_isolation.py
+++ b/tests/test_session_isolation.py
@@ -1,0 +1,159 @@
+"""Session isolation between peers.
+
+Covers two related defects:
+
+* the reserved ``"default"`` session must never reach the OVOS bus on behalf
+  of an unauthorized peer (HIVEMIND-BRIDGE-1 §4.1, OVOS-SESSION-2 §5);
+* ``peer`` must be unique per connection so two clients can not collide and
+  cross-deliver each other's responses (HIVEMIND-BRIDGE-1 §3,
+  HIVEMIND-AGENT-1 §3).
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+
+def _make_protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.return_value = agent.bus
+    agent.callbacks = MagicMock()
+
+    db_user = MagicMock()
+    db_user.allowed_types = ["recognizer_loop:utterance"]
+    db_user.is_admin = False
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+
+
+def _drop_configured_policies(protocol):
+    """Keep only the built-in, non-removable policies.
+
+    Models an operator running a non-OVOS backend: everything the operator
+    listed in ``policy.chain`` (OVOSAgentPolicy included) is gone.
+    """
+    import hivemind_core.policy as builtins
+    keep = [p for p in protocol.policy_chain.policies
+            if type(p).__module__ == builtins.__name__]
+    protocol.policy_chain.policies = keep
+    protocol.policy_chain._optional = [False] * len(keep)
+
+
+def _make_client(protocol, sess, key="test-key", name="test-client"):
+    client = HiveMindClientConnection(
+        key=key,
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+        sess=sess,
+    )
+    client.name = name
+    client.allowed_types = ["recognizer_loop:utterance"]
+    return client
+
+
+class TestReservedDefaultSession(unittest.TestCase):
+    def test_new_connection_never_stays_in_the_reserved_session(self):
+        # the websocket plugin mints every connection with
+        # Session(session_id="default"); core must move it off the reserved
+        # id before anything can be emitted under it.
+        protocol = _make_protocol()
+        client = _make_client(protocol, Session(session_id="default"))
+
+        protocol.handle_new_client(client)
+
+        self.assertNotEqual(client.sess.session_id, "default")
+
+    def test_disconnect_does_not_leak_a_default_session_of_a_non_admin(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, Session(session_id="default"))
+        client.is_admin = False
+
+        protocol.handle_client_disconnected(client)
+
+        emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
+        self.assertEqual(emitted.msg_type, "hive.client.disconnect")
+        self.assertNotIn("session", emitted.context)
+
+    def test_disconnect_keeps_the_session_of_an_admin(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, Session(session_id="default"))
+        client.is_admin = True
+
+        protocol.handle_client_disconnected(client)
+
+        emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
+        self.assertEqual(emitted.context["session"]["session_id"], "default")
+
+    def test_core_policy_chain_denies_a_non_admin_default_session(self):
+        # the gate must live in core, next to the force-prepended
+        # MessageTypeACLPolicy, not only in the removable OVOSAgentPolicy.
+        protocol = _make_protocol()
+        _drop_configured_policies(protocol)
+        client = _make_client(protocol, Session(session_id="a-session"))
+        client.is_admin = False
+        message = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
+                          {"session": {"session_id": "default"}})
+
+        verdict = protocol.policy_chain.review(message, client)
+
+        self.assertTrue(verdict.denied)
+        self.assertEqual(verdict.code, "session_id_default_forbidden")
+
+    def test_core_policy_chain_allows_an_admin_default_session(self):
+        protocol = _make_protocol()
+        _drop_configured_policies(protocol)
+        client = _make_client(protocol, Session(session_id="a-session"))
+        client.is_admin = True
+        message = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
+                          {"session": {"session_id": "default"}})
+
+        verdict = protocol.policy_chain.review(message, client)
+
+        self.assertFalse(verdict.denied)
+
+
+class TestPeerUniqueness(unittest.TestCase):
+    def _hello(self, protocol, client, session_id):
+        from hivemind_bus_client import HiveMessage, HiveMessageType
+        payload = {"session": Session(session_id).serialize()}
+        protocol.handle_hello_message(
+            HiveMessage(HiveMessageType.HELLO, payload), client)
+
+    def test_two_connections_with_the_same_name_and_session_do_not_collide(self):
+        protocol = _make_protocol()
+        first = _make_client(protocol, Session("conn-1"))
+        second = _make_client(protocol, Session("conn-2"))
+
+        self._hello(protocol, first, "shared-session")
+        self._hello(protocol, second, "shared-session")
+
+        self.assertNotEqual(first.peer, second.peer)
+        self.assertEqual(len(protocol.clients), 2)
+        self.assertIs(protocol.clients[first.peer], first)
+        self.assertIs(protocol.clients[second.peer], second)
+
+    def test_a_client_can_hello_twice_without_being_renamed(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol, Session("conn-1"))
+
+        self._hello(protocol, client, "my-session")
+        peer = client.peer
+        self._hello(protocol, client, "my-session")
+
+        self.assertEqual(client.peer, peer)
+        self.assertEqual(list(protocol.clients), [peer])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three defects found by a spec-conformance audit of the bridge against
HIVEMIND-BRIDGE-1, HIVEMIND-AGENT-1 and OVOS-SESSION-2. They are related
(all three are about what a peer can reach on the host bus), so they ship
together.

## 1. The reserved `default` session reached the OVOS bus from an unauthenticated peer

**Spec:** HIVEMIND-BRIDGE-1 §4.1 — deny an unauthorized peer the use of the
reserved session id. OVOS-SESSION-2 §5 — every inbound message with
`session_id == "default"` updates the authoritative device-local session
store of the host.

**Problem:** `hivemind-websocket-protocol` mints every connection with
`Session(session_id="default")` as a placeholder ("will be re-assigned once
client sends handshake"). HELLO is not mandatory: `handle_message`
dispatches BUS/BINARY/QUERY with no "has this client said HELLO" gate, and
the only reassignment happens in `handle_hello_message`. A client that never
says HELLO therefore stays in the reserved session for its whole life.
`handle_client_disconnected` then emitted `hive.client.disconnect` with
`session: client.sess.serialize()` onto the host bus, unconditionally and
outside the policy chain, so a peer that never authenticated itself wrote
into orchestrator-owned state.

**Fix:**

- `handle_new_client` moves a connection off the reserved id onto a fresh
  `Session()` before anything else runs. Nothing depends on the placeholder
  being literally `"default"`; an admin that wants the reserved session
  still asks for it in HELLO, where the existing admin check applies.
- `handle_client_disconnected` omits the session field when a non-admin
  connection is still in the reserved session.
- New built-in `DefaultSessionPolicy` enforces the reserved id for every
  admitted message. It is force-prepended next to `MessageTypeACLPolicy`
  and cannot be removed by configuration.

On that last point: the check previously existed **only** in
`OVOSAgentPolicy` (`hivemind_ovos_agent_plugin/policy.py`), which operators
drop whenever they run a non-OVOS backend — the gate disappeared with it.
The reserved id is a property of the bridge, not of one agent, so it is now
a core gate. `OVOSAgentPolicy` keeps its own copy; the two agree, and the
core one runs first.

**Companion change needed in `hivemind-websocket-protocol`:** the
placeholder at `hivemind_websocket_protocol/__init__.py:188` should be a
plain `Session()` instead of `Session(session_id="default")`. Core no longer
trusts it either way, but the placeholder is misleading and any other
consumer of that connection object inherits the same trap.

## 2. `peer` was not unique, so two connections could collide and cross-deliver responses

**Spec:** HIVEMIND-BRIDGE-1 §3 — distinct `source` per peer.
HIVEMIND-AGENT-1 §3 — a peer must never receive another peer's response.
OVOS-BRIDGE-1 §3.1 prescribes the remedy: use the client id verbatim "or
prefix it to guarantee uniqueness".

**Problem:** `peer` is `f"{name}::{session_id}"`. `name` comes from the
access key's DB row, `session_id` is chosen by the client in HELLO. Two
connections sharing an access key that HELLO with the same `session_id`
produce a byte-identical `peer`. `self.clients` is keyed on it and nothing
checked for an existing entry, so the second connection silently evicted the
first, and the agent then delivered the first peer's responses to the
second.

**Fix:** `handle_hello_message` detects the collision at registration time
and gives the newcomer a server-generated `::<uuid4-hex8>` suffix. All
`.peer` consumers were checked: everything resolves peers through
`client.peer` or through `self.clients` keys, both of which stay consistent
because `peer` is a property computed from the suffix. Registration also
drops the stale `self.clients` entry that a re-HELLO with a new
`session_id` used to leave behind — otherwise a later connection collides
with a peer that no longer exists.

## 3. `get_bus()` can raise `ConnectionError` and no caller handled it

Introduced by #29: the OVOS agent plugin's `get_bus` raises `ConnectionError`
when the OVOS messagebus does not reconnect within the timeout. hivemind-core
called it in eight places, none guarded. The exception escaped
`handle_new_client` (out of the websocket `open`), `handle_client_disconnected`
(out of `on_close`) and `handle_inject_agent_msg` (out of `on_message`) — in
that last case **after** `policy_chain.review` had already allowed the
message, so the peer got neither an answer nor a denial, `observe` never ran,
and the message was lost with no signal at all.

**Fix:**

- Inject, QUERY and CASCADE answer the originating peer with the existing
  `hive.policy.denied` shape carrying the new stable code
  `backend_unavailable`. On the inject path `observe` is deliberately not
  run: nothing was forwarded, so there is nothing to observe.
- Lifecycle notifications (`hive.client.connect`, `hive.client.disconnect`,
  the two `hive.client.connection.error` emits) log and continue via a new
  `_emit_lifecycle` helper. These describe the connection, not client
  traffic: the connection still has to be accepted, cleaned up or rejected
  whether or not the notification lands, and the peer has nothing to act on.
  Aborting a disconnect handler because the bus is down would leak the
  connection from `self.clients`.
- The CASCADE select-callback path keeps its collector and returns, so the
  queued responses are retried by the next response once the bus is back.

## Back-compat impact

- **Peer ids.** Unchanged in the normal case; only a colliding second
  connection gets a suffix, and it was broken before. Anything that assumed
  `peer` parses as exactly `name::session_id` must tolerate a third segment.
- **`hive.client.disconnect`.** The `session` field is now absent for a
  non-admin connection still in the reserved session. It carried `"default"`
  before, which was the bug.
- **Connection sessions.** A client that never sends HELLO now has a random
  session id instead of `"default"`. This is the intended behaviour of the
  placeholder.
- **Policy chain.** One more non-removable built-in. Operators who listed
  `DefaultSessionPolicy` explicitly are deduped like `MessageTypeACLPolicy`.
  `hivemind-core policy list` and `policy test` show both built-ins.
- **New deny code** `backend_unavailable` on the existing
  `hive.policy.denied` message. Clients that do not know the code see an
  unknown denial rather than silence.

## Tests

`tests/test_session_isolation.py` (7) and `tests/test_backend_unavailable.py`
(7), plus a fixture fix in `tests/test_last_seen_debounce.py` whose fake
client lacked `session_id`/`is_admin`. 11 of the 14 new tests fail on
`origin/dev`; the full non-e2e suite is green (162 passed, 1 skipped).

## AI transparency

Implemented by Claude Opus under Claude Fable 5 orchestration. The three
defects were found by a spec-conformance audit, not by a runtime incident.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added protection for the reserved `default` session, restricting access to administrators.
  - Added clearer client status reporting when the backend is unavailable.
  - Improved connection handling for duplicate peer names and unavailable backends.
  - Policy tools now display and enforce built-in policies automatically.

- **Documentation**
  - Updated policy, configuration, architecture, and extension guidance to explain mandatory built-in policies and denial statuses.

- **Bug Fixes**
  - Improved session isolation and lifecycle handling during connection, disconnection, and backend failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->