### PR TITLE
refactor: readability and duplication pass over the CLI, service, database and config

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -155,7 +155,10 @@ def runtime_password_min_bits() -> float:
         "1", "true", "yes", "on",
     ):
         return 0.0
+    # get_server_config() backfills every top level key, so _DEFAULT is the
+    # single source of truth for these fallbacks
     cfg = get_server_config()
-    if not cfg.get("runtime_password_strength_check", True):
+    if not cfg.get("runtime_password_strength_check",
+                   _DEFAULT["runtime_password_strength_check"]):
         return 0.0
-    return float(cfg.get("min_password_bits", 40))
+    return float(cfg.get("min_password_bits", _DEFAULT["min_password_bits"]))

--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -13,9 +13,6 @@ from hivemind_plugin_manager.database import Client
 class ClientDatabase:
 
     def __init__(self, config=None):
-        """
-        Initialize the client database with the specified backend.
-        """
         config = config or get_server_config()["database"]
         name = config["module"]
         db_class = DatabaseFactory.get_class(name)
@@ -36,13 +33,14 @@ class ClientDatabase:
         return self.db.search_by_value("name", name)
 
     def get_client_by_api_key(self, api_key: str) -> Optional[Client]:
+        # AbstractDB subclasses all expose this (and may index it), but the
+        # backend only has to be duck-typed, so fall back to the generic
+        # scan when it does not
         direct_lookup = getattr(self.db, "get_client_by_api_key", None)
-        if callable(direct_lookup):
+        if direct_lookup is not None:
             return direct_lookup(api_key)
-        search: List[Client] = self.db.search_by_value("api_key", api_key)
-        if len(search):
-            return search[0]
-        return None
+        matches: List[Client] = self.db.search_by_value("api_key", api_key)
+        return matches[0] if matches else None
 
     def get_client_by_id(self, client_id: int) -> Optional[Client]:
         return self.db.get_client_by_id(client_id)
@@ -82,6 +80,9 @@ class ClientDatabase:
                 user.name = name
             if allowed_types:
                 user.allowed_types = allowed_types
+            # unlike the fields above, admin is compared against None so that
+            # an explicit admin=False demotes the client instead of being
+            # read as "no change"
             if admin is not None:
                 user.is_admin = admin
             if crypto_key:

--- a/hivemind_core/database.py
+++ b/hivemind_core/database.py
@@ -33,14 +33,7 @@ class ClientDatabase:
         return self.db.search_by_value("name", name)
 
     def get_client_by_api_key(self, api_key: str) -> Optional[Client]:
-        # AbstractDB subclasses all expose this (and may index it), but the
-        # backend only has to be duck-typed, so fall back to the generic
-        # scan when it does not
-        direct_lookup = getattr(self.db, "get_client_by_api_key", None)
-        if direct_lookup is not None:
-            return direct_lookup(api_key)
-        matches: List[Client] = self.db.search_by_value("api_key", api_key)
-        return matches[0] if matches else None
+        return self.db.get_client_by_api_key(api_key)
 
     def get_client_by_id(self, client_id: int) -> Optional[Client]:
         return self.db.get_client_by_id(client_id)

--- a/hivemind_core/policy.py
+++ b/hivemind_core/policy.py
@@ -1,10 +1,6 @@
 # hivemind-core
 # Copyright (C) 2026 Casimiro Ferreira
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# SPDX-License-Identifier: Apache-2.0
 """Policy admission chain — consumer side of the primitives shipped in
 hivemind-plugin-manager (PolicyPlugin / Verdict / Mutation).
 

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -2,12 +2,15 @@
 # Copyright (C) 2026 Casimiro Ferreira
 # SPDX-License-Identifier: Apache-2.0
 import os
+from typing import Optional
 
 import click
 import json
 from rich.console import Console
 from rich.prompt import Prompt
 from rich.table import Table
+
+from hivemind_plugin_manager.database import Client
 
 from hivemind_core.database import ClientDatabase
 from hivemind_core.service import HiveMindService
@@ -27,17 +30,11 @@ def parse_client_metadata(metadata):
     return parsed
 
 
-def prompt_node_id(db: ClientDatabase) -> int:
-    """
-    Prompts the user to select a client ID from the database, displaying available clients in a table.
-    
-    If no clients are found, prints a message and exits. If multiple clients exist, presents a selection prompt; otherwise, selects the only available client.
-    
-    Args:
-        db: The client database to query.
-    
-    Returns:
-        The selected client ID as an integer.
+def prompt_node_id(db: ClientDatabase) -> str:
+    """Ask the operator to pick a client id, listing the known clients.
+
+    Exits the process when there is nothing to pick from, or when the
+    operator selects the synthetic "Exit" choice.
     """
     table = Table(title="HiveMind Clients")
     table.add_column("ID", justify="right", style="cyan", no_wrap=True)
@@ -72,35 +69,33 @@ def prompt_node_id(db: ClientDatabase) -> int:
     return node_id
 
 
+def resolve_client(db: ClientDatabase, node_id) -> Optional[Client]:
+    """Look up the client for ``node_id``, prompting when it was omitted.
+
+    Returns None when no client carries that id — every caller reports
+    that to the operator itself.
+    """
+    node_id = node_id or prompt_node_id(db)
+    for client in db:
+        if client.client_id == int(node_id):
+            return client
+    return None
+
+
 @click.group(help="HiveMind-core admin CLI.")
 def hmcore_cmds():
-    """
-    Main command group for HiveMind-core server administration.
-    
-    This group organizes CLI commands for managing clients, permissions, and server
-    configuration in the HiveMind-core environment.
-    """
     pass
 
 
 @hmcore_cmds.command(help="Print HiveMind server configuration.")
 def print_config():
-    """
-    Prints the current HiveMind server configuration as formatted JSON to the console.
-    """
-    cfg = get_server_config()
-    cfg = json.dumps(cfg, indent=2, ensure_ascii=False)
-    console = Console()
-    console.print(cfg)
+    cfg = json.dumps(get_server_config(), indent=2, ensure_ascii=False)
+    Console().print(cfg)
 
 
 @hmcore_cmds.command(help="Start listening for HiveMind connections.", name="listen")
 def listen():
-    """
-    Starts the HiveMind service and begins accepting client connections.
-    """
-    service = HiveMindService()
-    service.run()
+    HiveMindService().run()
 
 
 @hmcore_cmds.command(
@@ -120,8 +115,7 @@ def derive_psk(password, node_id):
     interoperate with no server-side distinction.
     """
     from poorman_handshake.noise import derive_psk as _derive
-    psk = _derive(password, node_id=node_id)
-    print(psk.hex())
+    print(_derive(password, node_id=node_id).hex())
 
 
 @hmcore_cmds.command(help="Add credentials for a new client.", name="add-client")
@@ -135,24 +129,7 @@ def derive_psk(password, node_id):
               help="Skip the password-strength check (not recommended). By default a "
                    "guessable/low-entropy --password is refused.")
 def add_client(name, access_key, password, crypto_key, admin, metadata, allow_weak_password):
-    """
-    Adds a new client to the database, generating credentials if not provided.
-    
-    If a crypto key is supplied, validates its length and warns about deprecation.
-    Random credentials are generated for any missing values. Prints the new client's
-    credentials and admin status after successful addition.
-    
-    Args:
-        name: Optional friendly name for the client. If not provided, a default is generated.
-        access_key: Optional API access key. If not provided, a random key is generated.
-        password: Optional password. If not provided, a random password is generated.
-        crypto_key: Optional 16-character encryption key. If not provided, a random key is generated.
-        admin: Boolean indicating whether the client should have administrator privileges.
-        metadata: Optional JSON object with admin-defined client metadata.
-    
-    Raises:
-        ValueError: If the crypto key is not exactly 16 characters, or if the client cannot be added.
-    """
+    """Add a client, generating any credential the operator did not supply."""
     key = crypto_key
     if key:
         print(
@@ -174,7 +151,7 @@ def add_client(name, access_key, password, crypto_key, admin, metadata, allow_we
     # protocol/config); this is the primary gate.
     if password and not allow_weak_password:
         from poorman_handshake import check_password_strength, WeakPasswordError
-        min_bits = get_server_config().get("min_password_bits", 40)
+        min_bits = get_server_config()["min_password_bits"]
         try:
             check_password_strength(password, min_bits=min_bits)
         except WeakPasswordError as e:
@@ -226,98 +203,67 @@ def add_client(name, access_key, password, crypto_key, admin, metadata, allow_we
 @click.argument("node_id", required=False, type=int)
 @click.option("--name", required=False, type=str, help="The new friendly name for the client")
 def rename_client(node_id, name):
-    """
-    Renames a client in the database to a new name.
-    
-    If node_id is not provided, prompts the user to select a client. Updates the client's name and prints a confirmation.
-    """
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                old_name = client.name
-                client.name = name
-                db.update_item(client)
-                print(f"Renamed '{old_name}' to {name}")
-                break
-        else:
+        client = resolve_client(db, node_id)
+        if client is None:
             print("Invalid Node ID!")
+            return
+        old_name = client.name
+        client.name = name
+        db.update_item(client)
+        print(f"Renamed '{old_name}' to {name}")
 
 
 @hmcore_cmds.command(help="Give administrator powers to a client in the database.", name="make-admin")
 @click.argument("node_id", required=False, type=int)
 def make_admin(node_id):
-    """
-    Grants administrator privileges to a client.
-    
-    If the client is already an administrator, notifies the user; otherwise, updates the client's admin status.
-    """
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if client.is_admin:
-                    print(f"{client.name} is already an administrator!")
-                    return
-                client.is_admin = True
-                db.update_item(client)
-                print(f"Gave administrator powers to {client.name}")
-                break
+        client = resolve_client(db, node_id)
+        if client is None:
+            return
+        if client.is_admin:
+            print(f"{client.name} is already an administrator!")
+            return
+        client.is_admin = True
+        db.update_item(client)
+        print(f"Gave administrator powers to {client.name}")
+
 
 @hmcore_cmds.command(help="Revoke administrator powers from a client in the database.", name="revoke-admin")
 @click.argument("node_id", required=False, type=int)
 def revoke_admin(node_id):
-    """
-    Revokes administrator privileges from a client.
-    
-    If the client is currently an administrator, their admin status is removed. If the client is not an administrator, a message is printed indicating no change.
-    """
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if not client.is_admin:
-                    print(f"{client.name} is not an administrator")
-                    return
-                client.is_admin = False
-                db.update_item(client)
-                print(f"Revoked administrator powers for {client.name}")
-                break
-        else:
-           print("Invalid Node ID!")
+        client = resolve_client(db, node_id)
+        if client is None:
+            print("Invalid Node ID!")
+            return
+        if not client.is_admin:
+            print(f"{client.name} is not an administrator")
+            return
+        client.is_admin = False
+        db.update_item(client)
+        print(f"Revoked administrator powers for {client.name}")
 
 
 @hmcore_cmds.command(help="Remove credentials for a client.", name="delete-client")
 @click.argument("node_id", required=False, type=int)
 def delete_client(node_id):
-    """
-    Deletes a client's credentials from the database by node ID.
-    
-    If no node ID is provided, prompts the user to select a client. Prints the revoked credentials upon successful deletion, or an error message if the node ID is invalid.
-    """
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                db.delete_client(client.api_key)
-                print(f"Revoked credentials!\n")
-                print("Node ID:", client.client_id)
-                print("Friendly Name:", client.name)
-                print("Access Key:", client.api_key)
-                print("Password:", client.password)
-                print("Encryption Key:", client.crypto_key)
-                break
-        else:
+        client = resolve_client(db, node_id)
+        if client is None:
             print("Invalid Node ID!")
+            return
+        db.delete_client(client.api_key)
+        print("Revoked credentials!\n")
+        print("Node ID:", client.client_id)
+        print("Friendly Name:", client.name)
+        print("Access Key:", client.api_key)
+        print("Password:", client.password)
+        print("Encryption Key:", client.crypto_key)
 
 
 @hmcore_cmds.command(help="List all clients and their credentials.", name="list-clients")
 def list_clients():
-    """
-    Displays a formatted table of all clients and their credentials stored in the database.
-    
-    Excludes clients with a client ID of -1 from the listing. The table includes each client's ID, name, access key, password, and crypto key.
-    """
     console = Console()
     table = Table(title="HiveMind Credentials:")
     table.add_column("ID", justify="center")
@@ -343,14 +289,8 @@ def list_clients():
 @hmcore_cmds.command(help="Export clients and credentials to a CSV file.", name="export-clients")
 @click.option("--path", required=False, type=str)
 def export_clients(path):
-    """
-    Exports all client credentials to a CSV file or prints them to stdout.
-    
-    If a directory path is provided, the CSV will be saved as 'hivemind_clients.csv' in that directory. If a file path is provided, the CSV will be saved to that file. If no path is given, the CSV content is printed to stdout. Excludes clients with client_id == -1.
-    
-    Args:
-        path: Optional file or directory path for the CSV output.
-    """
+    """Write the CSV to --path (a directory gets 'hivemind_clients.csv'),
+    or to stdout when no path is given."""
     if path and os.path.isdir(path):
         path = os.path.join(path, "hivemind_clients.csv")
 
@@ -370,129 +310,85 @@ def export_clients(path):
 @click.argument("msg_type", required=True, type=str)
 @click.argument("node_id", required=False, type=int)
 def allow_msg(msg_type, node_id):
-    """
-    Allows a specific message type for a client.
-    
-    If the client does not already have the message type in their allowed list, it is added and the change is saved. If the message type is already allowed, a notice is printed and the operation exits.
-    
-    Args:
-        msg_type: The message type to allow for the client.
-        node_id: The ID of the client to update. If not provided, prompts for selection.
-    """
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if msg_type in client.allowed_types:
-                    print(f"Client {client.name} already allowed '{msg_type}'")
-                    exit()
-                client.allowed_types.append(msg_type)
-                db.update_item(client)
-                print(f"Allowed '{msg_type}' for {client.name}")
-                break
-        else:
+        client = resolve_client(db, node_id)
+        if client is None:
             print("Invalid Node ID!")
+            return
+        if msg_type in client.allowed_types:
+            print(f"Client {client.name} already allowed '{msg_type}'")
+            exit()
+        client.allowed_types.append(msg_type)
+        db.update_item(client)
+        print(f"Allowed '{msg_type}' for {client.name}")
 
 
 @hmcore_cmds.command(help="Blacklist a message type from a client.", name="blacklist-msg")
 @click.argument("msg_type", required=True, type=str)
 @click.argument("node_id", required=False, type=int)
 def blacklist_msg(msg_type, node_id):
-    """
-    Removes a specific message type from a client's allowed list, effectively blacklisting it.
-    
-    If the client does not currently allow the specified message type, a notice is printed.
+    with ClientDatabase() as db:
+        client = resolve_client(db, node_id)
+        if client is None:
+            print("Invalid Node ID!")
+            return
+        if msg_type not in client.allowed_types:
+            print(f"Client '{client.name}' message already blacklisted: '{msg_type}'")
+            return
+        client.allowed_types.remove(msg_type)
+        db.update_item(client)
+        print(f"Blacklisted '{msg_type}' for {client.name}")
+
+
+def toggle_capability(attr: str, label: str, node_id, allow: bool) -> None:
+    """Flip one of the boolean routing capabilities on a client record.
+
+    ``attr`` is the ``Client`` field (``can_escalate`` / ``can_propagate``)
+    and ``label`` the HiveMessage type name printed to the operator.
     """
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if msg_type in client.allowed_types:
-                    client.allowed_types.remove(msg_type)
-                    db.update_item(client)
-                    print(f"Blacklisted '{msg_type}' for {client.name}")
-                    return
-                print(f"Client '{client.name}' message already blacklisted: '{msg_type}'")
-                break
-        else:
+        client = resolve_client(db, node_id)
+        if client is None:
             print("Invalid Node ID!")
+            return
+        if allow:
+            if getattr(client, attr):
+                print(f"Client {client.name} already allowed to send '{label}' messages")
+                exit()
+            setattr(client, attr, True)
+            db.update_item(client)
+            print(f"Allowed '{label}' messages for {client.name}")
+        else:
+            if not getattr(client, attr):
+                print(f"Client '{client.name}' '{label}' messages already blacklisted")
+                return
+            setattr(client, attr, False)
+            db.update_item(client)
+            print(f"Blacklisted '{label}' messages for {client.name}")
 
 
 @hmcore_cmds.command(help="Allow 'ESCALATE' messages to be sent from a client.", name="allow-escalate")
 @click.argument("node_id", required=False, type=int)
 def allow_escalate(node_id):
-    """
-    Grants a client permission to send 'ESCALATE' messages.
-    
-    If the client is already allowed, notifies the user and exits. Otherwise, updates the client's permissions to allow 'ESCALATE' messages and confirms the change.
-    """
-    with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if client.can_escalate:
-                    print(f"Client {client.name} already allowed to send 'ESCALATE' messages")
-                    exit()
-                client.can_escalate = True
-                db.update_item(client)
-                print(f"Allowed 'ESCALATE' messages for {client.name}")
-                break
-        else:
-            print("Invalid Node ID!")
+    toggle_capability("can_escalate", "ESCALATE", node_id, allow=True)
 
 
 @hmcore_cmds.command(help="blacklist 'ESCALATE' messages from being sent by a client", name="blacklist-escalate")
 @click.argument("node_id", required=False, type=int)
 def blacklist_escalate(node_id):
-    with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if client.can_escalate:
-                    client.can_escalate = False
-                    db.update_item(client)
-                    print(f"Blacklisted 'ESCALATE' messages for {client.name}")
-                    return
-                print(f"Client '{client.name}' 'ESCALATE' messages already blacklisted")
-                break
-        else:
-            print("Invalid Node ID!")
+    toggle_capability("can_escalate", "ESCALATE", node_id, allow=False)
 
 
 @hmcore_cmds.command(help="allow 'PROPAGATE' messages to be sent from a client", name="allow-propagate")
 @click.argument("node_id", required=False, type=int)
 def allow_propagate(node_id):
-    with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if client.can_propagate:
-                    print(f"Client {client.name} already allowed to send 'PROPAGATE' messages")
-                    exit()
-                client.can_propagate = True
-                db.update_item(client)
-                print(f"Allowed 'PROPAGATE' messages for {client.name}")
-                break
-        else:
-            print("Invalid Node ID!")
+    toggle_capability("can_propagate", "PROPAGATE", node_id, allow=True)
 
 
 @hmcore_cmds.command(help="blacklist 'PROPAGATE' messages from being sent by a client", name="blacklist-propagate")
 @click.argument("node_id", required=False, type=int)
 def blacklist_propagate(node_id):
-    with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if client.can_propagate:
-                    client.can_propagate = False
-                    db.update_item(client)
-                    print(f"Blacklisted 'PROPAGATE' messages for {client.name}")
-                    return
-                print(f"Client '{client.name}' 'PROPAGATE' messages already blacklisted")
-                break
-        else:
-            print("Invalid Node ID!")
+    toggle_capability("can_propagate", "PROPAGATE", node_id, allow=False)
 
 
 ##########################
@@ -507,31 +403,29 @@ def blacklist_propagate(node_id):
 def _toggle_metadata_blacklist(metadata_key: str, value: str,
                                node_id: int, add: bool) -> None:
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id != int(node_id):
-                continue
-            bl = list(client.metadata.get(metadata_key) or [])
-            if add:
-                if value in bl:
-                    print(f"Client {client.name} already has '{value}' "
-                          f"in {metadata_key}")
-                    return
-                bl.append(value)
-            else:
-                if value not in bl:
-                    print(f"'{value}' is not in {metadata_key} for "
-                          f"client {client.name}")
-                    return
-                bl.remove(value)
-            new_meta = dict(client.metadata)
-            new_meta[metadata_key] = bl
-            client.metadata = new_meta
-            db.update_item(client)
-            verb = "Blacklisted" if add else "Unblacklisted"
-            print(f"{verb} '{value}' for {client.name}")
+        client = resolve_client(db, node_id)
+        if client is None:
+            print("Invalid Node ID!")
             return
-        print("Invalid Node ID!")
+        bl = list(client.metadata.get(metadata_key) or [])
+        if add:
+            if value in bl:
+                print(f"Client {client.name} already has '{value}' "
+                      f"in {metadata_key}")
+                return
+            bl.append(value)
+        else:
+            if value not in bl:
+                print(f"'{value}' is not in {metadata_key} for "
+                      f"client {client.name}")
+                return
+            bl.remove(value)
+        new_meta = dict(client.metadata)
+        new_meta[metadata_key] = bl
+        client.metadata = new_meta
+        db.update_item(client)
+        verb = "Blacklisted" if add else "Unblacklisted"
+        print(f"{verb} '{value}' for {client.name}")
 
 
 @hmcore_cmds.command(help="Blacklist a skill for a client. OVOS-policy: requires "
@@ -597,20 +491,18 @@ def set_metadata(node_id, metadata, key, value, unset):
     if not updates and unset is None:
         raise click.BadParameter("pass --metadata, --key/--value, or --unset")
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id != int(node_id):
-                continue
-            new_meta = dict(client.metadata)
-            new_meta.update(updates)
-            if unset is not None:
-                new_meta.pop(unset, None)
-            client.metadata = new_meta
-            db.update_item(client)
-            print(f"Updated metadata for {client.name}:",
-                  json.dumps(client.metadata, sort_keys=True, ensure_ascii=False))
+        client = resolve_client(db, node_id)
+        if client is None:
+            print("Invalid Node ID!")
             return
-        print("Invalid Node ID!")
+        new_meta = dict(client.metadata)
+        new_meta.update(updates)
+        if unset is not None:
+            new_meta.pop(unset, None)
+        client.metadata = new_meta
+        db.update_item(client)
+        print(f"Updated metadata for {client.name}:",
+              json.dumps(client.metadata, sort_keys=True, ensure_ascii=False))
 
 
 @hmcore_cmds.command(
@@ -641,7 +533,6 @@ def migrate_db(from_module, to_module):
 
 @hmcore_cmds.group(name="policy", help="Inspect the policy admission chain.")
 def policy_group():
-    """Subcommands for introspecting the configured policy chain."""
     pass
 
 

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -340,12 +340,16 @@ def blacklist_msg(msg_type, node_id):
         print(f"Blacklisted '{msg_type}' for {client.name}")
 
 
-def toggle_capability(attr: str, label: str, node_id, allow: bool) -> None:
-    """Flip one of the boolean routing capabilities on a client record.
+# HiveMessage type an operator can toggle -> the Client field holding it
+CAPABILITY_FIELDS = {
+    "ESCALATE": "can_escalate",
+    "PROPAGATE": "can_propagate",
+}
 
-    ``attr`` is the ``Client`` field (``can_escalate`` / ``can_propagate``)
-    and ``label`` the HiveMessage type name printed to the operator.
-    """
+
+def toggle_capability(label: str, node_id, allow: bool) -> None:
+    """Grant or revoke one of the routing capabilities in CAPABILITY_FIELDS."""
+    attr = CAPABILITY_FIELDS[label]
     with ClientDatabase() as db:
         client = resolve_client(db, node_id)
         if client is None:
@@ -370,25 +374,25 @@ def toggle_capability(attr: str, label: str, node_id, allow: bool) -> None:
 @hmcore_cmds.command(help="Allow 'ESCALATE' messages to be sent from a client.", name="allow-escalate")
 @click.argument("node_id", required=False, type=int)
 def allow_escalate(node_id):
-    toggle_capability("can_escalate", "ESCALATE", node_id, allow=True)
+    toggle_capability("ESCALATE", node_id, allow=True)
 
 
 @hmcore_cmds.command(help="blacklist 'ESCALATE' messages from being sent by a client", name="blacklist-escalate")
 @click.argument("node_id", required=False, type=int)
 def blacklist_escalate(node_id):
-    toggle_capability("can_escalate", "ESCALATE", node_id, allow=False)
+    toggle_capability("ESCALATE", node_id, allow=False)
 
 
 @hmcore_cmds.command(help="allow 'PROPAGATE' messages to be sent from a client", name="allow-propagate")
 @click.argument("node_id", required=False, type=int)
 def allow_propagate(node_id):
-    toggle_capability("can_propagate", "PROPAGATE", node_id, allow=True)
+    toggle_capability("PROPAGATE", node_id, allow=True)
 
 
 @hmcore_cmds.command(help="blacklist 'PROPAGATE' messages from being sent by a client", name="blacklist-propagate")
 @click.argument("node_id", required=False, type=int)
 def blacklist_propagate(node_id):
-    toggle_capability("can_propagate", "PROPAGATE", node_id, allow=False)
+    toggle_capability("PROPAGATE", node_id, allow=False)
 
 
 ##########################

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -15,6 +15,7 @@ from hivemind_core.protocol import HiveMindListenerProtocol, ClientCallbacks
 from hivemind_plugin_manager import AgentProtocolFactory, NetworkProtocolFactory, BinaryDataHandlerProtocolFactory
 from hivemind_plugin_manager.protocols import BinaryDataHandlerProtocol
 
+
 def get_agent_protocol():
     config = get_server_config()["agent_protocol"]
     name = config["module"]
@@ -24,8 +25,8 @@ def get_agent_protocol():
 def get_binary_protocol():
     config = get_server_config()["binary_protocol"]
     name = config["module"]
-    if name is None: # binary protocol is optional
-        # dummy by default
+    if name is None:
+        # the binary protocol is optional; the base class is a no-op handler
         return BinaryDataHandlerProtocol, {}
     return BinaryDataHandlerProtocolFactory.get_class(name), config.get(name, {})
 
@@ -52,20 +53,11 @@ def on_stopping():
 
 @dataclasses.dataclass
 class HiveMindService:
-    """
-    A service that manages the HiveMind protocol, including agent communication,
-    database interactions, and network management.
+    """The hivemind-core server: agent protocol, client database, and the
+    network protocols that carry HiveMessages.
 
-    Attributes:
-        identity (NodeIdentity): The identity of the node in the HiveMind network.
-        db (ClientDatabase): The database used for storing client information.
-        hm_protocol (Type[HiveMindListenerProtocol]): The protocol for handling HiveMessages.
-        alive_hook (Callable[[None], None]): Hook called when the service is alive.
-        started_hook (Callable[[None], None]): Hook called when the service has started.
-        ready_hook (Callable[[None], None]): Hook called when the service is ready.
-        error_hook (Callable[[Exception], None]): Hook called when an error occurs.
-        stopping_hook (Callable[[None], None]): Hook called when the service is stopping.
-        _status (Optional[ProcessStatus]): The current status of the service.
+    The ``*_hook`` fields are the ovos-utils ProcessStatus callbacks; replace
+    them to report lifecycle transitions somewhere other than the log.
     """
     hm_protocol: Type[HiveMindListenerProtocol] = HiveMindListenerProtocol
 
@@ -82,10 +74,7 @@ class HiveMindService:
     _status: Optional[ProcessStatus] = None
 
     def __post_init__(self) -> None:
-        """
-        Initializes the service's status and presence objects after the dataclass
-        has been created.
-        """
+        self._presence = None
         self._status = self._status or ProcessStatus("HiveMind",
                                                      callback_map=StatusCallbackMap(
                                                          on_started=self.started_hook,
@@ -108,8 +97,10 @@ class HiveMindService:
         presence_cfg = cfg.get("presence", {})
         if not presence_cfg.get("enabled", True):
             return
+        # presence advertises a single endpoint, so the first configured
+        # network protocol (websocket, by default ordering) is the one announced
         net = cfg.get("network_protocol", {})
-        first = next(iter(net.values()), {}) if net else {}
+        first = next(iter(net.values()), {})
         self._presence = LocalPresence(
             port=first.get("port", 5678),
             ssl=first.get("ssl", False),
@@ -121,9 +112,8 @@ class HiveMindService:
         LOG.info("LocalPresence started")
 
     def _stop_presence(self) -> None:
-        presence = getattr(self, "_presence", None)
-        if presence is not None:
-            presence.stop()
+        if self._presence is not None:
+            self._presence.stop()
 
     def run(self):
         self._status.set_started()
@@ -155,7 +145,9 @@ class HiveMindService:
                 network_class = NetworkProtocolFactory.get_class(plug_name)
                 LOG.info(f"Network protocol: {network_class.__name__}")
                 protos.append(network_class(hm_protocol=hm_protocol, config=plug_conf))
-            except:
+            except Exception:
+                # one broken transport must not take down the others; the
+                # empty-protos check below still aborts startup if all fail
                 LOG.exception(f"Failed to load plugin '{plug_name}'")
 
         if not protos:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "hivemind_bus_client>=0.10.1a1,<1.0.0",
     "ovos_utils>=0.0.33,<1.0.0",
     "pybase64",
-    "hivemind-plugin-manager>=0.8.0a1,<1.0.0",
+    # 0.9.0a1 added AbstractDB.get_client_by_api_key, which ClientDatabase calls
+    "hivemind-plugin-manager>=0.9.0a1,<1.0.0",
     "ovos-bus-client>=2.0.0a3",
     "json-database>=0.10.2a1,<2.0.0",
     "hivemind-sqlite-database>=0.4.0a2",

--- a/tests/test_client_metadata.py
+++ b/tests/test_client_metadata.py
@@ -4,6 +4,8 @@ import pytest
 from click import BadParameter
 from click.testing import CliRunner
 
+from hivemind_plugin_manager.database import AbstractDB
+
 from hivemind_core.database import ClientDatabase
 from hivemind_core.scripts import (
     add_client,
@@ -13,8 +15,13 @@ from hivemind_core.scripts import (
 )
 
 
-class MemoryDB:
-    """Minimal AbstractDB stand-in for ClientDatabase tests."""
+class MemoryDB(AbstractDB):
+    """In-memory backend for ClientDatabase tests.
+
+    Inherits AbstractDB so the fake is held to the same contract as a real
+    backend plugin, and inherits the generic implementations (such as
+    get_client_by_api_key) instead of quietly omitting them.
+    """
 
     def __init__(self):
         self.clients = []


### PR DESCRIPTION
Readability and de-duplication pass over `scripts.py`, `service.py`, `database.py`, `config.py` and the `policy.py` file header, plus one dependency-floor fix. **No behavior change.** `protocol.py` is untouched.

## `hivemind_core/scripts.py`

Ten commands repeated the same four lines to turn an optional `node_id` into a client record:

```python
node_id = node_id or prompt_node_id(db)
for client in db:
    if client.client_id == int(node_id):
        ...
```

That is now one `resolve_client(db, node_id)` helper. Each command reports a missing id itself, because the commands do not agree on how (see the bug note below), so the helper returns `None` rather than printing.

`allow-escalate`, `blacklist-escalate`, `allow-propagate` and `blacklist-propagate` were four copies of one body that differed only in the flag name and the word printed. They are now four one-line commands over a shared `toggle_capability(label, node_id, allow)`, with a `CAPABILITY_FIELDS` table mapping the HiveMessage type name to the `Client` field. The table keeps the label/field pairing in one place instead of repeating it at every call site, and an unknown capability fails at the lookup rather than deep inside the helper. Every message the operator sees is byte-identical to before, including the `exit()` on the allow path.

Removed the generated docstrings that restated the `help=` text already on the click decorator, and the `Args:` blocks that repeated the parameter names. Kept every docstring that explains something the code does not say — `derive-psk` and its crypto-spec reference, the skill/intent metadata section header, `migrate-db`.

`prompt_node_id` was annotated `-> int` but returns a `str`; every caller wraps it in `int()`. Annotation corrected.

`min_password_bits` no longer repeats the literal `40`; it reads the key that `get_server_config()` guarantees is present.

## `hivemind_core/database.py` and `pyproject.toml` — a version-floor bug

`ClientDatabase.get_client_by_api_key` probed its backend before calling it:

```python
direct_lookup = getattr(self.db, "get_client_by_api_key", None)
```

Its two neighbours, `get_client_by_id` and `refresh`, call straight through with no probe. The class already hard-requires those methods on the backend, so probing for this one alone was inconsistent — and worse, a backend missing the method degraded silently to a full table scan instead of failing loudly.

The probe was a symptom of a wrong dependency floor. `AbstractDB.get_client_by_api_key` was added in **hivemind-plugin-manager 0.9.0a1** (absent from 0.8.0a1 through 0.8.0a3, present from 0.9.0a1 on), while `pyproject.toml` still floored the dependency at `>=0.8.0a1`. `get_client_by_id` and `refresh` have been on `AbstractDB` since 0.8.0a1, which is why only this one call appeared to need a guard.

Fixed properly: the floor is now `>=0.9.0a1` and the method is called directly, exactly like its neighbours.

The test suite's `MemoryDB` fake did not inherit `AbstractDB`, so it did not get the generic implementation and was the only thing the probe was protecting. It now inherits `AbstractDB` and is held to the same contract as a real backend plugin. It was the only duck-typed *backend* fake in `tests/`; `FakeClientDatabase` in `test_last_seen_debounce.py` stands in for the `ClientDatabase` wrapper rather than a backend, and already implements the method.

Also documented why `add_client` tests `admin is not None` while the neighbouring fields use truthiness — so an explicit `admin=False` demotes a client instead of reading as "no change". That distinction was invisible.

## `hivemind_core/service.py`

- `_stop_presence` used `getattr(self, "_presence", None)` because `_presence` was only ever created inside `_start_presence`. `__post_init__` now initialises it to `None`, so the attribute always exists and the defensive lookup is gone.
- Bare `except:` on network plugin loading is now `except Exception`, with a comment saying why the failure is tolerated: one broken transport must not take the others down, and the `if not protos` check below still aborts startup when they all fail. Nothing is silently swallowed at startup — the failure is logged with a traceback and a total failure is fatal.
- Replaced the `Attributes:` block that listed the dataclass fields (and had drifted — it never mentioned `callbacks`) with a short note on what the hooks are for.
- Added a comment explaining why presence announces the *first* configured network protocol, and dropped the redundant `if net else {}` guard on a `next(..., {})`.

## `hivemind_core/config.py`

`runtime_password_min_bits()` hardcoded `True` and `40` as fallbacks, duplicating `_DEFAULT`. It now reads them from `_DEFAULT`, which makes that dict the single source of truth it claims to be. The per-call work in `get_server_config()` was left alone: caching it would stop the server from picking up config edits, which is a behavior change.

## `hivemind_core/policy.py`

Header only. The file carried an **AGPL-3.0** notice while the repo `LICENSE`, `pyproject.toml` and every sibling module are Apache-2.0. Replaced with the `SPDX-License-Identifier: Apache-2.0` line the other modules use. No code changed — the fail-closed chain and the `TYPE_CHECKING`-only import are deliberate and untouched.

## Bug found, not fixed here

`make-admin` is the only client-targeting command that prints nothing when the node id does not match any client — it exits silently. Every sibling prints `Invalid Node ID!`. Preserved as-is so this PR stays behavior-neutral; it needs its own PR with a test.

## Verification

- `pytest tests/ --ignore=tests/e2e`: **185 passed, 1 skipped** — identical to the count on `dev` before the change.
- hivemind-test-harness `tests/test_spec_musts.py` at its committed HEAD: **10 passed, 1 xfailed, 1 failed**. The one failure, `TestFloodLoopSuppression::test_flood_terminates_and_reinjection_is_suppressed`, **is pre-existing on `dev`**: the same test fails the same way against an untouched `origin/dev` checkout, timing out in an unbounded propagate/ping recursion through `handle_propagate_message` -> `handle_ping_message` -> `propagate_to_master`. That is a route-loop defect in `protocol.py`, which this PR does not touch, and it is being handled separately. Every other spec-MUST test passes and is unchanged.
- CLI wiring exercised: `--help` on the root group lists all 24 commands unchanged, plus `allow-escalate`, `blacklist-propagate`, `make-admin`, `set-metadata`, `policy` and `rename-client`.

## AI transparency

Written by Claude Opus under Claude Fable 5 orchestration.
