### PR TITLE
fix: reject malformed wrapper payloads instead of crashing

### DIFF
--- a/docs/policy.md
+++ b/docs/policy.md
@@ -127,6 +127,7 @@ Codes returned by built-in policies and the chain runner:
 | `policy_chain_unavailable` | `DenyAllPolicy` | Chain construction failed at startup |
 | `session_id_default_forbidden` | `DefaultSessionPolicy` | Client tried to use the reserved `default` session id |
 | `backend_unavailable` | `HiveMindListenerProtocol` | The message passed admission, but the agent bus is unreachable, so nothing was forwarded. Not a policy decision — retry later |
+| `malformed_payload` | `HiveMindListenerProtocol` | A QUERY, BROADCAST, PROPAGATE, ESCALATE or CASCADE did not carry a nested `HiveMessage` payload, as HIVEMIND-MSG-1 §4 requires. Not a policy decision — the frame is unusable and the sender must fix it |
 
 Plugin authors are free to mint their own `code` values. Reuse a
 built-in code only when the semantics match.

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -127,7 +127,7 @@ Codes returned by built-in policies and the chain runner:
 | `policy_chain_unavailable` | `DenyAllPolicy` | Chain construction failed at startup |
 | `session_id_default_forbidden` | `DefaultSessionPolicy` | Client tried to use the reserved `default` session id |
 | `backend_unavailable` | `HiveMindListenerProtocol` | The message passed admission, but the agent bus is unreachable, so nothing was forwarded. Not a policy decision — retry later |
-| `malformed_payload` | `HiveMindListenerProtocol` | A QUERY, BROADCAST, PROPAGATE, ESCALATE or CASCADE did not carry a nested `HiveMessage` payload, as HIVEMIND-MSG-1 §4 requires. Not a policy decision — the frame is unusable and the sender must fix it |
+| `malformed_payload` | `HiveMindListenerProtocol` | The payload of the message can not be reconstructed, at any nesting level: a QUERY, BROADCAST, PROPAGATE, ESCALATE or CASCADE that does not carry a nested `HiveMessage` as HIVEMIND-MSG-1 §4 requires, a BUS or SHARED_BUS whose payload is not a bus `Message`, or a payload that is not a dict. The node catches every `Exception` the reconstruction raises. Not a policy decision — the frame is unusable and the sender must fix it |
 
 Plugin authors are free to mint their own `code` values. Reuse a
 built-in code only when the semantics match.

--- a/hivemind_core/policy.py
+++ b/hivemind_core/policy.py
@@ -24,6 +24,12 @@ if TYPE_CHECKING:
 #: decision — the message is lost and the client should retry.
 BACKEND_UNAVAILABLE = "backend_unavailable"
 
+#: Reported to the client when a wrapper message (QUERY, BROADCAST, PROPAGATE,
+#: ESCALATE, CASCADE) does not carry a nested ``HiveMessage`` payload, as
+#: HIVEMIND-MSG-1 §4 requires. Not a policy decision — the frame is unusable
+#: and the sender must fix how it builds it.
+MALFORMED_PAYLOAD = "malformed_payload"
+
 
 @dataclass
 class PolicyChain:

--- a/hivemind_core/policy.py
+++ b/hivemind_core/policy.py
@@ -24,10 +24,12 @@ if TYPE_CHECKING:
 #: decision — the message is lost and the client should retry.
 BACKEND_UNAVAILABLE = "backend_unavailable"
 
-#: Reported to the client when a wrapper message (QUERY, BROADCAST, PROPAGATE,
-#: ESCALATE, CASCADE) does not carry a nested ``HiveMessage`` payload, as
-#: HIVEMIND-MSG-1 §4 requires. Not a policy decision — the frame is unusable
-#: and the sender must fix how it builds it.
+#: Reported to the client when the payload of a message can not be
+#: reconstructed — a wrapper message (QUERY, BROADCAST, PROPAGATE, ESCALATE,
+#: CASCADE) that does not carry a nested ``HiveMessage`` as HIVEMIND-MSG-1 §4
+#: requires, a BUS or SHARED_BUS whose payload is not a bus ``Message``, or any
+#: payload that is not a dict at all. Not a policy decision — the frame is
+#: unusable and the sender must fix how it builds it.
 MALFORMED_PAYLOAD = "malformed_payload"
 
 

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -63,9 +63,17 @@ from hivemind_bus_client.hive_map import HiveMapper
 from hivemind_plugin_manager.protocols import AgentProtocol, BinaryDataHandlerProtocol, ClientCallbacks
 from hivemind_plugin_manager.database import Client
 from hivemind_plugin_manager.policy import PolicyPlugin
-from hivemind_core.policy import BACKEND_UNAVAILABLE, PolicyChain
+from hivemind_core.policy import (BACKEND_UNAVAILABLE, MALFORMED_PAYLOAD,
+                                  PolicyChain)
 from poorman_handshake import HandShake, PasswordHandShake
 from poorman_handshake.asymmetric.utils import decrypt_RSA, load_RSA_key, verify_RSA
+
+#: HIVEMIND-MSG-1 §4: the payload of these message types IS a nested
+#: ``HiveMessage``. Every other type carries a bus ``Message``, binary data or
+#: a plain dict.
+WRAPPER_TYPES = (HiveMessageType.PROPAGATE, HiveMessageType.BROADCAST,
+                 HiveMessageType.ESCALATE, HiveMessageType.QUERY,
+                 HiveMessageType.CASCADE)
 
 
 class ProtocolVersion(IntEnum):
@@ -752,6 +760,9 @@ class HiveMindListenerProtocol:
 
         message.update_hop_data()
 
+        if message.msg_type in WRAPPER_TYPES and not self._has_nested_payload(message, client):
+            return
+
         if message.msg_type == HiveMessageType.HANDSHAKE:
             self.handle_handshake_message(message, client)
         elif message.msg_type == HiveMessageType.HELLO:
@@ -782,6 +793,31 @@ class HiveMindListenerProtocol:
             self.handle_unknown_message(message, client)
 
         self.update_last_seen(client)
+
+    def _has_nested_payload(self, message: HiveMessage,
+                            client: HiveMindClientConnection) -> bool:
+        """Check that a wrapper message carries the nested ``HiveMessage`` that
+        HIVEMIND-MSG-1 §4 requires.
+
+        A peer that nests something else — a bus ``Message`` dict is the common
+        mistake — makes ``HiveMessage.payload`` raise while it rebuilds the
+        nested envelope, and that exception would escape the handler and take
+        the connection down. The frame is the sender's bug, so refuse it with
+        the ``hive.policy.denied`` reply used for every other refused message
+        and keep the peer connected: it is misinformed, not misbehaving, and it
+        needs the reply to learn that.
+        """
+        try:
+            message.payload
+        except Exception as e:
+            LOG.warning(f"malformed '{message.msg_type}' from {client.peer}: "
+                        f"payload is not a HiveMessage ({e})")
+            self._send_denied(
+                client, str(message.msg_type), MALFORMED_PAYLOAD,
+                f"'{message.msg_type}' payload must be a nested HiveMessage "
+                f"(HIVEMIND-MSG-1 §4)", {})
+            return False
+        return True
 
     # HiveMind protocol messages -  from slave -> master
     def handle_unknown_message(

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -71,6 +71,13 @@ from poorman_handshake.asymmetric.utils import decrypt_RSA, load_RSA_key, verify
 #: HIVEMIND-MSG-1 §4: the payload of these message types IS a nested
 #: ``HiveMessage``. Every other type carries a bus ``Message``, binary data or
 #: a plain dict.
+#:
+#: The list is documentation only — ``_payload_is_usable`` does NOT use it.
+#: Choosing the guarded types by spec section is what let the first version of
+#: the guard through with holes in it: ``SHARED_BUS`` rebuilds a bus
+#: ``Message`` from ``payload["type"]`` (``handle_client_shared_bus``) and is
+#: not in this list, and the wrapper handlers dereference the payload of the
+#: payload as well. Every type is checked instead — see ``_payload_is_usable``.
 WRAPPER_TYPES = (HiveMessageType.PROPAGATE, HiveMessageType.BROADCAST,
                  HiveMessageType.ESCALATE, HiveMessageType.QUERY,
                  HiveMessageType.CASCADE)
@@ -754,14 +761,17 @@ class HiveMindListenerProtocol:
 
         Process message from client, decide what to do internally here
         """
+        # BEFORE the debug log below: rendering a HiveMessage calls as_json,
+        # which asserts the payload is a dict, so a frame with a payload of
+        # ``7`` or ``[1, 2]`` crashes on the log line, not in a handler.
+        if not self._payload_is_usable(message, client):
+            return
+
         LOG.debug(f"message: {message}")
         # update internal peer ID
         message.update_source_peer(client.peer)
 
         message.update_hop_data()
-
-        if message.msg_type in WRAPPER_TYPES and not self._has_nested_payload(message, client):
-            return
 
         if message.msg_type == HiveMessageType.HANDSHAKE:
             self.handle_handshake_message(message, client)
@@ -794,27 +804,67 @@ class HiveMindListenerProtocol:
 
         self.update_last_seen(client)
 
-    def _has_nested_payload(self, message: HiveMessage,
-                            client: HiveMindClientConnection) -> bool:
-        """Check that a wrapper message carries the nested ``HiveMessage`` that
-        HIVEMIND-MSG-1 §4 requires.
+    @staticmethod
+    def _probe_payload(message: HiveMessage) -> None:
+        """Do everything ``handle_message`` and its handlers will later do to
+        the payload of ``message``, so a payload that cannot be reconstructed
+        raises here instead of inside a handler. Raises whatever the
+        reconstruction raises.
 
-        A peer that nests something else — a bus ``Message`` dict is the common
-        mistake — makes ``HiveMessage.payload`` raise while it rebuilds the
-        nested envelope, and that exception would escape the handler and take
-        the connection down. The frame is the sender's bug, so refuse it with
-        the ``hive.policy.denied`` reply used for every other refused message
-        and keep the peer connected: it is misinformed, not misbehaving, and it
+        Two things touch the payload of an incoming frame:
+
+        * ``as_json`` — the ``LOG.debug`` at the top of ``handle_message``
+          renders the message, and ``as_dict`` asserts the payload is a dict.
+        * ``HiveMessage.payload`` — it REBUILDS the payload for the types that
+          carry a nested envelope: a bus ``Message`` for ``BUS`` and
+          ``SHARED_BUS`` (``payload["type"]``), a ``HiveMessage`` for the five
+          wrapper types (``HiveMessage(**payload)``). Both raise on a payload
+          of the wrong shape. Every other type returns the payload as stored
+          and can never raise, so probing unconditionally is free for them —
+          and it removes the audit that the first version of this guard got
+          wrong.
+
+        The walk down the chain is what makes the guard deep enough. A wrapper
+        handler does not stop at ``message.payload``: it reads
+        ``message.payload.payload`` (``handle_propagate_message``,
+        ``handle_escalate_message``, ``_answer_query_locally``) and forwards
+        ``message.payload`` on to the next node, which will read a level deeper
+        again. So every level is rebuilt here, not one. The loop terminates
+        because each step descends one level of an already-parsed JSON object,
+        and json.loads has bounded the depth before this point.
+        """
+        if message.msg_type != HiveMessageType.BINARY:
+            message.as_dict  # what LOG.debug/__str__ does
+        node = message
+        while True:
+            payload = node.payload
+            if not isinstance(payload, HiveMessage):
+                return
+            node = payload
+
+    def _payload_is_usable(self, message: HiveMessage,
+                           client: HiveMindClientConnection) -> bool:
+        """Check the payload of ``message`` can be reconstructed, at every
+        level, before anything dereferences it.
+
+        A peer that sends a payload of the wrong shape — a bus ``Message`` dict
+        where HIVEMIND-MSG-1 §4 requires a nested ``HiveMessage``, a nested
+        envelope missing ``type``, a bare number — makes the reconstruction
+        raise, and the exception would escape the message handler and take the
+        connection down. The frame is the sender's bug, so refuse it with the
+        ``hive.policy.denied`` reply used for every other refused message and
+        keep the peer connected: it is misinformed, not misbehaving, and it
         needs the reply to learn that.
         """
         try:
-            message.payload
+            self._probe_payload(message)
         except Exception as e:
             LOG.warning(f"malformed '{message.msg_type}' from {client.peer}: "
-                        f"payload is not a HiveMessage ({e})")
+                        f"payload can not be reconstructed "
+                        f"({type(e).__name__}: {e})")
             self._send_denied(
                 client, str(message.msg_type), MALFORMED_PAYLOAD,
-                f"'{message.msg_type}' payload must be a nested HiveMessage "
+                f"'{message.msg_type}' payload can not be reconstructed "
                 f"(HIVEMIND-MSG-1 §4)", {})
             return False
         return True

--- a/tests/test_malformed_wrapper_payload.py
+++ b/tests/test_malformed_wrapper_payload.py
@@ -1,10 +1,13 @@
-"""A peer can send a malformed wrapper frame.
+"""A peer can send a frame whose payload can not be reconstructed.
 
 HIVEMIND-MSG-1 §4: the payload of a QUERY, BROADCAST, PROPAGATE, ESCALATE or
-CASCADE IS a nested ``HiveMessage``. A peer that nests a bus ``Message`` dict
-(``{"type": ..., "data": ..., "context": ...}``) instead breaks the spec, and
-``HiveMessage.payload`` raises ``TypeError`` when it tries to build the nested
-envelope.
+CASCADE IS a nested ``HiveMessage``, and the payload of a BUS or SHARED_BUS is
+a bus ``Message``. ``HiveMessage.payload`` rebuilds those on access, and
+rendering any message rebuilds it again through ``as_json``. Any payload of
+the wrong shape makes one of them raise — ``TypeError`` for a bus ``Message``
+dict where a nested envelope belongs, ``KeyError`` for a bus payload with no
+``type``, ``AssertionError`` for a payload that is not a dict — so the node
+catches ``Exception``, not one type.
 
 That is the sender's bug, but a node must not raise out of its message
 handler because a peer sent a bad frame. The node rejects the frame with the
@@ -111,6 +114,84 @@ class TestMalformedWrapperPayload(unittest.TestCase):
 
         self.assertNotIn("malformed_payload", _sent(client))
         protocol.agent_protocol.get_bus.assert_called()
+
+
+#: Exact frames an authenticated peer can put on the websocket. Each one used
+#: to escape ``handle_message`` uncaught. Keyed by what makes them malformed.
+MALFORMED_FRAMES = {
+    # the nested envelope is rebuilt, and ITS payload is dereferenced too:
+    # one forced level was not enough
+    "propagate/nested-bus-without-type":
+        '{"msg_type":"propagate","payload":{"msg_type":"bus","payload":{}}}',
+    "escalate/nested-bus-without-type":
+        '{"msg_type":"escalate","payload":{"msg_type":"bus","payload":{}}}',
+    "query/nested-bus-without-type":
+        '{"msg_type":"query","payload":{"msg_type":"bus","payload":{}}}',
+    "cascade/nested-bus-without-type":
+        '{"msg_type":"cascade","payload":{"msg_type":"bus","payload":{}}}',
+    "broadcast/nested-bus-without-type":
+        '{"msg_type":"broadcast","payload":{"msg_type":"bus","payload":{}}}',
+    # a bus Message dict nested two levels down
+    "propagate/bus-message-dict-two-levels-down":
+        '{"msg_type":"propagate","payload":{"msg_type":"propagate",'
+        '"payload":{"type":"x","data":{},"context":{}}}}',
+    # SHARED_BUS rebuilds a bus Message from payload["type"] as well
+    "shared_bus/payload-without-type":
+        '{"msg_type":"shared_bus","payload":{}}',
+    # a payload that is not a dict crashes the debug log, before any handler
+    "query/payload-is-a-list": '{"msg_type":"query","payload":[1,2]}',
+    "query/payload-is-a-number": '{"msg_type":"query","payload":7}',
+}
+
+
+class TestMalformedFrameOnTheWire(unittest.TestCase):
+    """The frames above, through the real ``decode()`` and
+    ``handle_message()`` path a websocket peer reaches."""
+
+    def _handle(self, raw: str):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+        message = client.decode(raw)  # must not raise
+        protocol.handle_message(message, client)  # must not raise
+        return client
+
+    def test_every_malformed_frame_is_denied_and_the_peer_stays(self):
+        for label, raw in MALFORMED_FRAMES.items():
+            with self.subTest(frame=label):
+                client = self._handle(raw)
+                sent = _sent(client)
+                self.assertIn("hive.policy.denied", sent)
+                self.assertIn("malformed_payload", sent)
+                client.disconnect.assert_not_called()
+
+    def test_a_well_formed_frame_still_gets_through(self):
+        raw = ('{"msg_type":"query","payload":{"msg_type":"bus","payload":'
+               '{"type":"recognizer_loop:utterance",'
+               '"data":{"utterances":["hi"]},"context":{}}}}')
+        client = self._handle(raw)
+        self.assertNotIn("malformed_payload", _sent(client))
+
+    def test_a_well_formed_shared_bus_frame_still_gets_through(self):
+        raw = ('{"msg_type":"shared_bus","payload":'
+               '{"type":"recognizer_loop:utterance",'
+               '"data":{"utterances":["hi"]},"context":{}}}')
+        client = self._handle(raw)
+        self.assertNotIn("malformed_payload", _sent(client))
+
+
+class TestGuardRunsBeforeTheDebugLog(unittest.TestCase):
+    """``handle_message`` logs the message before it dispatches it, and
+    rendering a HiveMessage asserts the payload is a dict. The guard has to be
+    above that line or a payload of ``7`` never reaches it."""
+
+    def test_a_non_dict_payload_never_reaches_the_log(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+        message = HiveMessage(HiveMessageType.QUERY, payload=7)
+
+        protocol.handle_message(message, client)  # must not raise
+
+        self.assertIn("malformed_payload", _sent(client))
 
 
 if __name__ == "__main__":

--- a/tests/test_malformed_wrapper_payload.py
+++ b/tests/test_malformed_wrapper_payload.py
@@ -1,0 +1,117 @@
+"""A peer can send a malformed wrapper frame.
+
+HIVEMIND-MSG-1 §4: the payload of a QUERY, BROADCAST, PROPAGATE, ESCALATE or
+CASCADE IS a nested ``HiveMessage``. A peer that nests a bus ``Message`` dict
+(``{"type": ..., "data": ..., "context": ...}``) instead breaks the spec, and
+``HiveMessage.payload`` raises ``TypeError`` when it tries to build the nested
+envelope.
+
+That is the sender's bug, but a node must not raise out of its message
+handler because a peer sent a bad frame. The node rejects the frame with the
+same ``hive.policy.denied`` shape used for every other refused message, and
+stays up.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivemind_bus_client import HiveMessage, HiveMessageType
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+#: the shape a misbehaving peer sends: a bus Message dict, not a HiveMessage
+BAD_PAYLOAD = {"type": "recognizer_loop:utterance",
+               "data": {"utterances": ["hello"]},
+               "context": {}}
+
+WRAPPER_TYPES = [HiveMessageType.QUERY, HiveMessageType.BROADCAST,
+                 HiveMessageType.PROPAGATE, HiveMessageType.ESCALATE,
+                 HiveMessageType.CASCADE]
+
+
+def _make_protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.callbacks = MagicMock()
+
+    db_user = MagicMock()
+    db_user.allowed_types = ["recognizer_loop:utterance"]
+    db_user.is_admin = True
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+
+
+def _make_client(protocol):
+    client = HiveMindClientConnection(
+        key="test-key",
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+        sess=Session("a-session"),
+    )
+    client.name = "test-client"
+    client.allowed_types = ["recognizer_loop:utterance"]
+    client.crypto_key = None
+    return client
+
+
+def _sent(client):
+    return "".join(str(c.args[0]) for c in client.send_msg.call_args_list)
+
+
+class TestMalformedWrapperPayload(unittest.TestCase):
+    def test_malformed_query_is_rejected_not_crashed(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+        message = HiveMessage(HiveMessageType.QUERY, payload=BAD_PAYLOAD)
+
+        protocol.handle_message(message, client)  # must not raise
+
+        sent = _sent(client)
+        self.assertIn("hive.policy.denied", sent)
+        self.assertIn("malformed_payload", sent)
+
+    def test_every_wrapper_type_rejects_a_malformed_payload(self):
+        for msg_type in WRAPPER_TYPES:
+            with self.subTest(msg_type=msg_type):
+                protocol = _make_protocol()
+                client = _make_client(protocol)
+                message = HiveMessage(msg_type, payload=BAD_PAYLOAD)
+
+                protocol.handle_message(message, client)  # must not raise
+
+                self.assertIn("malformed_payload", _sent(client))
+
+    def test_a_malformed_frame_does_not_kick_the_peer(self):
+        """A bad frame is a bug in the peer, not an illegal action — the
+        connection stays up so the peer can be told about it."""
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+
+        protocol.handle_message(
+            HiveMessage(HiveMessageType.QUERY, payload=BAD_PAYLOAD), client)
+
+        client.disconnect.assert_not_called()
+
+    def test_a_well_formed_query_is_untouched(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+        bus_msg = Message("recognizer_loop:utterance", {"utterances": ["hi"]})
+        message = HiveMessage(HiveMessageType.QUERY,
+                              payload=HiveMessage(HiveMessageType.BUS, bus_msg))
+
+        protocol.handle_message(message, client)
+
+        self.assertNotIn("malformed_payload", _sent(client))
+        protocol.agent_protocol.get_bus.assert_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

A peer that sends a `QUERY` whose payload is a bus `Message` dict
(`{"type": ..., "data": ..., "context": ...}`) instead of a nested
`HiveMessage` makes `HiveMessage.payload` raise while it rebuilds the nested
envelope. The exception escapes the message handler.

`handle_message` now checks the nested payload before it dispatches any of the
five wrapper types (QUERY, BROADCAST, PROPAGATE, ESCALATE, CASCADE) and answers
a bad frame with the existing `hive.policy.denied` shape, new code
`malformed_payload`. The peer is not disconnected: a bad frame is a bug in the
sender, not an illegal action, and the sender needs the reply to learn about
it. Documented in the deny-code table in `docs/policy.md`.

## Precisely what breaks today

Measured on a real node, not inferred. The hivemind-core **process** survives —
tornado catches the exception per request — but:

- tornado logs `Uncaught exception GET /?authorization=...` with a full traceback
- the offending peer's **websocket is closed**
- the peer gets **no reply at all**, so it cannot tell a malformed frame from a
  dead server
- the peer reconnects, loses its Noise session, and its next frames are refused
  as unencrypted — so a satellite with this bug in its sender ends up in a
  reconnect loop, not a single failed request

All five wrapper types are affected, not just QUERY: `HiveMessage.payload`
rebuilds a nested `HiveMessage` for all of them. PROPAGATE and ESCALATE fail
even earlier than QUERY, in the `LOG.debug("PAYLOAD_TYPE: " + ...)` line before
`_unpack_message`.

## Why

HIVEMIND-MSG-1 §4 says a QUERY payload IS a nested `HiveMessage`, so the sender
is wrong. But a node must not raise out of its message handler because a peer
sent a malformed frame.

## Live validation

Not just unit tests. A real rig: `ovos-messagebus` on 8291, a real
`hivemind-core listen` on 5791, a real `HiveMessageBusClient` satellite over a
real websocket with a protocol v3 Noise session. Each of the five wrapper types
was sent with a bus-`Message` dict payload, each from a **fresh** client so a
disconnect in one phase could not mask the next.

**Before (origin/dev @ a05a16a):**

```
[QUERY]     RESULT socket_still_open=False denials=0
[ESCALATE]  RESULT socket_still_open=False denials=0
[BROADCAST] RESULT socket_still_open=False denials=0
[PROPAGATE] RESULT socket_still_open=False denials=0
[CASCADE]   RESULT socket_still_open=False denials=0
```

Server log: `Uncaught exception` × 5, `TypeError: HiveMessage.__init__() got an
unexpected keyword argument 'type'` × 5, one per handler —
`handle_broadcast_message`, `handle_propagate_message`, `handle_query_message`,
`handle_cascade_message`, `handle_escalate_message`.

**After (this branch), same rig, same probe:**

```
[QUERY]     RESULT socket_still_open=True denials=1
   DENY {'denied_type': 'query', 'code': 'malformed_payload',
         'reason': "'query' payload must be a nested HiveMessage (HIVEMIND-MSG-1 §4)", 'data': {}}
[ESCALATE]  RESULT socket_still_open=True denials=1
[BROADCAST] RESULT socket_still_open=True denials=1
[PROPAGATE] RESULT socket_still_open=True denials=1
[CASCADE]   RESULT socket_still_open=True denials=1
FINAL: node_still_serving=True injected_on_ovos_bus=1
```

Server log: `Uncaught exception` **0**. Every frame produces one
`WARNING ... malformed 'query' from <peer>: payload is not a HiveMessage`.
A well-formed BUS message sent afterwards still reached the OVOS bus.

## Back-compat

**Nobody breaks.** No wire format change, no protocol change, no config change,
no new dependency.

- A well-formed wrapper message takes exactly the same code path as before. The
  guard reads `message.payload`, which the handler read anyway one line later.
  `test_a_well_formed_query_is_untouched` pins this, and the live rig confirmed
  normal traffic still flows.
- A frame that previously produced an uncaught traceback plus a dropped socket
  now produces a `hive.policy.denied` reply and a live socket. That is strictly
  more information for the peer.
- An older peer that does not understand `hive.policy.denied` simply ignores an
  unknown bus message — the same thing it already does for the
  `backend_unavailable` and `acl_disallowed_type` denials that ship today.
- `malformed_payload` is a new deny code. Anything matching on the exact set of
  codes would see one more value; the wire shape is unchanged.

## Adversarial self-check

**What input have I not tried?** Live: only the bus-`Message` dict, the shape a
real peer sent. In unit tests the guard catches any exception from
`HiveMessage.payload`, so a payload that is a string, a list, `None`, or a dict
missing `msg_type` is refused the same way — `HiveMessage(**payload)` raises
`TypeError` for all of them. Untested live: a payload nested many levels deep,
and a binary payload mislabelled as a wrapper type.

**What does a peer running an older version see?** A `hive.policy.denied` BUS
message it does not recognise, which it drops. Before this change it saw its
socket close. Strictly better, never worse.

**What if the peer sends a malformed frame it is not authorised to send?** The
guard runs before the permission check, so a malformed BROADCAST from a
non-admin gets `malformed_payload` rather than a disconnect. That is the right
order: an unparseable frame cannot be authorised, and the frame never reaches
the fan-out.

**Can the guard swallow a real bug?** It catches broadly, but only around
`message.payload` — one attribute read — and it always logs the exception text
at WARNING with the peer name. It cannot mask a failure in any handler body.

**Denial-of-service?** A peer can spam malformed frames and get one denial each.
That is the same cost as any refused message today, and cheaper than before,
when each one also tore down and re-established a websocket plus a Noise
handshake.

## Tests

New `tests/test_malformed_wrapper_payload.py`:

- `test_malformed_query_is_rejected_not_crashed`
- `test_every_wrapper_type_rejects_a_malformed_payload` (subtests over all 5)
- `test_a_malformed_frame_does_not_kick_the_peer`
- `test_a_well_formed_query_is_untouched`

Written first and proven against `origin/dev`: 7 failed, 2 passed, with the
`TypeError` raised for every wrapper type.

- Suite: **210 passed, 1 skipped, 5 subtests passed** (baseline 206 passed, 1 skipped)
- hivemind-test-harness `tests/test_spec_musts.py`: **11 passed, 1 xfailed**
  (baseline), `--timeout=300`

## AI transparency

Written by Claude Opus under Claude Fable 5 orchestration. The bug was found by
live multi-node testing, and the fix was verified the same way — the unit suite
alone would not have shown that the peer's socket is dropped.


---

# Update — adversarial review

A review attacked the guard through the real `decode()` + `handle_message()`
path, as an authenticated peer. It got past it three ways.

**1. One level too shallow.** `_has_nested_payload` forced `message.payload`
only. The wrapper handlers read `message.payload.payload` as well
(`handle_propagate_message`, `handle_escalate_message`,
`_answer_query_locally`), so these frames still raised `KeyError: 'type'` out
of the handler:

```
{"msg_type":"propagate","payload":{"msg_type":"bus","payload":{}}}
{"msg_type":"escalate","payload":{"msg_type":"bus","payload":{}}}
{"msg_type":"query","payload":{"msg_type":"bus","payload":{}}}
{"msg_type":"cascade","payload":{"msg_type":"bus","payload":{}}}
```

and a bus `Message` dict nested twice raised the `TypeError` this PR was
written to stop:

```
{"msg_type":"propagate","payload":{"msg_type":"propagate",
    "payload":{"type":"x","data":{},"context":{}}}}
```

**2. The guarded types were picked by spec section, not by call site.**
`SHARED_BUS` rebuilds a bus `Message` from `payload["type"]` in
`handle_client_shared_bus` and was not in `WRAPPER_TYPES`, so
`{"msg_type":"shared_bus","payload":{}}` raised `KeyError: 'type'`.

**3. The guard sat below the debug log.** `LOG.debug(f"message: {message}")`
renders the message, and `as_dict` asserts the payload is a dict, so
`{"msg_type":"query","payload":7}` and `..."payload":[1,2]` raised
`AssertionError` before the guard ever ran.

## What changed

- The guard runs **first** in `handle_message`, above the debug log, and
  probes `as_dict` too — the same thing the log does.
- It walks the **whole** payload chain, not one level. Each step descends one
  level of an already-parsed JSON object, so it terminates; `json.loads` has
  bounded the depth before this point.
- It runs for **every** message type. A type that does not rebuild its payload
  returns it as stored and can never raise, so probing it is free — and there
  is no list to keep in step with the call sites. `WRAPPER_TYPES` stays as
  documentation of the spec, and says so.
- Docstrings and the `docs/policy.md` row corrected: the catch is `Exception`,
  not `TypeError`, and the shape is any payload that cannot be reconstructed,
  not just a bus-`Message` dict.

All nine frames now answer `hive.policy.denied` / `malformed_payload` with the
peer still connected. Well-formed QUERY, PROPAGATE-in-ESCALATE, SHARED_BUS,
INTERCOM and PING frames are untouched.

## Tests

- `TestMalformedFrameOnTheWire::test_every_malformed_frame_is_denied_and_the_peer_stays`
  — the nine frames, as bytes, through `decode()` and `handle_message()`
- `TestMalformedFrameOnTheWire::test_a_well_formed_frame_still_gets_through`
- `TestMalformedFrameOnTheWire::test_a_well_formed_shared_bus_frame_still_gets_through`
- `TestGuardRunsBeforeTheDebugLog::test_a_non_dict_payload_never_reaches_the_log`

Fail-on-old, `git stash` of `hivemind_core/protocol.py`: **10 failed, 7
passed**. With the fix: **8 passed, 14 subtests passed**.

- Suite: **214 passed, 1 skipped, 14 subtests passed**
- hivemind-test-harness `tests/test_spec_musts.py`: **11 passed, 1 xfailed**,
  `--timeout=300`

## Separate finding, not fixed here

`HiveMessage.as_dict` in `hivemind_bus_client` ends with a bare
`assert isinstance(pload, dict)`. Under `python -O` that assert is stripped and
`as_json` emits a frame with a non-dict payload; with asserts on it raises
`AssertionError` with no message from inside `__str__`, which is why a payload
of `7` crashed on a log line. That belongs in `hivemind_bus_client`, not here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed nested message payloads are now rejected safely with a clear denial reason.
  * Invalid payloads no longer cause exceptions, misleading debug logs, or peer disconnections.
  * Valid wrapped messages continue to be accepted and processed normally.

* **Documentation**
  * Added documentation for the `malformed_payload` denial code and its handling of unusable message data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->