### PR TITLE
fix: stamp provenance with the node public key, not a shared constant

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -387,6 +387,9 @@ class CascadeCollector:
 class HiveMindListenerProtocol:
     agent_protocol: Optional[AgentProtocol] = None
     binary_data_protocol: Optional[BinaryDataHandlerProtocol] = None
+    # Human-readable label for logs only. ``service.py`` never sets it, so
+    # every deployed node shares this default — it identifies nothing. Use
+    # ``_node_id`` (the node public key) for provenance and addressing.
     peer: str = "master:0.0.0.0"
 
     require_crypto: bool = True  # throw error if crypto key not available
@@ -576,7 +579,7 @@ class HiveMindListenerProtocol:
             "pubkey": client.handshake.pubkey,
             # allows any node to verify messages are signed with this
             "peer": client.peer,  # this identifies the connected client in ovos message.context
-            "node_id": self.peer
+            "node_id": self._node_id
         }
         client._hello_payload = hello_payload  # bound into the Noise prologue
         msg = HiveMessage(HiveMessageType.HELLO, payload=hello_payload)
@@ -915,7 +918,7 @@ class HiveMindListenerProtocol:
                 client.noise_handshake = start_noise_handshake(
                     initiator=False, pattern=pattern, suite=suite,
                     password=client.pswd_handshake.password,
-                    node_id=self.peer, prologue=prologue,
+                    node_id=self._node_id, prologue=prologue,
                     key_path=self.identity.noise_key,
                     remote_pubkey=pinned if pattern == NOISE_PATTERN_KK else None)
                 node_payload = json.loads(
@@ -1213,7 +1216,7 @@ class HiveMindListenerProtocol:
         pload = message.payload
         # keep info about which nodes this message has been to
         pload.replace_route(message.route)
-        pload.update_source_peer(self.peer)
+        pload.update_source_peer(self._node_id)
         pload.remove_target_peer(client.peer)
         return pload
 
@@ -1407,7 +1410,7 @@ class HiveMindListenerProtocol:
         # Build our own responsive PING with the same flood_id
         own_ping_payload = {
             "flood_id": flood_id,
-            "peer": self.peer,
+            "peer": self._node_id,
             "site_id": self.identity.site_id,
             "timestamp": time.time(),
         }
@@ -1570,14 +1573,14 @@ class HiveMindListenerProtocol:
                 resp = Message("speak", {"utterance": chunk, "lang": lang},
                                {"query_id": query_id})
                 send_fn(self._build_query_response(
-                    msg_type, resp, query_id, originator_peer, self.peer,
+                    msg_type, resp, query_id, originator_peer, self._node_id,
                     route=route))
         except NotImplementedError:
             return False  # agent has no NL backend -> escalate
         if answered:
             send_fn(self._build_query_response(
                 msg_type, Message(QUERY_STREAM_END, {}), query_id,
-                originator_peer, self.peer, route=route))
+                originator_peer, self._node_id, route=route))
         return answered
 
     def _route_query_response(self, message: HiveMessage,
@@ -1683,7 +1686,7 @@ class HiveMindListenerProtocol:
                                 {"query_id": query_id, "error": "no_answer"})
             client.send(self._build_query_response(
                 HiveMessageType.QUERY, error_bus, query_id,
-                originator_peer, self.peer, route=message.route))
+                originator_peer, self._node_id, route=message.route))
 
     def cascade_from_master(self, message: HiveMessage) -> None:
         """Relay a CASCADE received from the upstream master.
@@ -1979,7 +1982,6 @@ class HiveMindListenerProtocol:
         # send client message to internal mycroft bus
         LOG.info(f"Forwarding message '{message.msg_type}' to agent bus from client: {client.peer}")
         message.context["peer"] = message.context["source"] = client.peer
-        message.context["source"] = client.peer
 
         try:
             bus = self.get_bus(client)

--- a/tests/test_illegal_action_disconnect.py
+++ b/tests/test_illegal_action_disconnect.py
@@ -19,6 +19,7 @@ from hivemind_core.protocol import HiveMindListenerProtocol
 def _make_protocol():
     proto = object.__new__(HiveMindListenerProtocol)
     proto.peer = "master:0.0.0.0"
+    proto.identity = MagicMock(public_key="master-pubkey")
     proto.clients = {}
     proto.illegal_callback = MagicMock()
     proto.broadcast_callback = MagicMock()

--- a/tests/test_node_provenance.py
+++ b/tests/test_node_provenance.py
@@ -1,0 +1,98 @@
+"""Provenance fields must carry this node's real identity, not a constant.
+
+``HiveMindListenerProtocol.peer`` is the class default ``"master:0.0.0.0"``
+and ``service.py`` never overrides it, so every node in every deployment
+announced the same string. Loop detection was already moved to
+``self._node_id`` (the node public key) for exactly that reason; the other
+provenance and addressing uses were left behind:
+
+* ``_unpack_message`` -> ``update_source_peer``
+* the responsive PING payload ``peer``
+* ``responder_peer`` on QUERY/CASCADE responses
+
+These tests build nodes the way production does — shared default ``peer``,
+distinct public keys — and pin every one of those fields to the public key.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+DEFAULT_PEER = "master:0.0.0.0"
+NODE_KEY = "pubkey-of-this-node"
+
+
+def _make_node() -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = DEFAULT_PEER
+    node.identity = MagicMock(public_key=NODE_KEY, site_id="site-a")
+    node.clients = {}
+    node.hive_mapper = MagicMock()
+    node.agent_protocol = MagicMock()
+    node._seen_flood_ids = set()
+    node._upstream_hm = None
+    return node
+
+
+def _client() -> MagicMock:
+    client = MagicMock()
+    client.peer = "satellite::1"
+    return client
+
+
+def test_unpacked_message_source_peer_is_the_node_key():
+    node = _make_node()
+    inner = HiveMessage(HiveMessageType.BUS,
+                        payload=Message("speak", {"utterance": "hi"}))
+    outer = HiveMessage(HiveMessageType.PROPAGATE, payload=inner)
+
+    payload = node._unpack_message(outer, _client())
+
+    assert payload.source_peer == NODE_KEY, (
+        "a relayed payload must name this node by its public key, not the "
+        f"shared default {DEFAULT_PEER!r}")
+
+
+def test_responsive_ping_announces_the_node_key():
+    node = _make_node()
+    sent = []
+    conn = _client()
+    conn.send = sent.append
+    node.clients = {conn.peer: conn}
+    node.propagate_to_master = lambda msg: None
+
+    ping = HiveMessage(HiveMessageType.PING, payload={
+        "flood_id": "flood-1", "peer": "somewhere-else",
+        "site_id": "site-b", "timestamp": 0})
+    node.handle_ping_message(ping, _client())
+
+    assert sent, "an unseen flood must be re-flooded to peers"
+    payload = sent[0].payload.payload
+    assert payload["peer"] == NODE_KEY, (
+        "the responsive PING must announce this node's public key, not the "
+        f"shared default {DEFAULT_PEER!r}")
+
+
+def test_query_response_responder_peer_is_the_node_key():
+    node = _make_node()
+    node.default_lang = "en-US"
+    node.agent_protocol.answer_query.return_value = iter(["hello there"])
+    node._admit_for_query = lambda message, client: message
+
+    inner = HiveMessage(HiveMessageType.BUS,
+                        payload=Message("recognizer_loop:utterance",
+                                        {"utterances": ["hi"]}))
+    query = HiveMessage(HiveMessageType.QUERY, payload=inner,
+                        metadata={"query_id": "q1"})
+    sent = []
+    answered = node._answer_query_locally(
+        query, _client(), "q1", "satellite::1",
+        HiveMessageType.QUERY, query.route, sent.append)
+
+    assert answered and sent
+    for response in sent:
+        assert response.metadata["responder_peer"] == NODE_KEY, (
+            "a query response must identify the answering node by public "
+            f"key, not the shared default {DEFAULT_PEER!r}")


### PR DESCRIPTION
## The defect

`HiveMindListenerProtocol.peer` is the class default `"master:0.0.0.0"`, and
`hivemind_core/service.py` builds the protocol without ever passing `peer`. So
every node, in every deployment, reports the identical string. Loop detection
was already moved off it onto `self._node_id` (the node public key) for exactly
this reason — see the `_node_id` docstring — but the other uses were left
behind and still stamped the shared constant onto the wire.

## How it manifests for an operator

Anything that identifies "which node did this" is useless in a mesh: query
responses all claim to come from `master:0.0.0.0`, PING floods announce the same
origin from every node, and relayed payloads all carry the same `source_peer`.
Debugging a multi-node hive by reading provenance is impossible, and a remote
node cannot key on any of it.

## The fix

Use `self._node_id` (`identity.public_key`) everywhere the value is provenance
or addressing:

- the HELLO `node_id` field a client stores as its master's identity
- the Noise PSK salt (`start_noise_handshake(node_id=...)`)
- `_unpack_message` -> `update_source_peer`
- the responsive PING payload `peer`
- `responder_peer` on QUERY and CASCADE responses

Also removes a duplicated `message.context["source"] = client.peer` line left by
a merge (the line above already assigns it).

### What was deliberately kept

The `peer` field itself stays, now documented as a log label only. It is still
read by log lines and by `hivemind-test-harness` (`test_spec_musts.py` uses it
as an arbitrary PING origin), and removing it would break external callers for
no gain. Nothing keys on it any more. Connection-level `client.peer` is
untouched — that one is a real per-connection name.

## Back-compat and migration impact

The Noise PSK salt is `SHA-256(node_id)` where `node_id` is *the value the
server announced in its cleartext HELLO*. The client reads it from that HELLO
rather than assuming a constant, so both sides still derive the same salt and no
handshake breaks across the change. Clients that pinned the old announced
`node_id` will see the master's identity change from `master:0.0.0.0` to its
public key once; the Noise static-key pin store is keyed on `host:port`, not on
`node_id`, so pinning is unaffected. Any external tooling that hardcoded
`master:0.0.0.0` as a peer name must stop doing so — it never identified
anything.

## Tests

New `tests/test_node_provenance.py`, all three fail on `dev`:

- `test_unpacked_message_source_peer_is_the_node_key`
- `test_responsive_ping_announces_the_node_key`
- `test_query_response_responder_peer_is_the_node_key`

`tests/test_illegal_action_disconnect.py` gained an `identity` mock on its
hand-built protocol fixture.

## Results

- Unit suite: 188 passed, 1 skipped (baseline 185 passed, 1 skipped).
- In-repo e2e: 51 passed, 2 skipped, 1 xpassed. The XPASS
  (`test_bridge1_conformance.py::test_fifo_order_relay_chain`, non-strict) is
  pre-existing on `dev` and unrelated to this change.
- Harness conformance gate (`hivemind-test-harness/tests/test_spec_musts.py`):
  **11 passed, 1 xfailed** — matches the `dev` baseline exactly, no XPASS.

## AI transparency

Found by structural analysis and fixed by Claude Opus under Claude Fable 5
orchestration. Reviewed by a human before merge.
