### PR TITLE
fix(test): give the broadcast fixture an identity

### DIFF
--- a/tests/test_broadcast_permission.py
+++ b/tests/test_broadcast_permission.py
@@ -22,6 +22,9 @@ from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerPro
 def _make_protocol():
     proto = object.__new__(HiveMindListenerProtocol)
     proto.peer = "master:0.0.0.0"
+    # provenance is stamped from the node public key, so a hand-built
+    # protocol needs an identity even when the test is about permissions
+    proto.identity = MagicMock(public_key="pubkey-master", site_id=None)
     proto.clients = {}
     proto.illegal_callback = MagicMock()
     proto.broadcast_callback = MagicMock()


### PR DESCRIPTION
`dev` is red. PRs #181 and #183 each passed their own gate and broke each other on merge.

#181 added `tests/test_broadcast_permission.py` with a hand-built fixture (`object.__new__`) that sets `peer` and `clients`. #183 then moved provenance stamping from the shared `peer` constant onto the node public key, so the broadcast path now reads `self.identity` — which that fixture never set:

    AttributeError: 'HiveMindListenerProtocol' object has no attribute 'identity'

Three of #181's own tests fail on current dev HEAD as a result.

Test-only fix: the fixture gets an `identity` mock, matching what #183 already did for the equivalent fixture in `test_illegal_action_disconnect.py`.

- `tests/test_broadcast_permission.py`: 4 passed
- full non-e2e suite: 192 passed, 1 skipped

Worth noting for process: both PRs were gated green independently against the same baseline, and neither gate could see the other's change. Sequential merges need a post-merge check on dev, not just a pre-merge gate per branch.

---
*Written by Claude Opus 4.8 under Claude Fable 5 orchestration, without human oversight.*