### PR TITLE
fix: drop QUERY/CASCADE responses with no return path

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1590,11 +1590,14 @@ class HiveMindListenerProtocol:
 
     def _route_query_response(self, message: HiveMessage,
                               client: Optional[HiveMindClientConnection]):
-        """Route a QUERY response downstream toward its originator (direct
-        client if connected here, else fan to downstream peers).
+        """Route a QUERY response downstream toward its originator: the direct
+        client if it is connected here, else the downstream hop the request
+        arrived on (from the recorded route). A response that resolves to
+        neither is dropped — see the end of this method.
 
-        ``client`` is the connection the response arrived on, excluded from the
-        last-resort fan-out. It is None when the response came from upstream.
+        ``client`` is the connection the response arrived on; it is never a
+        return path for its own response. It is None when the response came
+        from upstream.
         """
         sender = client.peer if client else None
         metadata = message.metadata or {}
@@ -1640,11 +1643,12 @@ class HiveMindListenerProtocol:
             if src and src != sender and src in self.clients:
                 self.clients[src].send(message)
                 return
-        # unknown return path: fan downstream (excluding the sender) as a last resort
-        for peer in self.clients:
-            if peer == sender:
-                continue
-            self.clients[peer].send(message)
+        # no return path: the originator is not ours and the route names no
+        # peer we can reach. Fanning the response downstream would hand one
+        # peer's answer to its siblings (NODE-1 §5.2, AGENT-1 §3.2), so drop it.
+        LOG.warning(f"dropping {message.msg_type} response with no return path: "
+                    f"query_id={metadata.get('query_id', '')} "
+                    f"originator_peer={originator_peer}")
 
     def handle_query_message(self, message: HiveMessage,
                              client: HiveMindClientConnection):

--- a/tests/test_query_response_isolation.py
+++ b/tests/test_query_response_isolation.py
@@ -1,0 +1,131 @@
+"""Response isolation for QUERY/CASCADE answers.
+
+HIVEMIND-NODE-1 §5.2: "A chunk goes to the originator only, never to the
+other downstream nodes of a relay."
+
+HIVEMIND-AGENT-1 §3.2: "A peer MUST NOT receive a response generated for a
+different peer."
+
+A node routes a response to the originator if it is a direct client, else to
+the downstream hop the request arrived on (the recorded route). When neither
+resolves, the node does not know where the response belongs — it MUST drop it,
+because delivering it anywhere else hands one peer's answer to its siblings.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_node(node_key: str = "pubkey-A") -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = "master:0.0.0.0"
+    node.identity = MagicMock(public_key=node_key, site_id=None)
+    node.clients = {}
+    node.cascade_select_callback = None
+    node._pending_cascades = {}
+    return node
+
+
+def _wire_peers(node, *peers):
+    sent = {p: [] for p in peers}
+    for p in peers:
+        conn = MagicMock()
+        conn.send = lambda m, box=sent[p]: box.append(m)
+        node.clients[p] = conn
+    return sent
+
+
+def _response(originator: str, route=None) -> HiveMessage:
+    msg = HiveMessage(
+        HiveMessageType.QUERY,
+        payload=HiveMessage(HiveMessageType.BUS,
+                            payload=Message("speak", {"utterance": "42"})),
+        metadata={"query_id": "q1", "is_response": True,
+                  "originator_peer": originator,
+                  "responder_peer": "pubkey-Z"})
+    if route:
+        msg.replace_route(route)
+    return msg
+
+
+# --- the defect: an unresolvable return path must not be fanned out --------
+
+def test_unresolvable_response_reaches_no_peer():
+    """No originator, no usable route -> nobody gets the answer."""
+    node = _make_node()
+    sent = _wire_peers(node, "sibling::1", "sibling::2")
+
+    node._route_query_response(_response("gone::9"), None)
+
+    assert sent["sibling::1"] == [], "a sibling received another peer's answer"
+    assert sent["sibling::2"] == [], "a sibling received another peer's answer"
+
+
+def test_response_with_unknown_route_hops_reaches_no_peer():
+    """A route naming only nodes we are not connected to is not a return path."""
+    node = _make_node()
+    sent = _wire_peers(node, "sibling::1", "sibling::2")
+
+    node._route_query_response(
+        _response("gone::9", route=[{"source": "pubkey-R", "targets": ["x"]}]),
+        None)
+
+    assert sent["sibling::1"] == []
+    assert sent["sibling::2"] == []
+
+
+def test_unresolvable_response_from_a_client_reaches_no_peer():
+    """Same rule when the response arrives from a downstream peer."""
+    node = _make_node()
+    sent = _wire_peers(node, "responder::1", "sibling::2")
+    client = MagicMock(peer="responder::1")
+
+    node._route_query_response(_response("gone::9"), client)
+
+    assert sent["responder::1"] == []
+    assert sent["sibling::2"] == [], "a sibling received another peer's answer"
+
+
+# --- positive controls: legitimate responses still get delivered -----------
+
+def test_direct_originator_still_receives_the_response():
+    node = _make_node()
+    sent = _wire_peers(node, "asker::1", "sibling::2")
+
+    node._route_query_response(_response("asker::1"), None)
+
+    assert len(sent["asker::1"]) == 1
+    assert sent["sibling::2"] == []
+
+
+def test_route_walk_still_delivers_to_the_downstream_hop():
+    """The originator sits behind a relay: the hop the request arrived on is
+    recorded in the route and is the return path."""
+    node = _make_node()
+    sent = _wire_peers(node, "relay::1", "sibling::2")
+
+    node._route_query_response(
+        _response("behind-relay::7",
+                  route=[{"source": "relay::1", "targets": ["master:0.0.0.0"]}]),
+        None)
+
+    assert len(sent["relay::1"]) == 1, "route-walk return path stopped delivering"
+    assert sent["sibling::2"] == []
+
+
+def test_route_walk_does_not_send_the_response_back_to_its_sender():
+    node = _make_node()
+    sent = _wire_peers(node, "relay::1", "responder::2")
+    client = MagicMock(peer="responder::2")
+
+    node._route_query_response(
+        _response("behind-relay::7",
+                  route=[{"source": "responder::2", "targets": ["master:0.0.0.0"]},
+                         {"source": "relay::1", "targets": ["master:0.0.0.0"]}]),
+        client)
+
+    assert len(sent["relay::1"]) == 1
+    assert sent["responder::2"] == []


### PR DESCRIPTION
## The spec clause

**HIVEMIND-NODE-1 §5.2**

> Each chunk is relayed back toward the originator **as it is produced**, in order [...] A chunk goes to the originator only, never to the other downstream nodes of a relay.

**HIVEMIND-AGENT-1 §3.2**

> A peer **MUST NOT** receive a response generated for a different peer. This **response isolation** is what lets many peers share one backend without observing each other's traffic.

## How the code violated it

`_route_query_response` in `hivemind_core/protocol.py` used a three-step ladder:

1. deliver to `originator_peer` if it is a direct client;
2. else walk the recorded `route` back and deliver to the first hop we are connected to;
3. **else send the response to every downstream client except the sender.**

Step 3 is a broadcast of one peer's answer to all of its siblings. It fires whenever a response arrives whose originator is not ours and whose route names no peer we hold — for example after the originator's relay disconnects. Every sibling then sees an answer generated for somebody else.

PR #172 fixed the case where such a response arrives from upstream. Step 3 is what remained.

## Is fan-out ever the only way home?

No. It was worth checking, because if an originator behind a relay could leave no resolvable hop, dropping would strand legitimate answers.

It always leaves one. `handle_message` stamps every arriving message before dispatch:

```python
message.update_source_peer(client.peer)
message.update_hop_data()
```

`update_hop_data` appends `{"source": <the peer id of the connection it arrived on>}` to `route`. So when a QUERY reaches this node through relay `R`, the last route hop names `R` **as this node knows it** — the same string used as the key in `self.clients`. The response carries that route back (`_build_query_response(..., route=message.route)`), so the route walk in step 2 resolves the hop for any originator that is reachable through a relay we are still connected to.

The only way both steps fail is that the return path genuinely no longer exists here: the connection is gone, or the route was never recorded. In neither case does the node know which peer the answer belongs to, and guessing is precisely the violation.

Note that route hops written by `_append_self_hop` use `_node_id` (the node public key), which is a different namespace and never matches a `self.clients` key. That is intentional — those hops are for MSG-1 §5 loop detection, not for return addressing — and it is not what the return walk relies on.

## The fix

Replace the fan-out with a warning naming the query id and the originator, then drop. The docstring now states the delivery contract instead of describing a fan-out.

## Back-compat impact

Stated plainly: a response that previously reached the wrong peers now reaches nobody, and a `WARNING` line appears in the node log.

There is no deployment where this loses a correct delivery — the fan-out could only ever deliver to peers the response was not for. If a deployment was relying on the fan-out, it was relying on the originator's sibling forwarding the answer on by accident; that behaviour was never in the spec and leaked every peer's answers to every other peer along the way.

Timeouts are unaffected: NODE-1 §5.5 already requires the originator to bound its own wait, so a dropped response degrades to the same timeout as a vanished relay.

## Tests

New `tests/test_query_response_isolation.py`.

The defect (all three fail on `origin/dev`, pass here):

- `test_unresolvable_response_reaches_no_peer`
- `test_response_with_unknown_route_hops_reaches_no_peer`
- `test_unresolvable_response_from_a_client_reaches_no_peer`

Positive controls (pass on `origin/dev` and here, so the fix does not quietly stop delivering legitimate responses):

- `test_direct_originator_still_receives_the_response`
- `test_route_walk_still_delivers_to_the_downstream_hop`
- `test_route_walk_does_not_send_the_response_back_to_its_sender`

Fail-on-old proof, with the fix reverted:

```
FAILED tests/test_query_response_isolation.py::test_unresolvable_response_reaches_no_peer
FAILED tests/test_query_response_isolation.py::test_response_with_unknown_route_hops_reaches_no_peer
FAILED tests/test_query_response_isolation.py::test_unresolvable_response_from_a_client_reaches_no_peer
3 failed, 3 passed
```

## Counts

| Suite | Baseline on `dev` | This branch |
|---|---|---|
| unit (`tests/`, no e2e) | 194 passed, 1 skipped | **200 passed, 1 skipped** |
| conformance gate (`hivemind-test-harness` `test_spec_musts.py`) | 11 passed, 1 xfailed | **11 passed, 1 xfailed** |
| in-repo e2e (`tests/e2e`) | 51 passed, 2 skipped, 1 xpassed | **51 passed, 2 skipped, 1 xpassed** |

The e2e `XPASS` is `test_bridge1_conformance.py::test_fifo_order_relay_chain`. It is pre-existing — confirmed by running that file against `origin/dev`'s `protocol.py` — the marker is not strict, and it is unrelated to this change.

## AI transparency

Written by Claude Opus under Claude Fable 5 orchestration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query response routing to deliver responses only along the correct return path.
  * Prevented responses without a reachable return path from being sent to unrelated peers.
  * Ensured responses are not echoed back to the sender.

* **Tests**
  * Added coverage for direct, routed, and unresolved response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->