### PR TITLE
fix: honour the can_broadcast grant on BROADCAST

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -152,6 +152,7 @@ class HiveMindClientConnection:
     allowed_types: List[str] = field(default_factory=list)
     binarize: bool = False
     site_id: str = "unknown"
+    can_broadcast: bool = True
     can_escalate: bool = True
     can_propagate: bool = True
     is_admin: bool = False
@@ -1180,7 +1181,11 @@ class HiveMindListenerProtocol:
         """
         payload = self._unpack_message(message, client)
 
-        if not client.is_admin:
+        # BROADCAST stays an admin privilege, and ``can_broadcast`` narrows it:
+        # the DB column defaults to True, so an operator who revokes it on an
+        # admin client stops that client's broadcasts, while ordinary clients
+        # gain nothing from the default.
+        if not (client.is_admin and client.can_broadcast):
             LOG.warning("Received broadcast message from downstream, illegal action")
             if self.illegal_callback:
                 self.illegal_callback(payload)

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -418,6 +418,49 @@ def blacklist_msg(msg_type, node_id):
             print("Invalid Node ID!")
 
 
+@hmcore_cmds.command(help="allow 'BROADCAST' messages to be sent from a client", name="allow-broadcast")
+@click.argument("node_id", required=False, type=int)
+def allow_broadcast(node_id):
+    """Grant a client permission to send 'BROADCAST' messages.
+
+    The client must also be an admin — broadcast is an admin privilege and
+    this grant only narrows it.
+    """
+    with ClientDatabase() as db:
+        node_id = node_id or prompt_node_id(db)
+        for client in db:
+            if client.client_id == int(node_id):
+                if client.can_broadcast:
+                    print(f"Client {client.name} already allowed to send 'BROADCAST' messages")
+                    exit()
+                client.can_broadcast = True
+                db.update_item(client)
+                print(f"Allowed 'BROADCAST' messages for {client.name}")
+                if not client.is_admin:
+                    print(f"NOTE: {client.name} is not an admin, so it still can not broadcast")
+                break
+        else:
+            print("Invalid Node ID!")
+
+
+@hmcore_cmds.command(help="blacklist 'BROADCAST' messages from being sent by a client", name="blacklist-broadcast")
+@click.argument("node_id", required=False, type=int)
+def blacklist_broadcast(node_id):
+    with ClientDatabase() as db:
+        node_id = node_id or prompt_node_id(db)
+        for client in db:
+            if client.client_id == int(node_id):
+                if client.can_broadcast:
+                    client.can_broadcast = False
+                    db.update_item(client)
+                    print(f"Blacklisted 'BROADCAST' messages for {client.name}")
+                    return
+                print(f"Client '{client.name}' 'BROADCAST' messages already blacklisted")
+                break
+        else:
+            print("Invalid Node ID!")
+
+
 @hmcore_cmds.command(help="Allow 'ESCALATE' messages to be sent from a client.", name="allow-escalate")
 @click.argument("node_id", required=False, type=int)
 def allow_escalate(node_id):

--- a/tests/test_broadcast_permission.py
+++ b/tests/test_broadcast_permission.py
@@ -1,0 +1,79 @@
+"""BROADCAST must honour the ``can_broadcast`` grant on the client row.
+
+``Client.can_broadcast`` is a column in the hivemind-plugin-manager database
+and the websocket protocol plugin copies it onto the live connection, but
+``HiveMindClientConnection`` never declared the field and
+``handle_broadcast_message`` gated on ``is_admin`` alone. An operator who
+revoked broadcast on a client saw no change in behaviour.
+
+The gate is now ``is_admin and can_broadcast``: admin is still required (the
+DB default is ``can_broadcast=True``, so gating on it alone would hand
+broadcast to every client), and revoking the grant now actually works.
+"""
+import dataclasses
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
+
+
+def _make_protocol():
+    proto = object.__new__(HiveMindListenerProtocol)
+    proto.peer = "master:0.0.0.0"
+    proto.clients = {}
+    proto.illegal_callback = MagicMock()
+    proto.broadcast_callback = MagicMock()
+    return proto
+
+
+def _make_client(is_admin: bool, can_broadcast: bool) -> MagicMock:
+    client = MagicMock()
+    client.peer = "node::abc"
+    client.is_admin = is_admin
+    client.can_broadcast = can_broadcast
+    return client
+
+
+def _broadcast() -> HiveMessage:
+    inner = HiveMessage(HiveMessageType.BUS,
+                        payload=Message("speak", {"utterance": "hi"}))
+    return HiveMessage(HiveMessageType.BROADCAST, payload=inner)
+
+
+def test_connection_declares_can_broadcast():
+    """The grant must be a real field, like ``can_escalate``/``can_propagate``,
+    not a stray attribute assigned by the transport plugin."""
+    fields = {f.name: f for f in dataclasses.fields(HiveMindClientConnection)}
+    assert "can_broadcast" in fields, \
+        "HiveMindClientConnection must declare can_broadcast"
+    assert fields["can_broadcast"].default is True, \
+        "default must match the Client DB column default (True)"
+
+
+def test_revoked_broadcast_is_denied_even_for_admin():
+    proto = _make_protocol()
+    client = _make_client(is_admin=True, can_broadcast=False)
+    proto.handle_broadcast_message(_broadcast(), client)
+    proto.broadcast_callback.assert_not_called()
+    proto.illegal_callback.assert_called_once()
+    client.disconnect.assert_called_once_with()
+
+
+def test_granted_broadcast_is_allowed_for_admin():
+    proto = _make_protocol()
+    client = _make_client(is_admin=True, can_broadcast=True)
+    proto.handle_broadcast_message(_broadcast(), client)
+    proto.broadcast_callback.assert_called_once()
+    client.disconnect.assert_not_called()
+
+
+def test_grant_alone_does_not_promote_a_non_admin():
+    """``can_broadcast`` defaults to True on every DB row, so it may only
+    narrow the admin privilege, never widen it to ordinary clients."""
+    proto = _make_protocol()
+    client = _make_client(is_admin=False, can_broadcast=True)
+    proto.handle_broadcast_message(_broadcast(), client)
+    proto.broadcast_callback.assert_not_called()
+    client.disconnect.assert_called_once_with()


### PR DESCRIPTION
## The defect

`Client.can_broadcast` is a real column in the client database
(`hivemind_plugin_manager.database.Client`, default `True`), and the websocket
transport plugin copies it onto the live connection with
`self.client.can_broadcast = user.can_broadcast`. But
`HiveMindClientConnection` never declared the field, so that assignment only
created a stray instance attribute that nothing in hivemind-core ever read.
`handle_broadcast_message` gated on `client.is_admin` instead.

## How it manifests for an operator

An operator who revokes broadcast on a client — in the database, or through a
management UI — sees no change at all. The client keeps broadcasting. There was
also no CLI command to set the flag, so the grant was inert from end to end.

## The fix

- Declare `can_broadcast: bool = True` on `HiveMindClientConnection`, next to
  `can_escalate` and `can_propagate`, matching their idiom.
- Gate `handle_broadcast_message` on `client.is_admin and client.can_broadcast`.
- Add `allow-broadcast` and `blacklist-broadcast` CLI commands, mirroring the
  escalate and propagate commands.

### Why `is_admin and can_broadcast`, not `can_broadcast` alone

The database default is `can_broadcast=True` for every row. Gating on the flag
alone would hand BROADCAST to every connected client, including ordinary
satellites — a privilege escalation, not a bug fix. Keeping admin in the gate
means the flag can only narrow the admin privilege. Revocation now works;
nothing gains a permission it did not have before.

## Back-compat and migration impact

None. Every existing admin client has `can_broadcast=True` by default, so
behaviour is unchanged after upgrade. The only new behaviour is that revoking
the flag now takes effect.

## Companion change (different repo)

`hivemind-websocket-protocol` already assigns `can_broadcast` onto the
connection; with this PR merged that assignment starts working, so no change is
needed there. For the record, the neighbouring assignments in the same block —
`msg_blacklist`, `skill_blacklist`, `intent_blacklist` — are still dead: nothing
in hivemind-core reads them. hivemind-core is whitelist-only by design
(`allowed_types` + `MessageTypeACLPolicy`), and the skill/intent blacklists live
in `Client.metadata` for the OVOS policy. Documented here only; nothing removed.

## Tests

New `tests/test_broadcast_permission.py`:

- `test_connection_declares_can_broadcast`
- `test_revoked_broadcast_is_denied_even_for_admin`
- `test_granted_broadcast_is_allowed_for_admin`
- `test_grant_alone_does_not_promote_a_non_admin`

The first two fail on `dev`.

## Results

- Unit suite: 189 passed, 1 skipped (baseline 185 passed, 1 skipped).
- Harness conformance gate (`hivemind-test-harness/tests/test_spec_musts.py`):
  **11 passed, 1 xfailed** — matches the `dev` baseline exactly, no XPASS.

## AI transparency

Found by structural analysis and fixed by Claude Opus under Claude Fable 5
orchestration. Reviewed by a human before merge.
