### PR TITLE
docs: correct stale CLI, config, and protocol claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ For more details and demonstrations, check the [YouTube channel](https://www.you
    * [Quick Start](#quick-start)
       + [Installation](#installation)
       + [Adding a Satellite](#adding-a-satellite)
+      + [Granting Message Types](#granting-message-types)
       + [Running the Server](#running-the-server)
    * [Commands Overview](#commands-overview)
    * [Plugins Overview](#plugins-overview)
@@ -100,7 +101,7 @@ The default configuration:
 }
 ```
 
-> **Default backend:** fresh installs use **SQLite** (transactional, concurrency-safe, stdlib). An existing JSON deployment (a `clients.json` already on disk) keeps using JSON, so upgrades never strand the credentials store. Move an existing store with `hivemind-core migrate-db --to sqlite` (also supports `--from`/`--to` for JSON ⇄ SQLite ⇄ Redis).
+> **Default backend:** fresh installs use **SQLite** (transactional, concurrency-safe, stdlib). An existing JSON deployment (a `clients.json` already on disk) keeps using JSON, so upgrades never strand the credentials store. Move an existing store with `hivemind-core migrate-db --from hivemind-json-db-plugin --to hivemind-sqlite-db-plugin`. Both flags take a database plugin entry-point name, so the same command moves a store between JSON, SQLite, and Redis.
 
 ### Policy Admission Chain
 
@@ -108,11 +109,11 @@ Every inbound message passes through an ordered **policy admission chain** befor
 
 **How it works:**
 
-1. `MessageTypeACLPolicy` is **always prepended** to the chain. Configuration cannot remove it. It enforces the per-client `allowed_types` whitelist: if `message.msg_type` is not in the client's `allowed_types`, the message is denied. `Client.is_admin` is informational and gives no admission bypass. Admins follow the whitelist like any other client (`hivemind_core/policy.py:174`).
+1. `MessageTypeACLPolicy` is **always prepended** to the chain. Configuration cannot remove it. It enforces the per-client `allowed_types` whitelist: if `message.msg_type` is not in the client's `allowed_types`, the message is denied. Binary payloads cross the same gate, so an empty whitelist denies binary too. A failed database lookup denies with `policy_error`. `Client.is_admin` is informational and gives no admission bypass. Admins follow the whitelist like any other client (`MessageTypeACLPolicy` in `hivemind_core/policy.py`).
 2. `DefaultSessionPolicy` is **always prepended** too, right after it. Configuration cannot remove it. It denies any non-admin client that puts the reserved `default` session id in `message.context["session"]`: that id addresses the host's own device-local session, so a peer must not write into it.
 3. Configured plugins in `policy.chain` run after the built-ins, in order. Each plugin can deny the message or contribute mutations applied before the next plugin runs.
-4. The chain is **always fail-closed**. Any unhandled exception in a policy becomes `Verdict.deny("policy_error", ...)`. There is no operator setting to override this (`hivemind_core/policy.py:36`).
-5. If the chain fails to build at startup, HiveMind installs a `DenyAllPolicy` fallback, which rejects every message with `code="policy_chain_unavailable"` until you fix the configuration (`hivemind_core/policy.py:151`).
+4. The chain is **fail-closed by default**. An unhandled exception in a policy becomes `Verdict.deny("policy_error", ...)` (`PolicyChain.review` in `hivemind_core/policy.py`). Mark a single chain entry with `"optional": true` to make the chain log a warning and continue instead. The two built-in policies ignore that flag and stay mandatory.
+5. If the chain fails to build at startup, HiveMind installs a `DenyAllPolicy` fallback, which rejects every message with `code="policy_chain_unavailable"` until you fix the configuration (`DenyAllPolicy` in `hivemind_core/policy.py`).
 
 **Denied messages** get a `hive.policy.denied` BUS response with this payload:
 
@@ -125,11 +126,11 @@ Every inbound message passes through an ordered **policy admission chain** befor
 }
 ```
 
-`handle_inject_agent_msg` runs `policy_chain.review()` then `policy_chain.observe()` for every accepted message. `handle_binary_message` runs `policy_chain.review_binary()` (`hivemind_core/protocol.py:908`, `hivemind_core/protocol.py:457`).
+`handle_inject_agent_msg` runs `policy_chain.review()` then `policy_chain.observe()` for every accepted message. `handle_binary_message` runs `policy_chain.review_binary()` (both in `hivemind_core/protocol.py`).
 
 **ACL model: whitelist-only, deny-by-default**
 
-- `allowed_types` is the only ACL field on `HiveMindClientConnection`. There is no message blacklist (`hivemind_core/protocol.py:92`).
+- `allowed_types` is the only ACL field on `HiveMindClientConnection`. There is no message blacklist (`HiveMindClientConnection` in `hivemind_core/protocol.py`).
 - A freshly created client (via `add-client`) has an **empty** `allowed_types` list. HiveMind denies it all messages until the operator explicitly grants types with `allow-msg`. This applies to admin clients too. `Client.is_admin` is informational only and gives no admission bypass.
 
 To grant a message type:
@@ -179,7 +180,7 @@ pip install hivemind-core
 Add credentials for each satellite device:
 
 ```bash
-$ hivemind-core add-client --db-backend sqlite 
+$ hivemind-core add-client --name "HiveMind-Node-2"
 Database backend: SQLiteDB
 Credentials added to database!
 
@@ -192,6 +193,19 @@ WARNING: Encryption Key is deprecated, only use if your client does not support 
 ```
 
 **NOTE**: You must provide this information on the client devices so they can connect.
+
+### Granting Message Types
+
+A new client starts with an **empty** `allowed_types` whitelist. The server denies every
+message, and every binary payload, from that client until you grant the types it needs:
+
+```bash
+$ hivemind-core allow-msg "recognizer_loop:utterance" 3
+$ hivemind-core allow-msg "speak" 3
+```
+
+If you skip this step, the client connects and then gets a `hive.policy.denied` answer to
+each message.
 
 ### Running the Server
 
@@ -233,6 +247,11 @@ Commands:
   blacklist-intent     blacklist an intent for a client (OVOS-policy)
   blacklist-skill      blacklist a skill for a client (OVOS-policy)
   set-metadata         set arbitrary metadata on a client (read by policy plugins)
+  derive-psk           derive a pre-shared key from a site password and node id
+  export-clients       export clients and credentials to a CSV file
+  migrate-db           copy all clients from one database backend to another
+  policy               inspect the policy admission chain
+  print-config         print the server configuration
 ```
 
 For detailed help on each command, use `--help` (for example, `hivemind-core add-client --help`).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,17 +45,18 @@ messages). Responses from the agent travel back through the same path.
 | Type | Direction | Purpose |
 |---|---|---|
 | `HANDSHAKE` | bidirectional | Cipher/key negotiation on connect |
-| `HELLO` | server → satellite | Server identity announcement |
+| `HELLO` | bidirectional | Identity announcement. The server sends its pubkey and peer id; the client answers with its session, site id, and pubkey |
 | `BUS` | bidirectional | Wraps an OVOS `Message`; the most common type |
 | `SHARED_BUS` | server → satellite | Bus event pushed to satellite |
 | `BROADCAST` | satellite → server | Deliver to all connected satellites |
 | `PROPAGATE` | satellite → server | Forward upstream to the parent server |
 | `ESCALATE` | satellite → server | Forward up the relay chain |
-| `PING` | bidirectional | Keepalive |
+| `PING` | bidirectional | Topology discovery flood. Each node answers with its own PING carrying the same `flood_id`. There is no PONG |
 | `QUERY` | satellite → server | Natural-language query. The server streams answer chunks |
 | `CASCADE` | server → satellite(s) | Scatter/gather: distributes a query across children |
 | `INTERCOM` | bidirectional | Signed/encrypted end-to-end peer message |
-| `BINARY` | bidirectional | Raw bytes (audio, image, file) |
+| `BINARY` | bidirectional | Raw bytes (audio, image, file). Crosses the same `allowed_types` gate as `BUS` |
+| `THIRDPRTY` | bidirectional | User-land message. HiveMind carries it and does nothing else with it |
 
 ### QUERY / CASCADE streaming
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -31,7 +31,9 @@ hivemind-core blacklist-skill "mycroft-weather.mycroftai" 1
 
 ### Allowing Messages
 
-New clients start with an empty `allowed_types` whitelist and are denied all messages. To let a client receive `speak` messages:
+New clients start with an empty `allowed_types` whitelist. The server denies every
+message, and every binary payload, that such a client sends. To let a client send `speak`
+messages:
 
 ```bash
 hivemind-core allow-msg "speak" 1

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,7 +25,12 @@ Commands:
   blacklist-intent    Add an intent to OVOSAgentPolicy's intent_blacklist (via metadata)
   allow-intent        Remove an intent from OVOSAgentPolicy's intent_blacklist (via metadata)
   set-metadata        Set arbitrary Client.metadata keys
-  migrate-db          Migrate the client database between backends
+  migrate-db          Copy all clients from one database backend to another
+  export-clients      Export clients and credentials to a CSV file
+  derive-psk          Derive a pre-shared key from a site password and node id
+  print-config        Print the server configuration as JSON
+  policy list         Print the loaded policy chain
+  policy test         Dry-run a message through the policy chain
 ```
 
 ---
@@ -62,8 +67,11 @@ Options:
 | `--access-key TEXT` | random | API key the satellite presents on connect |
 | `--password TEXT` | random | Used for key derivation |
 | `--crypto-key TEXT` | random | Legacy encryption key (deprecated; only for old clients without password support) |
-| `--db-backend TEXT` | from config | Override the database backend for this command |
+| `--admin BOOL` | `False` | Mark the client as an administrator. Informational: it grants no admission bypass |
 | `--metadata JSON` | `{}` | Initial `Client.metadata` as a JSON object |
+| `--allow-weak-password` | off | Accept a password below `min_password_bits` |
+
+The database backend comes from `server.json`. There is no per-command override flag.
 
 A freshly created client has an **empty** `allowed_types` whitelist. It is denied all
 messages until you run `allow-msg`.
@@ -90,7 +98,7 @@ hivemind-core rename-client "new name" 1
 
 ## `delete-client`
 
-Revoke a client's credentials. The row is replaced with a tombstone (prevents ID reuse).
+Revoke a client's credentials. The row is deleted from the database.
 
 ```bash
 hivemind-core delete-client 1
@@ -125,7 +133,10 @@ hivemind-core allow-msg "speak" 1
 hivemind-core blacklist-msg "speak" 1
 ```
 
-Changes take effect on the **next** message from that client; no reconnect required.
+Binary payloads cross the same gate. A client with an empty whitelist cannot send audio,
+images, or files either.
+
+Changes take effect on the **next** message from that client. No reconnect is needed.
 
 ---
 
@@ -194,13 +205,75 @@ hivemind-core set-metadata 1 --unset region
 Migrate the client database between backends. Both `--from` and `--to` accept a backend
 plugin name.
 
+Both flags take a database plugin entry-point name. `--from` defaults to
+`hivemind-json-db-plugin` and `--to` defaults to `hivemind-sqlite-db-plugin`.
+
 ```bash
-# Migrate from JSON to SQLite
-hivemind-core migrate-db --to sqlite
+# Migrate from JSON to SQLite (both defaults, so the flags are optional)
+hivemind-core migrate-db --from hivemind-json-db-plugin --to hivemind-sqlite-db-plugin
 
 # Migrate from SQLite to Redis
-hivemind-core migrate-db --from sqlite --to redis \
-  --host 192.168.1.10 --port 6379 --password s3cr3t
+hivemind-core migrate-db --from hivemind-sqlite-db-plugin --to hivemind-redis-db-plugin
+```
+
+The command reads the target backend's connection settings from `server.json`. It takes
+no host, port, or password flags. The source database is left untouched.
+
+---
+
+## `export-clients`
+
+Write every client record to a CSV file. The columns are `client_id`, `name`, `is_admin`,
+`access_key`, `password`, and `crypto_key`.
+
+```bash
+hivemind-core export-clients --path /srv/backup/
+```
+
+`--path` accepts a file or a directory. If it names a directory, the command writes
+`hivemind_clients.csv` inside it. If you omit `--path`, the CSV goes to stdout.
+
+The file holds plaintext credentials. Store it accordingly.
+
+---
+
+## `derive-psk`
+
+Print the pre-shared key that a site password and a node id produce. Use it to configure
+a client that authenticates with a shared site password.
+
+```bash
+hivemind-core derive-psk --password "site-secret" --node-id "kitchen-pi"
+```
+
+Both flags are mandatory.
+
+---
+
+## `print-config`
+
+Print the active server configuration as JSON.
+
+```bash
+hivemind-core print-config
+```
+
+---
+
+## `policy list` / `policy test`
+
+Inspect the admission chain. `policy list` prints the built-in policies first, then the
+plugins built from `policy.chain`.
+
+```bash
+hivemind-core policy list
+```
+
+`policy test` builds a fake message of the given type, runs the full chain against the
+client that owns the given access key, and prints the verdict as JSON.
+
+```bash
+hivemind-core policy test 42caf3d2405075fb9e7a4e1ff44e4c4f "speak"
 ```
 
 Source: `hivemind_core/scripts.py`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -50,7 +50,9 @@ hivemind-core add-client [OPTIONS]
 | `--access-key` | `str` | API access key (auto-generated if omitted) |
 | `--password` | `str` | Password used for session key derivation (auto-generated if omitted) |
 | `--crypto-key` | `str` | **Deprecated.** Legacy 16-character encryption key. Use `--password` instead |
-| `--admin` | `bool` | Grant administrator privileges (default: `False`) |
+| `--admin` | `bool` | Mark the client as an administrator (default: `False`). Informational only: it grants no admission bypass |
+| `--metadata` | `str` | Initial `Client.metadata` as a JSON object |
+| `--allow-weak-password` | flag | Accept a password below `min_password_bits` |
 
 **Example: auto-generated credentials**
 
@@ -66,6 +68,9 @@ Encryption Key: f46351c54f61a715
 ```
 
 Provide the **Access Key** and **Password** to the client device.
+
+A new client has an **empty** `allowed_types` whitelist. Grant the message types it needs
+with [`allow-msg`](#allow-msg) before it can send anything.
 
 ---
 
@@ -135,11 +140,13 @@ hivemind-core revoke-admin [NODE_ID]
 
 ## Message type permissions
 
-By default, clients may only send a restricted set of message types (e.g. `recognizer_loop:utterance`). Use these commands to expand or restrict that set.
+A client may only send the message types in its `allowed_types` whitelist. A new client
+has an empty whitelist, so the server denies every message and every binary payload it
+sends. Use these commands to grant and revoke types.
 
 ### `allow-msg`
 
-Allow a client to send an additional OVOS message type.
+Add an OVOS message type to a client's `allowed_types` whitelist.
 
 ```bash
 hivemind-core allow-msg MSG_TYPE [NODE_ID]
@@ -184,7 +191,9 @@ hivemind-core blacklist-propagate [NODE_ID]
 
 ## Skill & intent permissions
 
-These permissions are enforced by injecting blacklists into the OVOS session associated with the client's requests.
+`OVOSAgentPolicy` enforces these permissions. It reads the lists from `Client.metadata`
+and injects them into the OVOS session for each request. The commands have no effect
+unless `hivemind-ovos-agent-policy` is in the server's `policy.chain`.
 
 ### `blacklist-skill` / `allow-skill`
 
@@ -211,6 +220,56 @@ hivemind-core allow-intent INTENT_ID [NODE_ID]
 ```bash
 hivemind-core blacklist-intent skill-weather.openvoiceos:WeatherIntent 1
 ```
+
+---
+
+## Client metadata
+
+### `set-metadata`
+
+Write arbitrary keys to `Client.metadata`. Policy plugins read the keys they know about.
+
+```bash
+hivemind-core set-metadata 1 --metadata '{"tier":"pro","region":"eu"}'
+hivemind-core set-metadata 1 --key tier --value pro
+hivemind-core set-metadata 1 --unset region
+```
+
+---
+
+## Keys and databases
+
+### `derive-psk`
+
+Print the pre-shared key that a site password and a node id produce.
+
+```bash
+hivemind-core derive-psk --password "site-secret" --node-id "kitchen-pi"
+```
+
+### `migrate-db`
+
+Copy every client from one database backend to another. Both flags take a database plugin
+entry-point name. The source is left untouched.
+
+```bash
+hivemind-core migrate-db --from hivemind-json-db-plugin --to hivemind-sqlite-db-plugin
+```
+
+---
+
+## Policy chain
+
+### `policy list` / `policy test`
+
+```bash
+hivemind-core policy list
+hivemind-core policy test <access_key> "speak"
+```
+
+`policy list` prints the built-in policies, then the plugins from `policy.chain`.
+`policy test` runs a fake message of the given type through the chain and prints the
+verdict as JSON.
 
 ---
 [← Protocol](protocol.md) · [Home](index.md) · [Plugin Development →](plugin_development.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,20 @@ The file is created with defaults on first run if absent.
   ],
   "allowed_ciphers": ["CHACHA20-POLY1305", "AES-GCM"],
 
+  "min_protocol_version": 2,
+
+  "min_password_bits": 40,
+  "runtime_password_strength_check": true,
+
+  "last_seen_update_interval": 0,
+
+  "presence": {
+    "enabled": true,
+    "name": "HiveMind-Node",
+    "zeroconf": true,
+    "upnp": false
+  },
+
   "agent_protocol": {
     "module": "hivemind-ovos-agent-plugin",
     "hivemind-ovos-agent-plugin": {
@@ -70,6 +84,18 @@ The file is created with defaults on first run if absent.
 | `binarize` | bool | `false` | Enable HiveMind binarization protocol (requires compatible client version) |
 | `allowed_encodings` | list | see above | Ordered list of accepted message encodings; first match wins during handshake |
 | `allowed_ciphers` | list | `["CHACHA20-POLY1305", "AES-GCM"]` | Accepted session ciphers; first match wins |
+| `min_protocol_version` | int | `2` | Lowest HiveMind protocol version a client may negotiate. The server rejects a client that completes the handshake below this version. It advertises the higher of this value and the version its crypto settings need |
+| `min_password_bits` | float | `40` | Lowest password entropy `add-client` accepts, and the handshake backstop rejects |
+| `runtime_password_strength_check` | bool | `true` | Re-check password strength at handshake time. Set to `false`, or set `HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK=1`, to skip the backstop |
+| `last_seen_update_interval` | int | `0` | Seconds to debounce the `last_seen` write. `0` writes on every admitted message |
+| `presence` | dict | see above | Local-network advertisement through the optional `hivemind-presence` package. Keys: `enabled`, `name`, `zeroconf` (mDNS), `upnp` (SSDP) |
+
+> **`require_crypto` is not a config key.** It is an attribute of
+> `HiveMindListenerProtocol` and it defaults to `True`. While it is true, the server
+> drops an `INTERCOM` frame that carries no signed envelope: such a frame proves nothing
+> about its origin, so the server does not relay it or escalate it. To change the value,
+> subclass the protocol or set the attribute on the instance you pass to
+> `HiveMindService`.
 
 ---
 
@@ -154,8 +180,11 @@ Selects the client credential store. `module` is the entry-point name.
 JSON backend automatically. Migrate with:
 
 ```bash
-hivemind-core migrate-db --to sqlite
+hivemind-core migrate-db --from hivemind-json-db-plugin --to hivemind-sqlite-db-plugin
 ```
+
+`--from` and `--to` take database plugin entry-point names, not short aliases. The
+defaults are the two names shown above.
 
 Available backends:
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -9,11 +9,11 @@ This page maps every repository in the HiveMind ecosystem to its role and links 
 | Repo | Role | Docs |
 |---|---|---|
 | **hivemind-core** | Central server. Authenticates clients, routes messages, enforces permissions | [docs](index.md) |
-| **hivemind-plugin-manager** | Plugin discovery and factory system used by hivemind-core | [docs](../../hivemind-plugin-manager/docs/index.md) |
-| **hivemind-websocket-client** | Python client library and CLI for connecting to a HiveMind Core server | [docs](../../hivemind-websocket-client/docs/index.md) |
-| **poorman_handshake** | RSA + password-based handshake primitives used for key exchange | [docs](../../poorman_handshake/docs/index.md) |
-| **z85base91** | Binary-to-text encoding schemes (Z85B, Z85P, Base91) used for wire efficiency | [docs](../../z85base91/docs/index.md) |
-| **HiveBeacon** | UDP LAN broadcast and discovery. Advertises the server's presence on the local network | [docs](../../HiveBeacon/docs/index.md) |
+| **hivemind-plugin-manager** | Plugin discovery and factory system used by hivemind-core | [repo](https://github.com/JarbasHiveMind/hivemind-plugin-manager) |
+| **hivemind-websocket-client** | Python client library and CLI for connecting to a HiveMind Core server | [docs](https://github.com/JarbasHiveMind/hivemind-websocket-client/blob/dev/docs/index.md) |
+| **poorman_handshake** | RSA + password-based handshake primitives used for key exchange | [repo](https://github.com/JarbasHiveMind/poorman_handshake) |
+| **z85base91** | Binary-to-text encoding schemes (Z85B, Z85P, Base91) used for wire efficiency | [repo](https://github.com/JarbasHiveMind/z85base91) |
+| **HiveBeacon** | UDP LAN broadcast and discovery. Advertises the server's presence on the local network | [repo](https://github.com/JarbasHiveMind/HiveBeacon) |
 
 ---
 
@@ -23,8 +23,8 @@ Transport layer plugins loaded by hivemind-core. Multiple can run simultaneously
 
 | Repo | Entry-point name | Docs |
 |---|---|---|
-| **hivemind-websocket-protocol** | `hivemind-websocket-plugin` | [docs](../../hivemind-websocket-protocol/docs/index.md) |
-| **hivemind-http-protocol** | `hivemind-http-plugin` | [docs](../../hivemind-http-protocol/docs/index.md) |
+| **hivemind-websocket-protocol** | `hivemind-websocket-plugin` | [docs](https://github.com/JarbasHiveMind/hivemind-websocket-protocol/blob/dev/docs/index.md) |
+| **hivemind-http-protocol** | `hivemind-http-plugin` | [repo](https://github.com/JarbasHiveMind/hivemind-http-protocol) |
 
 ---
 
@@ -34,7 +34,7 @@ Handle binary payloads (audio, images, files) arriving at the server.
 
 | Repo | Entry-point name | Docs |
 |---|---|---|
-| **hivemind-audio-binary-protocol** | `hivemind-audio-binary-protocol-plugin` | [docs](../../hivemind-audio-binary-protocol/docs/index.md) |
+| **hivemind-audio-binary-protocol** | `hivemind-audio-binary-protocol-plugin` | [repo](https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol) |
 
 ---
 
@@ -45,8 +45,8 @@ Credential storage backends.
 | Repo | Entry-point name | Docs |
 |---|---|---|
 | **hivemind-json-db-plugin** | `hivemind-json-db-plugin` | (bundled with json_database) |
-| **hivemind-sqlite-database** | `hivemind-sqlite-db-plugin` | [docs](../../hivemind-sqlite-database/docs/index.md) |
-| **hivemind-redis-database** | `hivemind-redis-db-plugin` | [docs](../../hivemind-redis-database/docs/index.md) |
+| **hivemind-sqlite-database** | `hivemind-sqlite-db-plugin` | [repo](https://github.com/JarbasHiveMind/hivemind-sqlite-database) |
+| **hivemind-redis-database** | `hivemind-redis-db-plugin` | [repo](https://github.com/JarbasHiveMind/hivemind-redis-database) |
 
 ---
 
@@ -56,10 +56,10 @@ Devices that connect to a HiveMind Core server and provide voice or chat interac
 
 | Repo | Processing model | Requires audio binary protocol | Docs |
 |---|---|---|---|
-| **HiveMind-voice-sat** | Wake word, STT, and TTS all run **on device** | No | [docs](../../HiveMind-voice-sat/docs/index.md) |
-| **HiveMind-voice-relay** | Wake word on device. STT and TTS offloaded **to the server** | Yes | [docs](../../HiveMind-voice-relay/docs/index.md) |
-| **hivemind-mic-satellite** | Only mic and VAD on device. All audio streamed **to the server** | Yes | [docs](../../hivemind-mic-satellite/docs/index.md) |
-| **hivemind-webspeech** | VAD in the browser. Audio streamed to the server through JS | Yes | [docs](../../hivemind-webspeech/docs/index.md) |
+| **HiveMind-voice-sat** | Wake word, STT, and TTS all run **on device** | No | [docs](https://github.com/JarbasHiveMind/HiveMind-voice-sat/blob/dev/docs/index.md) |
+| **HiveMind-voice-relay** | Wake word on device. STT and TTS offloaded **to the server** | Yes | [docs](https://github.com/JarbasHiveMind/HiveMind-voice-relay/blob/dev/docs/index.md) |
+| **hivemind-mic-satellite** | Only mic and VAD on device. All audio streamed **to the server** | Yes | [docs](https://github.com/JarbasHiveMind/hivemind-mic-satellite/blob/dev/docs/index.md) |
+| **hivemind-webspeech** | VAD in the browser. Audio streamed to the server through JS | Yes | [docs](https://github.com/JarbasHiveMind/hivemind-webspeech/blob/dev/docs/index.md) |
 
 ---
 
@@ -69,9 +69,9 @@ Connect external messaging platforms to a HiveMind Core server.
 
 | Repo | Platform | Docs |
 |---|---|---|
-| **hivemind-flask-chatroom** | Web browser (Flask multi-user chatroom) | [docs](../../hivemind-flask-chatroom/docs/index.md) |
-| **HiveMind-matrix-bridge** | Matrix chat protocol | [docs](../../HiveMind-matrix-bridge/docs/index.md) |
-| **HiveMind-deltachat-bridge** | DeltaChat (email-based) | [docs](../../HiveMind-deltachat-bridge/docs/index.md) |
+| **hivemind-flask-chatroom** | Web browser (Flask multi-user chatroom) | [repo](https://github.com/JarbasHiveMind/hivemind-flask-chatroom) |
+| **HiveMind-matrix-bridge** | Matrix chat protocol | [repo](https://github.com/JarbasHiveMind/HiveMind-matrix-bridge) |
+| **HiveMind-deltachat-bridge** | DeltaChat (email-based) | [repo](https://github.com/JarbasHiveMind/HiveMind-deltachat-bridge) |
 
 ---
 
@@ -81,8 +81,8 @@ Plugins that run inside an OpenVoiceOS instance and connect it outward to a Hive
 
 | Repo | Type | Purpose | Docs |
 |---|---|---|---|
-| **ovos-hivemind-pipeline-plugin** | OVOS intent pipeline plugin | Forward unmatched utterances to a remote HiveMind Core server | [docs](../../ovos-hivemind-pipeline-plugin/docs/index.md) |
-| **ovos-solver-hivemind-plugin** | OVOS solver plugin | Query a HiveMind Core server as a question-answering backend | [docs](../../ovos-solver-hivemind-plugin/docs/index.md) |
+| **ovos-hivemind-pipeline-plugin** | OVOS intent pipeline plugin | Forward unmatched utterances to a remote HiveMind Core server | [repo](https://github.com/JarbasHiveMind/ovos-hivemind-pipeline-plugin) |
+| **ovos-solver-hivemind-plugin** | OVOS solver plugin | Query a HiveMind Core server as a question-answering backend | [repo](https://github.com/JarbasHiveMind/ovos-solver-hivemind-plugin) |
 
 ---
 
@@ -90,9 +90,9 @@ Plugins that run inside an OpenVoiceOS instance and connect it outward to a Hive
 
 | Repo | Description | Docs |
 |---|---|---|
-| **hivemind-media-player** | Turn any device into an OCP (OVOS Common Play) media player controlled via HiveMind | [docs](../../hivemind-media-player/docs/index.md) |
-| **hivemind-homeassistant** | Home Assistant custom integration. Exposes HiveMind devices as HA media players | [docs](../../hivemind-homeassistant/docs/index.md) |
-| **hivemind-ggwave** | Data-over-sound pairing. Provisions satellite credentials over audio, without a keyboard | [docs](../../hivemind-ggwave/docs/index.md) |
+| **hivemind-media-player** | Turn any device into an OCP (OVOS Common Play) media player controlled via HiveMind | [repo](https://github.com/JarbasHiveMind/hivemind-media-player) |
+| **hivemind-homeassistant** | Home Assistant custom integration. Exposes HiveMind devices as HA media players | [docs](https://github.com/JarbasHiveMind/hivemind-homeassistant/blob/dev/docs/index.md) |
+| **hivemind-ggwave** | Data-over-sound pairing. Provisions satellite credentials over audio, without a keyboard | [docs](https://github.com/JarbasHiveMind/hivemind-ggwave/blob/dev/docs/index.md) |
 
 ---
 
@@ -100,8 +100,8 @@ Plugins that run inside an OpenVoiceOS instance and connect it outward to a Hive
 
 | Repo | Description | Docs |
 |---|---|---|
-| **hivemind-docker** | Docker Compose stacks for running various HiveMind services | [docs](../../hivemind-docker/docs/index.md) |
-| **hivemind-skills-server-docker** | Docker setup for a persona-based HiveMind skills server | [docs](../../hivemind-skills-server-docker/docs/index.md) |
+| **hivemind-docker** | Docker Compose stacks for running various HiveMind services | [repo](https://github.com/JarbasHiveMind/hivemind-docker) |
+| **hivemind-skills-server-docker** | Docker setup for a persona-based HiveMind skills server | [docs](https://github.com/JarbasHiveMind/hivemind-skills-server-docker/blob/master/docs/index.md) |
 
 ---
 [← Network Map](hive_map.md) · [Home](index.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - A running OVOS instance on `localhost:8181` (default agent backend), **or** a
   [Persona](https://github.com/OpenVoiceOS/ovos-persona) server if you want an LLM backend.
 - Satellite devices or clients that will connect (e.g. `hivemind-voice-sat`,
@@ -27,8 +27,9 @@ and the default database backend (SQLite) are pulled in automatically.
 hivemind-core listen
 ```
 
-The server starts on `0.0.0.0:5678` (WebSocket) and `0.0.0.0:5679` (HTTP) by default,
-connecting to the OVOS bus at `127.0.0.1:8181`.
+The server starts every network protocol plugin listed in `network_protocol` that is
+installed. With both default plugins present it listens on `0.0.0.0:5678` (WebSocket) and
+`0.0.0.0:5679` (HTTP), and connects to the OVOS bus at `127.0.0.1:8181`.
 
 ---
 
@@ -56,8 +57,8 @@ Provide the **Access Key** and **Password** to the satellite device's configurat
 
 ## Grant Message Types
 
-New clients have an empty `allowed_types` whitelist and are denied all messages until you
-grant access. For a typical voice satellite:
+New clients have an empty `allowed_types` whitelist. The server denies every message, and
+every binary payload, until you grant access. For a typical voice satellite:
 
 ```bash
 hivemind-core allow-msg "recognizer_loop:utterance" 1

--- a/docs/hive_map.md
+++ b/docs/hive_map.md
@@ -9,7 +9,7 @@ with the same `flood_id`, so all nodes in the network sync in one round. There i
 no separate PONG message. The `flood_id` stops infinite relay loops.
 
 For a conceptual overview of the discovery protocol, see
-[`HiveMind-community-docs: docs/20_network_discovery.md`](../../HiveMind-community-docs/docs/20_network_discovery.md).
+[HiveMind community docs: network discovery](https://github.com/JarbasHiveMind/HiveMind-community-docs/blob/master/docs/20_network_discovery.md).
 
 ---
 
@@ -257,8 +257,8 @@ print(mapper.to_json())
 ## Related Documents
 
 - [Protocol Internals](protocol.md): handler lifecycle and message routing.
-- [`HiveMind-community-docs: 20_network_discovery.md`](../../HiveMind-community-docs/docs/20_network_discovery.md): conceptual overview.
-- [`hivemind-websocket-client: docs/cli_guide.md`](../../hivemind-websocket-client/docs/cli_guide.md): the `hivemind-client ping` command.
+- [HiveMind community docs: network discovery](https://github.com/JarbasHiveMind/HiveMind-community-docs/blob/master/docs/20_network_discovery.md): conceptual overview.
+- [hivemind-websocket-client: CLI guide](https://github.com/JarbasHiveMind/hivemind-websocket-client/blob/dev/docs/cli_guide.md): the `hivemind-client ping` command.
 
 ---
 [← Plugin Development](plugin_development.md) · [Home](index.md) · [Ecosystem →](ecosystem.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python 3.8+
+- Python 3.10+
 - At least one network protocol plugin (e.g. `hivemind-websocket-protocol`)
 - At least one agent protocol plugin (e.g. `hivemind-ovos-agent-plugin`)
 

--- a/docs/plugin_development.md
+++ b/docs/plugin_development.md
@@ -36,6 +36,16 @@ Define where the server stores client credentials and permissions.
 - **Entry point**: `hivemind.database`
 - **Example implementation**: `hivemind_sqlite_database.SQLiteDB`
 
+### 5. Policy Plugins
+
+Define admission control: rate limits, quotas, metadata injection, or audit logging.
+
+- **Base class**: `hivemind_plugin_manager.policy.PolicyPlugin`
+- **Entry point**: `hivemind.policy`
+- **Example implementation**: `hivemind_ovos_agent_plugin.policy.OVOSAgentPolicy`
+
+Add the plugin to the `policy.chain` list in `server.json`. See [Policy Chain](policy.md).
+
 ## Example: Creating a Database Plugin
 
 1. Inherit from `hivemind_plugin_manager.database.AbstractDB`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -54,7 +54,9 @@ Optional. Invoked when a `HiveMessageType.BINARY` message is received.
 |---|---|---|
 | `hivemind-audio-binary-protocol` | STT transcription and audio handling via `ovos-plugin-manager` | `pip install hivemind-audio-binary-protocol` |
 
-When no binary protocol is configured (`"module": null`), binary messages are silently ignored.
+Binary payloads cross the `allowed_types` gate first. A client with an empty whitelist
+cannot send binary at all. When no binary protocol is configured (`"module": null`), an
+admitted binary message reaches a no-op stub and nothing happens to it.
 
 Binary payload types dispatched to the plugin:
 
@@ -81,10 +83,14 @@ Configuration example:
 
 ```json
 "database": {
-  "module": "hivemind-sqlite-database",
-  "hivemind-sqlite-database": { "path": "~/.local/share/hivemind/clients.db" }
+  "module": "hivemind-sqlite-db-plugin",
+  "hivemind-sqlite-db-plugin": { "name": "clients", "subfolder": "hivemind-core" }
 }
 ```
+
+The key in `database` is the plugin entry-point name, not the package name. The three
+entry-point names are `hivemind-sqlite-db-plugin`, `hivemind-json-db-plugin`, and
+`hivemind-redis-db-plugin`.
 
 ---
 
@@ -104,6 +110,7 @@ The four base classes are:
 | `AgentProtocol` | `hivemind_plugin_manager.protocols` |
 | `BinaryDataHandlerProtocol` | `hivemind_plugin_manager.protocols` |
 | `AbstractDB` | `hivemind_plugin_manager.database` |
+| `PolicyPlugin` | `hivemind_plugin_manager.policy` |
 
 ---
 [← Policy Chain](policy.md) · [Home](README.md) · [Extending →](extending.md)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -11,6 +11,11 @@ This document describes the server-side protocol classes that process HiveMind c
 | `2` | Binary serialisation support |
 | `3` | Noise handshake (XXpsk2/KKpsk0) with authenticated, forward-secret transport; falls back to v2 against older clients |
 
+The server admits a client only if the version it negotiates is at least
+`min_protocol_version` (default `2`) from `server.json`. The check runs when the handshake
+completes, not only when the server advertises the floor. The advertised floor is the
+higher of the configured value and the value the crypto settings need.
+
 ## Connection lifecycle
 
 ```
@@ -18,7 +23,9 @@ Client connects (network layer)
         │
         ▼
 HiveMindListenerProtocol.handle_new_client()
+  ├─ moves the connection off the reserved "default" session
   ├─ emits hive.client.connect on agent bus
+  ├─ computes min/max protocol version, drops the client if they do not overlap
   ├─ sends HELLO  (server pubkey + peer id)
   └─ sends HANDSHAKE  (capabilities, crypto requirements)
         │
@@ -27,6 +34,7 @@ Client sends HANDSHAKE (pubkey or password envelope)
         │
 HiveMindListenerProtocol.handle_handshake_message()
   ├─ derives session AES key
+  ├─ drops the client if the agreed version is below min_protocol_version
   └─ sends HANDSHAKE response (envelope + chosen cipher/encoding)
         │
         ▼
@@ -63,7 +71,7 @@ from hivemind_core.protocol import HiveMindListenerProtocol
 | `db` | `ClientDatabase` | Credential storage |
 | `identity` | `NodeIdentity` | This node's RSA keypair / peer ID |
 | `clients` | `dict[str, HiveMindClientConnection]` | Currently connected clients keyed by peer ID |
-| `require_crypto` | `bool` | Reject connections without encryption (default `True`) |
+| `require_crypto` | `bool` | Require proof of origin (default `True`). While it is true, an `INTERCOM` frame with no signed envelope is dropped, not relayed and not escalated. This is an attribute, not a `server.json` key |
 | `handshake_enabled` | `bool` | Negotiate a per-session key when no pre-shared key exists |
 
 ### Message handlers
@@ -81,38 +89,38 @@ from hivemind_core.protocol import HiveMindListenerProtocol
 | `handle_escalate_message(message, client)` | `HiveMessageType.ESCALATE` received |
 | `handle_intercom_message(message, client)` | `HiveMessageType.INTERCOM` received |
 | `handle_binary_message(message, client)` | `HiveMessageType.BINARY` received |
+| `handle_query_message(message, client)` | `HiveMessageType.QUERY` received |
+| `handle_cascade_message(message, client)` | `HiveMessageType.CASCADE` received |
 | `handle_ping_message(message, client)` | `HiveMessageType.PING` inner payload received (unwrapped from PROPAGATE) |
-| `handle_pong_message(message, client)` | `HiveMessageType.PONG` inner payload received (unwrapped from PROPAGATE) |
+| `handle_noise_handshake_message(message, client)` | A protocol v3 Noise handshake frame is received |
+| `handle_client_shared_bus(message, client)` | `HiveMessageType.SHARED_BUS` received |
+| `handle_invalid_key_connected(client)` | A client presents an access key that is not in the database |
+| `handle_invalid_protocol_version(client)` | A client negotiates below `min_protocol_version` |
+| `handle_unknown_message(message, client)` | The message type matches no handler |
 
-### PING / PONG handler behaviour
+### PING handler behaviour
 
 #### `handle_ping_message(message, client)`
 
 Called when a PROPAGATE message's inner payload is a PING.
 
-All nodes SHOULD relay the PING to all connected peers (except the sender) and MAY respond with a
-PONG. Whether to respond is a node-level policy decision. For example, a top-level node may be configured
-to act as a discovery boundary and silently drop the PING instead of relaying it further upstream.
+Discovery is PING-only. There is no PONG message. The handler feeds the PING into the
+local `HiveMapper`, emits `hive.ping.received` on the agent bus, then checks the
+`flood_id`. If the node has not seen that `flood_id` before, it builds its own PING with
+the same `flood_id` and sends it to every connected peer and upstream. If it has seen the
+`flood_id`, it stops. That check is what ends the flood.
 
 ```
 Receive PROPAGATE(PING)
-  ├─ relay PROPAGATE(PING) to all connected peers except sender   [SHOULD]
-  └─ build PROPAGATE(PONG) and send back toward originator        [MAY, node policy]
+  ├─ hive_mapper.on_ping(message)
+  ├─ emit hive.ping.received on the agent bus
+  └─ if flood_id is new: send PROPAGATE(PING) with the same flood_id
+       to all peers and upstream
 ```
 
-See [network discovery docs](../../HiveMind-community-docs/docs/20_network_discovery.md) for the
-full design rationale and wire format.
-
-#### `handle_pong_message(message, client)`
-
-Called when a PROPAGATE message's inner payload is a PONG.
-
-1. Feed the PONG into the local `HiveMapper` instance (`self.hive_mapper.on_pong(message)`).
-2. Emit `hive.pong.received` on the agent bus with the PONG payload.
-3. Relay the PONG onward via PROPAGATE (standard propagation semantics).
-
-The originating node collects PONGs until its timeout expires, then calls
-`HiveMapper.to_ascii()` / `to_dict()` to read the topology.
+The node that started the flood collects the answering PINGs until its timeout expires,
+then calls `HiveMapper.to_ascii()` or `to_dict()` to read the topology. See
+[Hive Map](hive_map.md) for the mapper API.
 
 ### Optional callbacks
 
@@ -142,17 +150,20 @@ from hivemind_core.protocol import HiveMindClientConnection
 | Attribute | Type | Description |
 |---|---|---|
 | `key` | `str` | API access key used to look up this client in the database |
-| `peer` | `str` | Unique identifier (`name::session_id`) used in message routing |
+| `peer` | `str` | Unique identifier (`name::session_id`) used in message routing. If another live connection already owns that string, the server appends a suffix to keep the two apart |
 | `sess` | `Session` | OVOS session associated with this client |
 | `crypto_key` | `str \| None` | AES session key (set after handshake) |
 | `is_admin` | `bool` | Whether this client has admin privileges |
 | `can_escalate` | `bool` | Client may send ESCALATE messages |
 | `can_propagate` | `bool` | Client may send PROPAGATE messages |
-| `msg_blacklist` | `list[str]` | OVOS message types never forwarded to this client |
-| `skill_blacklist` | `list[str]` | Skill IDs blocked for this client |
-| `intent_blacklist` | `list[str]` | Intent IDs blocked for this client |
-| `allowed_types` | `list[str]` | OVOS message types this client may inject |
+| `allowed_types` | `list[str]` | OVOS message types this client may inject. The only ACL field on the connection |
 | `binarize` | `bool` | Use binary serialisation with this client |
+| `site_id` | `str` | Site this client belongs to |
+| `noise_transport` | `NoiseTransport \| None` | Session layer on a protocol v3 connection. Replaces `crypto_key` |
+
+There is no message, skill, or intent blacklist on the connection. `allowed_types` is
+whitelist-only and deny-by-default. Skill and intent blacklists live in `Client.metadata`
+and `OVOSAgentPolicy` reads them.
 
 ### Key methods
 
@@ -160,7 +171,8 @@ from hivemind_core.protocol import HiveMindClientConnection
 |---|---|
 | `send(message)` | Encrypt and transmit a `HiveMessage` to this client |
 | `decode(payload)` | Decrypt and deserialise a received payload into a `HiveMessage` |
-| `authorize(message)` | Return `True` if this client is allowed to inject the given message |
+| `authorize(message)` | Subclass hook. Returns `True` by default. The `allowed_types` check moved to `MessageTypeACLPolicy` |
+| `resolve_user(db)` | Return the cached database row for this connection, refetching at most once per TTL window |
 
 ---
 
@@ -192,7 +204,7 @@ Thin wrapper around the configured database plugin.
 from hivemind_core.database import ClientDatabase
 
 with ClientDatabase() as db:
-    db.add_client("my-satellite", access_key="abc", password="xyz")
+    db.add_client("my-satellite", key="abc", password="xyz")
     client = db.get_client_by_api_key("abc")
     print(client.name, client.is_admin)
 ```
@@ -201,7 +213,9 @@ with ClientDatabase() as db:
 
 | Method | Description |
 |---|---|
-| `add_client(name, key, ...)` | Add or update a client record |
+| `add_client(name, key, ...)` | Add or update a client record. The access key is the `key` argument |
+| `get_client_by_id(client_id)` | Look up a `Client` by numeric node id |
+| `refresh(client_id)` | Refetch a `Client` row from the backend |
 | `get_client_by_api_key(key)` | Look up a `Client` by access key |
 | `get_clients_by_name(name)` | Find clients by name |
 | `delete_client(key)` | Delete a client by access key |

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,14 +7,16 @@ HiveMind Core secures communication between the server and its satellites with t
 HiveMind Core uses the `poorman_handshake` protocol for initial authentication and session key setup, managed by `HiveMindClientConnection` in `hivemind_core.protocol`.
 
 1. **Identity**: every client has an `Access Key` and a `Password` stored through `hivemind_core.database.ClientDatabase`.
-2. **Session Key**: during connection, the server derives a temporary AES-256-GCM session key with PBKDF2, using `poorman_handshake.PasswordHandShake` or `poorman_handshake.HandShake`.
-3. **Encryption**: this session key encrypts all later traffic.
+2. **Session Key**: during connection, the server derives a temporary session key with PBKDF2, using `poorman_handshake.PasswordHandShake` or `poorman_handshake.HandShake`.
+3. **Cipher**: the client proposes ciphers and the server picks the first one its `allowed_ciphers` list also holds. The default order prefers `CHACHA20-POLY1305`, then `AES-GCM`.
+4. **Encryption**: this session key encrypts all later traffic.
+5. **Protocol v3**: a client that supports the Noise handshake (XXpsk2/KKpsk0) gets an authenticated, forward-secret transport instead of the session-key layer.
 
 ## Encryption Standards
 
-- **AES-256-GCM**: used for transport layer encryption. GCM (Galois/Counter Mode) provides both confidentiality and data integrity (AEAD).
+- **ChaCha20-Poly1305** and **AES-256-GCM**: used for transport layer encryption. Both are AEAD ciphers, so both give confidentiality and data integrity.
 - **PBKDF2**: used for deriving keys from passwords, resisting brute-force attacks.
-- **PGP (optional)**: used for `INTERCOM` messages, so nodes can exchange end-to-end encrypted secret messages that the server itself cannot decrypt.
+- **RSA**: used for `INTERCOM` messages, so nodes can exchange end-to-end encrypted messages that a relay node cannot read. The server verifies the origin signature and pins the sender's public key on first sighting. While `require_crypto` is true, the server drops an unsigned `INTERCOM` frame instead of relaying it.
 
 ## Permissions and Access Control
 


### PR DESCRIPTION
QA pass over `README.md` and `docs/`. Every command, flag, config key, default, port, and
code snippet was checked against the source on `dev`. No code changes.

## Blocker — the documented command does not work

- **`hivemind-core add-client --db-backend sqlite`** (README quick start,
  `docs/cli-reference.md` option table). There is no `--db-backend` option. The backend
  comes from `server.json`. A reader copying the quick start hits a click error on the
  first command.
- **`hivemind-core migrate-db --to sqlite`** (README, `docs/configuration.md`,
  `docs/cli-reference.md`). `--from`/`--to` take a database plugin entry-point name, so
  `sqlite` builds a `ClientDatabase` for a module that does not exist. The documented
  `--host`, `--port`, and `--password` flags do not exist either.

## Blocker — the onboarding path leaves the reader locked out

- The README quick start went **add-client → listen**. `add-client` creates a client with
  an empty `allowed_types`, and `MessageTypeACLPolicy` denies everything until
  `allow-msg` runs. Added a **Granting Message Types** step between the two.
- `docs/cli.md` stated clients "may only send a restricted set of message types (e.g.
  `recognizer_loop:utterance`)" by default. The default set is empty.

## High — stale behavior claims

- `docs/protocol.md` documented `handle_pong_message` and a `PONG` wire message. Neither
  exists. Discovery is a PING flood keyed on `flood_id`, and `docs/hive_map.md` already
  said so, so the two pages contradicted each other. Rewrote the section and added the
  handlers that were missing from the table (`query`, `cascade`, `noise_handshake`,
  `client_shared_bus`, `invalid_key_connected`, `invalid_protocol_version`, `unknown`).
- `docs/protocol.md` listed `msg_blacklist`, `skill_blacklist`, and `intent_blacklist` as
  attributes of `HiveMindClientConnection`. Those fields are gone; `allowed_types` is the
  only ACL field.
- `docs/protocol.md` called `ClientDatabase.add_client(name, access_key=...)`. The
  argument is `key`. The snippet raises `TypeError`.
- `docs/cli-reference.md` claimed `delete-client` writes a tombstone to prevent ID reuse.
  It deletes the row.
- `docs/plugins.md` said binary messages are "silently ignored" without a binary plugin.
  Since #171, binary crosses the `allowed_types` gate first and an empty whitelist denies
  it.
- `docs/plugins.md` database config example used the package name
  (`hivemind-sqlite-database`) and a `path` key. The entry-point name is
  `hivemind-sqlite-db-plugin` and the keys are `name`/`subfolder`.
- `docs/auth.md` said `allow-msg` lets a client *receive* a type. It gates injection.
- `docs/security.md` claimed AES-256-GCM for transport. `allowed_ciphers` prefers
  ChaCha20-Poly1305, and protocol v3 uses a Noise transport instead. It also called
  INTERCOM encryption "PGP"; it is RSA with an origin signature.
- README stated the chain is fail-closed with "no operator setting to override this",
  while `docs/configuration.md` documents the per-entry `optional: true` flag. Both pages
  now say the same thing.
- `docs/architecture.md` marked `HELLO` server-to-satellite only and called `PING` a
  keepalive.

## Medium — missing reference material

- `docs/configuration.md` calls itself the full `server.json` reference but omitted
  `min_protocol_version`, `min_password_bits`, `runtime_password_strength_check`,
  `last_seen_update_interval`, and `presence`. Added, with defaults from
  `hivemind_core/config.py`.
- Added an explicit note that **`require_crypto` is not a config key**. It is a
  `HiveMindListenerProtocol` attribute, default `True`, and while true the server drops an
  unsigned INTERCOM frame rather than relaying it (#166, #169).
- Documented that `min_protocol_version` is checked when the handshake completes, not only
  advertised (#165).
- Command lists in README, `docs/cli.md`, and `docs/cli-reference.md` omitted
  `print-config`, `derive-psk`, `export-clients`, `migrate-db`, and the `policy`
  group. Added, with a section for each.
- `add-client` option tables omitted `--admin`, `--metadata`, and
  `--allow-weak-password`.
- `docs/plugin_development.md` listed four plugin types. Policy is the fifth.
- Documented `peer` disambiguation on collision (#174).
- Documented that `handle_new_client` moves a connection off the reserved `default`
  session (#174).
- Python version: `docs/getting-started.md` said 3.9+, `docs/installation.md` said 3.8+.
  `pyproject.toml` requires 3.10.

## Low

- Replaced five `file.py:NNN` citations in the README. All five had drifted. They now name
  the symbol.
- Fixed 27 relative links that pointed outside the repository (`../../<repo>/docs/...`).
  Every one was broken on GitHub. Resolved each repo's org and default branch, and linked
  `docs/index.md` where it exists or the repo root where it does not.

## Verified correct, left alone

- Every `hivemind-core` subcommand name against the click group, including the
  `allow-skill`/`allow-intent` names (the functions are `unblacklist_*`, but the CLI names
  are right).
- The default `server.json` block in both README and `docs/configuration.md` against
  `_DEFAULT`, including the SQLite-on-fresh-install fallback logic.
- Ports 5678 (WebSocket) and 5679 (HTTP), and the 8181 OVOS bus default.
- The whole of `docs/hive_map.md`: the `HiveMapper` API, `NodeInfo` fields, PING-only
  discovery, and the `handle_ping_message` integration snippet all match.
- The whole of `docs/policy.md`: built-in policy order, the `optional` flag semantics, the
  deny-code table including `backend_unavailable` from #174, and the `hive.policy.denied`
  payload shape.
- `docs/extending.md`: every entry-point group, base class, and registration snippet.
- `HiveMindNodeType` members, including `FAKECROFT`.
- `HiveMindBinaryPayloadType` handler dispatch table in `docs/plugins.md`.
- `docs/architecture.md` horizontal-scaling section and the QUERY/CASCADE streaming
  description.

## Not fixed

- `docs/index.md` and `docs/README.md` are two competing tables of contents that link
  disjoint sets of pages, and `docs/cli.md` and `docs/cli-reference.md` are two CLI
  references. Both pairs are now factually correct, but merging them is a restructure, not
  a QA fix.
- `hivemind-persona-agent-plugin` as the Persona entry-point name. It is out of this repo
  and could not be verified without installing `ovos-persona`.

## AI transparency

Written by Claude Opus, under Claude Fable 5 orchestration. Every claim was checked
against the source in this branch. All touched files pass
`ste_lint.py` with zero SLOP-category violations.