### PR TITLE
fix: apply the admission chain before relaying traffic upstream

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1294,6 +1294,59 @@ class HiveMindListenerProtocol:
                "targets": list(payload.target_peers) or [self._node_id]}
         payload.replace_route(list(payload.route) + [hop])
 
+    def _relayed_bus_payload(self, message: HiveMessage) -> Optional[Message]:
+        """Return the agent bus message carried inside a routing envelope, or
+        None when the envelope carries no agent traffic.
+
+        Nested routing envelopes are unwrapped: an ESCALATE wrapping a
+        PROPAGATE wrapping a BUS still ends up on some agent's bus, so wrapping
+        must not buy a way around the admission gate.
+        """
+        inner = message.payload
+        while isinstance(inner, HiveMessage) and inner.msg_type in (
+                HiveMessageType.ESCALATE, HiveMessageType.PROPAGATE,
+                HiveMessageType.CASCADE):
+            inner = inner.payload
+        if isinstance(inner, HiveMessage) and inner.msg_type == HiveMessageType.BUS:
+            inner = inner.payload
+        return inner if isinstance(inner, Message) else None
+
+    def _admit_relayed_message(self, message: HiveMessage,
+                               client: HiveMindClientConnection) -> bool:
+        """HIVEMIND-NODE-1 §3.3: a relay applies its own admission control to
+        traffic from a downstream node before relaying it.
+
+        Without this gate a downstream client denied here can still have its
+        payload relayed upstream, where the master admits it against the
+        RELAY's credentials instead of the originator's. ``can_escalate`` /
+        ``can_propagate`` do not help: they say whether a peer may route at
+        all, not what it may say.
+
+        Returns True when the message may be handled and relayed. On a deny the
+        originator gets the same ``hive.policy.denied`` frame the inject path
+        sends, and the caller stops.
+
+        Only agent traffic (an inner BUS message) is reviewed. PING is mesh
+        discovery with its own flood gate, INTERCOM is end-to-end encrypted and
+        unreadable to a relay, and the chain reviews an OVOS ``Message`` — none
+        of those are admission decisions this node can make.
+
+        ``observe()`` is deliberately not fired here. On the inject path it is
+        a post-delivery hook, run after the message reaches this node's agent
+        bus; a relayed message reaches no agent here. When the same message is
+        ALSO delivered locally, the inject path fires ``observe`` exactly once.
+        """
+        payload = self._relayed_bus_payload(message)
+        if payload is None:
+            return True
+        verdict = self.policy_chain.review(payload, client)
+        if not verdict.denied:
+            return True
+        LOG.info(f"policy denied relayed '{payload.msg_type}' from "
+                 f"{client.peer}: {verdict.code} ({verdict.reason})")
+        self._send_policy_denied(client, payload, verdict)
+        return False
+
     def handle_propagate_message(
             self, message: HiveMessage, client: HiveMindClientConnection
     ):
@@ -1312,6 +1365,14 @@ class HiveMindListenerProtocol:
                 self.illegal_callback(payload)
             # kick client for misbehaviour so it stops doing that
             client.disconnect()
+            return
+
+        # NODE-1 §3.3: admit the traffic against THIS client's credentials
+        # before it is relayed anywhere. Run before local delivery: the local
+        # inject path applies the same chain to the same message, so a denied
+        # message loses no delivery here, and the originator gets one denial
+        # instead of two.
+        if not self._admit_relayed_message(message, client):
             return
 
         # HIVEMIND-MSG-1 §5 gates *re-forwarding* of a looped message, not local
@@ -1721,6 +1782,11 @@ class HiveMindListenerProtocol:
             client.disconnect()
             return
 
+        # NODE-1 §3.3: admit against this client's credentials before relaying
+        # (see handle_propagate_message for why this runs before local delivery)
+        if not self._admit_relayed_message(message, client):
+            return
+
         # HIVEMIND-MSG-1 §5 gates re-forwarding of a looped message, not local
         # handling; suppress only the fan-out + master-forward at the end.
         looped = self._is_routing_loop(message)
@@ -1777,6 +1843,11 @@ class HiveMindListenerProtocol:
                 self.illegal_callback(payload)
             # kick client for misbehaviour so it stops doing that
             client.disconnect()
+            return
+
+        # NODE-1 §3.3: admit against this client's credentials before relaying
+        # (see handle_propagate_message for why this runs before local delivery)
+        if not self._admit_relayed_message(message, client):
             return
 
         # HIVEMIND-MSG-1 §5 gates re-forwarding of a looped message, not local

--- a/tests/test_mesh_routing_conformance.py
+++ b/tests/test_mesh_routing_conformance.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 from ovos_bus_client.message import Message
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 
+from hivemind_core.policy import PolicyChain
 from hivemind_core.protocol import HiveMindListenerProtocol
 
 DEFAULT_PEER = "master:0.0.0.0"
@@ -38,6 +39,9 @@ def _make_node(node_key: str = "pubkey-A", site_id=None) -> HiveMindListenerProt
     node.escalate_callback = None
     node.broadcast_callback = None
     node._upstream_hm = None
+    # these tests are about routing, not admission: an empty chain admits
+    # everything, so the NODE-1 §3.3 relay gate never interferes
+    node.policy_chain = PolicyChain()
     return node
 
 

--- a/tests/test_relay_admission.py
+++ b/tests/test_relay_admission.py
@@ -1,0 +1,188 @@
+"""HIVEMIND-NODE-1 §3.3: a relay applies its own admission control to traffic
+from its downstream nodes *before* forwarding it upstream.
+
+Before this suite, ``handle_escalate_message``, ``handle_propagate_message`` and
+``handle_cascade_message`` forwarded the payload upstream without ever running
+``policy_chain``. A downstream client with an empty ``allowed_types`` could wrap
+an arbitrary BUS message in an ESCALATE: the relay denied it locally, then
+relayed it intact to the master, which admitted it against the *relay's*
+credentials instead of the originator's.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+from hivemind_core.policy import MessageTypeACLPolicy, PolicyChain
+from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
+
+SITE = "test-site"
+
+
+def _make_relay():
+    """A relay node: an upstream master bound, a real ACL policy chain."""
+    agent = MagicMock()
+    bus = FakeBus()
+    agent.bus = bus
+    agent.get_bus.return_value = bus
+    agent.answer_query.return_value = iter(())
+
+    proto = HiveMindListenerProtocol.__new__(HiveMindListenerProtocol)
+    proto.agent_protocol = agent
+    proto.binary_data_protocol = MagicMock()
+    proto.identity = MagicMock(public_key="relay-pubkey", site_id=SITE)
+    proto.db = None
+    proto.peer = "master:0.0.0.0"
+    proto.clients = {}
+    proto.hive_mapper = MagicMock()
+    proto.illegal_callback = None
+    proto.escalate_callback = None
+    proto.propagate_callback = None
+    proto.agent_bus_callback = None
+    proto.cascade_select_callback = None
+    proto.default_lang = "en-US"
+    proto._seen_flood_ids = set()
+    proto._pending_cascades = {}
+    proto._upstream_hm = MagicMock()
+    proto.policy_chain = PolicyChain(policies=[MessageTypeACLPolicy()])
+    return proto, bus
+
+
+def _make_client(allowed_types):
+    client = MagicMock(spec=HiveMindClientConnection)
+    client.allowed_types = list(allowed_types)
+    client.is_admin = False
+    client.peer = "downstream::1"
+    client.can_escalate = True
+    client.can_propagate = True
+    client.sess = MagicMock()
+    client.sess.session_id = "session-1"
+    client.sess.serialize.return_value = {"session_id": "session-1"}
+    client.sess.pipeline = None
+    client.authorize.return_value = True
+    client.send = MagicMock()
+    return client
+
+
+def _wrap(outer_type, bus_msg, target_site_id=None, metadata=None):
+    inner = HiveMessage(HiveMessageType.BUS, payload=bus_msg)
+    return HiveMessage(outer_type, payload=inner,
+                       target_site_id=target_site_id, metadata=metadata)
+
+
+def _speak():
+    return Message("speak", {"utterance": "drop the shields"},
+                   {"session": {"session_id": "session-1"}})
+
+
+def _denials(client):
+    return [c[0][0].payload for c in client.send.call_args_list
+            if c[0][0].payload.msg_type == "hive.policy.denied"]
+
+
+class TestRelayDeniesUnauthorizedUpstream(unittest.TestCase):
+    """An unauthorized inner BUS message is not laundered upstream."""
+
+    def _assert_denied(self, proto, client):
+        proto._upstream_hm.emit.assert_not_called()
+        denials = _denials(client)
+        self.assertEqual(len(denials), 1)
+        self.assertEqual(denials[0].data["denied_type"], "speak")
+        self.assertEqual(denials[0].data["code"], "acl_disallowed_type")
+
+    def test_escalate_with_empty_whitelist_is_not_forwarded(self):
+        proto, _ = _make_relay()
+        client = _make_client([])
+        proto.handle_escalate_message(_wrap(HiveMessageType.ESCALATE, _speak()), client)
+        self._assert_denied(proto, client)
+
+    def test_propagate_with_empty_whitelist_is_not_forwarded(self):
+        proto, _ = _make_relay()
+        client = _make_client([])
+        proto.handle_propagate_message(_wrap(HiveMessageType.PROPAGATE, _speak()), client)
+        self._assert_denied(proto, client)
+
+    def test_cascade_with_empty_whitelist_is_not_forwarded(self):
+        proto, _ = _make_relay()
+        client = _make_client([])
+        proto.handle_cascade_message(
+            _wrap(HiveMessageType.CASCADE, _speak(), metadata={"query_id": "q1"}),
+            client)
+        self._assert_denied(proto, client)
+
+    def test_nested_escalate_wrapping_propagate_is_not_forwarded(self):
+        """Nesting a routing envelope must not buy a way around the gate."""
+        proto, _ = _make_relay()
+        client = _make_client([])
+        nested = HiveMessage(HiveMessageType.ESCALATE,
+                             payload=_wrap(HiveMessageType.PROPAGATE, _speak()))
+        proto.handle_escalate_message(nested, client)
+        self._assert_denied(proto, client)
+
+
+class TestRelayStillForwardsAuthorizedTraffic(unittest.TestCase):
+    """Positive controls — the gate must not break relaying. These pass both
+    before and after the fix."""
+
+    def test_escalate_of_a_granted_type_is_forwarded(self):
+        proto, _ = _make_relay()
+        client = _make_client(["speak"])
+        proto.handle_escalate_message(_wrap(HiveMessageType.ESCALATE, _speak()), client)
+        proto._upstream_hm.emit.assert_called_once()
+        self.assertEqual(_denials(client), [])
+
+    def test_propagate_of_a_granted_type_is_forwarded(self):
+        proto, _ = _make_relay()
+        client = _make_client(["speak"])
+        proto.handle_propagate_message(_wrap(HiveMessageType.PROPAGATE, _speak()), client)
+        proto._upstream_hm.emit.assert_called_once()
+        self.assertEqual(_denials(client), [])
+
+    def test_ping_inside_a_propagate_is_forwarded_unreviewed(self):
+        """A PING is mesh discovery, not agent traffic — no BUS payload to
+        review, so the ACL whitelist does not apply to it."""
+        proto, _ = _make_relay()
+        client = _make_client([])
+        ping = HiveMessage(HiveMessageType.PING, {"flood_id": "f1", "peer": client.peer})
+        proto.handle_propagate_message(
+            HiveMessage(HiveMessageType.PROPAGATE, payload=ping), client)
+        self.assertTrue(proto._upstream_hm.emit.called)
+        self.assertEqual(_denials(client), [])
+
+
+class TestLocalDeliveryStillWorks(unittest.TestCase):
+    """No regression on the site-targeted local-delivery path."""
+
+    def test_site_targeted_escalate_reaches_the_agent_bus_once(self):
+        proto, bus = _make_relay()
+        client = _make_client(["speak"])
+        emitted = []
+        bus.on("speak", emitted.append)
+
+        proto.handle_escalate_message(
+            _wrap(HiveMessageType.ESCALATE, _speak(), target_site_id=SITE), client)
+
+        self.assertEqual(len(emitted), 1)
+        self.assertEqual(_denials(client), [])
+        proto._upstream_hm.emit.assert_called_once()
+
+    def test_denied_site_targeted_escalate_denies_exactly_once(self):
+        """The relay gate and the local inject path must not both send a
+        denial for the same message."""
+        proto, bus = _make_relay()
+        client = _make_client([])
+        emitted = []
+        bus.on("speak", emitted.append)
+
+        proto.handle_escalate_message(
+            _wrap(HiveMessageType.ESCALATE, _speak(), target_site_id=SITE), client)
+
+        self.assertEqual(emitted, [])
+        self.assertEqual(len(_denials(client)), 1)
+        proto._upstream_hm.emit.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_route_loop_suppression.py
+++ b/tests/test_route_loop_suppression.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock
 from ovos_bus_client.message import Message
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 
+from hivemind_core.policy import PolicyChain
 from hivemind_core.protocol import HiveMindListenerProtocol
 
 # HiveMindListenerProtocol.peer is a class default that service.py never sets,
@@ -44,6 +45,9 @@ def _make_node(node_key: str, peer: str = DEFAULT_PEER) -> HiveMindListenerProto
     node.propagate_callback = MagicMock()
     node.escalate_callback = MagicMock()
     node._upstream_hm = None
+    # these tests are about routing, not admission: an empty chain admits
+    # everything, so the NODE-1 §3.3 relay gate never interferes
+    node.policy_chain = PolicyChain()
     return node
 
 


### PR DESCRIPTION
## The bug

HIVEMIND-NODE-1 §3.3: *"A relay node MUST apply its own admission control to traffic from its downstream nodes before forwarding upstream."*

`handle_escalate_message`, `handle_propagate_message` and `handle_cascade_message` forwarded the payload through `escalate_to_master` / `propagate_to_master` / `cascade_to_master` **without ever calling `self.policy_chain`**. The chain ran only on the local-injection path (`handle_inject_agent_msg`), the binary path, and the QUERY-answer path (`_admit_for_query`).

### Exploit path, concretely

1. A satellite connects to a relay with `allowed_types = []` (or without `speak` granted).
2. It sends `ESCALATE { BUS { speak } }` instead of a bare `BUS`.
3. The relay does not deliver `speak` locally — either the site does not match, or `handle_inject_agent_msg` denies it. So far, correct.
4. The relay then calls `escalate_to_master(...)` with the payload intact.
5. The master receives the ESCALATE over the **relay's** connection. Every credential check upstream — `allowed_types`, `is_admin`, the reserved `default` session gate — is now evaluated against the relay's access key, not the originator's.
6. The master's agent runs the message.

The only gates on that path today are the coarse per-connection `can_escalate` / `can_propagate` booleans. Those say whether a peer may route at all; they say nothing about what it may say. A relay was silently laundering unauthorized traffic upstream.

## The fix

A new `_admit_relayed_message()` runs `policy_chain.review()` on the relayed bus message against the originating client, in all three handlers. On a deny it logs, sends the originator the existing `hive.policy.denied` frame through `_send_policy_denied` (same wire shape, same verdict codes as the inject path), and the handler stops. No new mechanism.

`_relayed_bus_payload()` finds the message to review.

## The four design questions

**Non-BUS inner types pass through, deliberately.** PING is mesh discovery with its own `flood_id` dedup gate and carries no agent traffic. INTERCOM is end-to-end encrypted to a target public key — a relay cannot read it, so it cannot make an admission decision about it, by design. The chain's `review()` signature takes an OVOS `Message`; there is nothing to hand it for these. A test (`test_ping_inside_a_propagate_is_forwarded_unreviewed`) pins this so it is a decision, not an omission.

**Nested routing envelopes ARE unwrapped.** An `ESCALATE { PROPAGATE { BUS } }` still reaches an agent's bus at the far end, so letting nesting skip the gate would leave the same hole one level deeper. `_relayed_bus_payload` descends through ESCALATE/PROPAGATE/CASCADE to the innermost BUS. Covered by `test_nested_escalate_wrapping_propagate_is_not_forwarded`.

**`observe()` does not fire here.** On the inject path `observe()` runs *after* `bus.emit`; it is a post-delivery hook, and the existing code already skips it when the agent bus is unreachable and nothing was delivered. A relayed message reaches no agent on this node, so there is nothing to observe. When the same message is also delivered locally, the inject path fires `observe` exactly once, at the point of actual delivery.

**No double review that double-counts, and never two denials.** The gate runs *before* local delivery, not at the forwarding site. That ordering matters: the current handlers deliver locally first and forward afterwards, so a gate at the forwarding site would fire after `handle_inject_agent_msg` (or `_admit_for_query`) had already sent its own denial — two denials for one message. Running first makes the denial single. Nothing is lost by returning early: the local inject path applies the same chain to the same message with the same client, so a message denied by the relay gate would have been denied locally too. On the allow path the local inject path re-reviews (pure, cached) and calls `observe` once. `test_denied_site_targeted_escalate_denies_exactly_once` pins the single-denial behavior.

**Performance.** No new DB traffic. `MessageTypeACLPolicy` resolves the client row through `client.resolve_user(db)`, which caches on the connection with a 5s TTL, so a flood from one peer resolves at most once per 5s regardless of message rate. The gate adds one in-process chain pass per relayed message, and on the allow path it short-circuits to `True` immediately for any envelope with no inner BUS message.

## Back-compat impact

Say it plainly: **a relay that was silently laundering unauthorized traffic upstream now denies it.** If a deployment relies on a satellite reaching the master's agent through a relay with message types it was never granted, that traffic stops and the satellite starts receiving `hive.policy.denied`. The fix is to grant the type on the originating client (`hivemind-core allow-msg`), which is what the whitelist was always meant to express. Traffic that was properly granted is unaffected — the positive controls in this PR pass both before and after the change.

Secondary, same clause: a denied message is now also not fanned out to sibling peers, since the gate precedes the whole handler. Relaying unauthorized traffic sideways is the same laundering hole pointed at a different neighbour.

## Tests

New `tests/test_relay_admission.py`, written before the fix and proven red on `origin/dev` (**5 failed, 4 passed** — the 4 are the positive controls, green both before and after):

- `test_escalate_with_empty_whitelist_is_not_forwarded` (red before)
- `test_propagate_with_empty_whitelist_is_not_forwarded` (red before)
- `test_cascade_with_empty_whitelist_is_not_forwarded` (red before)
- `test_nested_escalate_wrapping_propagate_is_not_forwarded` (red before)
- `test_denied_site_targeted_escalate_denies_exactly_once` (red before)
- `test_escalate_of_a_granted_type_is_forwarded` (positive control)
- `test_propagate_of_a_granted_type_is_forwarded` (positive control)
- `test_ping_inside_a_propagate_is_forwarded_unreviewed` (positive control)
- `test_site_targeted_escalate_reaches_the_agent_bus_once` (local delivery, no regression from #172's envelope work)

`tests/test_route_loop_suppression.py` and `tests/test_mesh_routing_conformance.py` build nodes with `object.__new__` and left `policy_chain` unset. Both factories now get an empty (allow-all) `PolicyChain`; these suites test routing, not admission.

**Unit suite:** `194 passed, 1 skipped` (`tests/ --ignore=tests/e2e`).

**hivemind-test-harness conformance gate:** `11 passed, 1 xfailed` — an exact match with the baseline on `dev`. No XPASS.

## AI transparency

Found by a spec-conformance audit. Written by Claude Opus under Claude Fable 5 orchestration, reviewed by a human before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admission checks for relayed messages nested within routing envelopes.
  * Unauthorized messages are blocked locally and no longer forwarded.
  * Authorized traffic continues to route normally, including site-targeted messages.
  * PING messages continue to bypass BUS access checks.

* **Bug Fixes**
  * Prevented unauthorized nested messages from reaching local services or upstream destinations.
  * Ensured denied site-targeted messages generate a single policy-denied response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->