### PR TITLE
feat: let a node be given an upstream in server.json

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,17 @@ The connection opens on a background thread and the client keeps retrying, so
 an unreachable master delays nothing at startup: the node comes up and serves
 its downstream clients while it waits.
 
+You do not have to write the whole block. Any key you leave out keeps its
+default from the table above, and a block that is not a block at all (`null`,
+say) is replaced by the defaults with a warning. Nothing in the `upstream`
+block can keep the node from starting.
+
+Point `upstream` at the master **above** this node, never at this node. An
+upstream aimed at one of this node's own listeners is refused at startup, with
+an error in the log: the link would connect, be rejected, and reconnect every
+few seconds forever. `127.0.0.1` and `0.0.0.0` name the same listener here, so
+both are refused.
+
 ---
 
 ## `network_protocol`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,16 @@ The file is created with defaults on first run if absent.
     "module": null
   },
 
+  "upstream": {
+    "enabled": false,
+    "host": "127.0.0.1",
+    "port": 5678,
+    "key": "",
+    "password": "",
+    "ssl": false,
+    "self_signed": true
+  },
+
   "network_protocol": {
     "hivemind-websocket-plugin": {
       "host": "0.0.0.0",
@@ -89,6 +99,7 @@ The file is created with defaults on first run if absent.
 | `runtime_password_strength_check` | bool | `true` | Re-check password strength at handshake time. Set to `false`, or set `HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK=1`, to skip the backstop |
 | `last_seen_update_interval` | int | `0` | Seconds to debounce the `last_seen` write. `0` writes on every admitted message |
 | `presence` | dict | see above | Local-network advertisement through the optional `hivemind-presence` package. Keys: `enabled`, `name`, `zeroconf` (mDNS), `upnp` (SSDP) |
+| `upstream` | dict | see above | Connection to a master above this node. Disabled by default |
 
 > **`require_crypto` is not a config key.** It is an attribute of
 > `HiveMindListenerProtocol` and it defaults to `True`. While it is true, the server
@@ -135,6 +146,45 @@ Optional server-side audio/image handler. Set `module` to `null` to use the no-o
 The `hivemind-audio-binary-protocol` plugin enables server-side STT and TTS, used by
 lightweight satellites (voice relay, mic satellite) that stream raw audio instead of
 running a local speech stack.
+
+---
+
+## `upstream`
+
+Connects this node to a master above it. The node keeps serving its own
+downstream clients, and it also forwards downstream `PROPAGATE` and `ESCALATE`
+up to that master, and fans `BROADCAST` and `PROPAGATE` from the master back
+down (HIVEMIND-NODE-1 §3.3 and §4). It is disabled by default, so a node with
+no upstream is a top-level master, as before.
+
+```json
+"upstream": {
+  "enabled": true,
+  "host": "master.example.com",
+  "port": 5678,
+  "key": "the-access-key",
+  "password": "the-password",
+  "ssl": true,
+  "self_signed": false
+}
+```
+
+| Key | Type | Default | Purpose |
+|---|---|---|---|
+| `enabled` | bool | `false` | Connect upstream. When `false`, this node is a top-level master |
+| `host` | str | `127.0.0.1` | Hostname or IP of the master. Write it without a scheme; `ssl` picks `ws://` or `wss://` |
+| `port` | int | `5678` | Port the master listens on |
+| `key` | str | `""` | Access key the master issued to this node |
+| `password` | str | `""` | Password the master issued to this node |
+| `ssl` | bool | `false` | Connect with `wss://` |
+| `self_signed` | bool | `true` | Accept a self-signed certificate from the master |
+
+Run `hivemind-core add-client` **on the master** to get the `key` and
+`password` for this node.
+
+The connection opens on a background thread and the client keeps retrying, so
+an unreachable master delays nothing at startup: the node comes up and serves
+its downstream clients while it waits.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,7 +180,14 @@ no upstream is a top-level master, as before.
 | `self_signed` | bool | `true` | Accept a self-signed certificate from the master |
 
 Run `hivemind-core add-client` **on the master** to get the `key` and
-`password` for this node.
+`password` for this node. Set both: with either one empty the node logs an
+error and stays a top-level master, rather than refusing to start and taking
+its own clients offline with it.
+
+The upstream connection keeps its credentials in its own identity file,
+`~/.config/hivemind/_identity_upstream.json`. The node's own
+`_identity.json` — the identity it presents to its downstream clients — is
+never written to by the upstream link.
 
 The connection opens on a background thread and the client keeps retrying, so
 an unreachable master delays nothing at startup: the node comes up and serves

--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -46,6 +46,21 @@ _DEFAULT = {
         "zeroconf": True,   # mDNS (optional zeroconf)
         "upnp": False,      # UPnP/SSDP (optional upnpclient)
     },
+    # optional connection to a master above this node — HIVEMIND-NODE-1
+    # §3.3/§4. Disabled by default: the node is a top-level master. Enable it
+    # and the node also holds one connection upstream.
+    # `key` and `password` are the credentials that master issued to this node
+    # with `hivemind-core add-client`. `ssl` picks ws:// or wss:// for `host`,
+    # and `self_signed` accepts a self-signed certificate from the master.
+    "upstream": {
+        "enabled": False,
+        "host": "127.0.0.1",
+        "port": 5678,
+        "key": "",
+        "password": "",
+        "ssl": False,
+        "self_signed": True,
+    },
     "network_protocol": {"hivemind-websocket-plugin": {
                              "host": "0.0.0.0",
                              "port": 5678,

--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2026 Casimiro Ferreira
 # SPDX-License-Identifier: Apache-2.0
 import os.path
+from typing import Mapping, Optional
 
 from json_database import JsonStorageXDG
 from ovos_utils.log import LOG
@@ -152,7 +153,36 @@ def get_server_config() -> JsonStorageXDG:
     if "chain" not in policy_cfg:
         policy_cfg["chain"] = list(_DEFAULT["policy"]["chain"])
     db["policy"] = policy_cfg
+    # the `upstream` block is indexed sub-key by sub-key at the use site
+    # (`HiveMindService._connect_upstream`), and that runs BEFORE the network
+    # protocols start. A hand-edited block holding only some of the keys — or
+    # `null` — raised KeyError/TypeError there and took the whole node offline,
+    # satellites included. Deep-merge it against the defaults, like the policy
+    # block above, so every sub-key is always present.
+    db["upstream"] = upstream_config(db)
     return db
+
+
+def upstream_config(server_config: Optional[Mapping] = None) -> dict:
+    """The ``upstream`` block, every sub-key present.
+
+    ``get_server_config`` calls this, so a config read the normal way is
+    already complete. It is also called at the read site
+    (``HiveMindService._connect_upstream``) because that is the code that
+    would take the node offline if a sub-key were ever missing, and merging
+    an already-merged block changes nothing.
+    """
+    if server_config is None:
+        server_config = get_server_config()
+    upstream = server_config.get("upstream")
+    if not isinstance(upstream, dict):
+        if "upstream" in server_config:
+            LOG.warning(
+                f"server.json 'upstream' is {type(upstream).__name__}, not a "
+                f"block of settings — using the defaults (upstream disabled)."
+            )
+        upstream = {}
+    return {**_DEFAULT["upstream"], **upstream}
 
 
 def runtime_password_min_bits() -> float:

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -2,7 +2,9 @@
 # Copyright (C) 2026 Casimiro Ferreira
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
-from typing import Callable, Optional, Type
+import ipaddress
+import socket
+from typing import Callable, Mapping, Optional, Type
 
 from json_database import JsonConfigXDG
 
@@ -14,7 +16,7 @@ from hivemind_bus_client.client import HiveMessageBusClient
 from hivemind_bus_client.fakebus import FakeBus
 from hivemind_bus_client.identity import NodeIdentity
 from hivemind_bus_client.protocol import HiveMindSlaveProtocol
-from hivemind_core.config import get_server_config
+from hivemind_core.config import get_server_config, upstream_config
 from hivemind_core.database import ClientDatabase
 from hivemind_core.protocol import HiveMindListenerProtocol, ClientCallbacks
 from hivemind_plugin_manager import AgentProtocolFactory, NetworkProtocolFactory, BinaryDataHandlerProtocolFactory
@@ -36,6 +38,56 @@ def get_binary_protocol():
     return BinaryDataHandlerProtocolFactory.get_class(name), config.get(name, {})
 
 
+#: hosts that mean "this machine" to a listener or a client
+_LOOPBACK = {"127.0.0.1", "::1", "localhost", "localhost.localdomain"}
+#: hosts a listener binds to mean "every interface on this machine"
+_WILDCARD = {"", "0.0.0.0", "::", "*"}
+
+
+def _is_this_machine(host: str) -> bool:
+    """Whether ``host`` names the machine this node runs on."""
+    host = str(host).strip().lower().strip("[]")
+    for scheme in ("ws://", "wss://", "http://", "https://"):
+        if host.startswith(scheme):
+            host = host[len(scheme):]
+    host = host.rstrip("/")
+    if host in _LOOPBACK or host in _WILDCARD:
+        return True
+    if host == socket.gethostname().lower():
+        return True
+    try:
+        return ipaddress.ip_address(socket.gethostbyname(host)).is_loopback
+    except (socket.gaierror, ValueError, UnicodeError):
+        return False
+
+
+def own_listener_for(host: str, port: int, network_protocol: Mapping) -> Optional[str]:
+    """The name of this node's own listener that ``host:port`` points at, or
+    None when the endpoint belongs to some other node.
+
+    An upstream aimed at this node's own listener connects, gets rejected,
+    reconnects five seconds later and does that forever, emitting a
+    ``hive.client.connection.error`` on the bus every time — the reconnect
+    counter never backs off, because each attempt does connect. Better to
+    refuse the loop at startup.
+
+    A listener bound to ``0.0.0.0`` answers on every address of this machine,
+    so ``127.0.0.1`` reaches it just as ``0.0.0.0`` would: the comparison is
+    "same machine and same port", not "same host string".
+    """
+    if not _is_this_machine(host):
+        return None
+    for name, conf in network_protocol.items():
+        if not isinstance(conf, Mapping) or conf.get("port") is None:
+            continue
+        if int(conf["port"]) != int(port):
+            continue
+        listener_host = str(conf.get("host", "")).strip().lower()
+        if listener_host in _WILDCARD or _is_this_machine(listener_host):
+            return name
+    return None
+
+
 def upstream_identity() -> NodeIdentity:
     """Identity for the client this node uses to reach its upstream master,
     kept in ``hivemind/_identity_upstream.json``.
@@ -53,7 +105,9 @@ def upstream_identity() -> NodeIdentity:
         # NodeIdentity does `identity_file or JsonConfigXDG("_identity", ...)`,
         # and a JsonConfigXDG for a file that does not exist yet is an empty
         # dict — which is falsy, so it would silently fall back to the node's
-        # own identity. Seed the file so the first run gets its own.
+        # own identity. Write one key so the file exists and is TRUTHY; the
+        # value is never read. HiveMessageBusClient overwrites `name` with the
+        # name the master knows this node by, so do not read anything into it.
         identity_file["name"] = "hivemind-core-upstream"
         identity_file.store()
     return NodeIdentity(identity_file=identity_file)
@@ -153,7 +207,8 @@ class HiveMindService:
         as long as the master is unreachable. The client owns its own reconnect
         loop, so once started it keeps retrying on its own.
         """
-        config = get_server_config()["upstream"]
+        server_config = get_server_config()
+        config = upstream_config(server_config)
         if not config["enabled"]:
             return None
 
@@ -166,6 +221,17 @@ class HiveMindService:
                       "both set in server.json — staying a top-level master. "
                       "Run 'hivemind-core add-client' ON THE MASTER and copy "
                       "the credentials it prints into the upstream block.")
+            return None
+
+        own = own_listener_for(config["host"], config["port"],
+                               server_config.get("network_protocol") or {})
+        if own is not None:
+            LOG.error(f"upstream points at this node's own '{own}' listener "
+                      f"({config['host']}:{config['port']}) — staying a "
+                      f"top-level master. A node can not be its own master: "
+                      f"the link would connect, be rejected and reconnect "
+                      f"every few seconds forever. Point 'upstream' at the "
+                      f"master above this node.")
             return None
 
         scheme = "wss://" if config["ssl"] else "ws://"

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -4,6 +4,8 @@
 import dataclasses
 from typing import Callable, Optional, Type
 
+from json_database import JsonConfigXDG
+
 from ovos_utils import create_daemon, wait_for_exit_signal
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
@@ -32,6 +34,29 @@ def get_binary_protocol():
         # the binary protocol is optional; the base class is a no-op handler
         return BinaryDataHandlerProtocol, {}
     return BinaryDataHandlerProtocolFactory.get_class(name), config.get(name, {})
+
+
+def upstream_identity() -> NodeIdentity:
+    """Identity for the client this node uses to reach its upstream master,
+    kept in ``hivemind/_identity_upstream.json``.
+
+    It MUST NOT be the node's own ``_identity.json``. ``HiveMessageBusClient``
+    copies the credentials it is given onto the identity it holds, and the
+    first successful Noise handshake calls ``pin_noise_key``, which saves that
+    whole identity to disk. Handed the node's own identity, the client would
+    overwrite the node's ``password`` and ``access_key`` — the very values the
+    node presents to its own downstream clients — and every satellite would
+    then fail its handshake with "invalid api key".
+    """
+    identity_file = JsonConfigXDG("_identity_upstream", subfolder="hivemind")
+    if not identity_file:
+        # NodeIdentity does `identity_file or JsonConfigXDG("_identity", ...)`,
+        # and a JsonConfigXDG for a file that does not exist yet is an empty
+        # dict — which is falsy, so it would silently fall back to the node's
+        # own identity. Seed the file so the first run gets its own.
+        identity_file["name"] = "hivemind-core-upstream"
+        identity_file.store()
+    return NodeIdentity(identity_file=identity_file)
 
 
 def on_ready():
@@ -132,12 +157,24 @@ class HiveMindService:
         if not config["enabled"]:
             return None
 
+        if not config["key"] or not config["password"]:
+            # Serving the downstream clients matters more than reaching the
+            # master: come up as a top-level master and say so, loudly. Raising
+            # here would abort startup and take every satellite offline over a
+            # typo in one config key.
+            LOG.error("upstream is enabled but 'key' and 'password' are not "
+                      "both set in server.json — staying a top-level master. "
+                      "Run 'hivemind-core add-client' ON THE MASTER and copy "
+                      "the credentials it prints into the upstream block.")
+            return None
+
         scheme = "wss://" if config["ssl"] else "ws://"
         upstream = HiveMessageBusClient(key=config["key"],
                                         password=config["password"],
                                         host=scheme + config["host"],
                                         port=config["port"],
-                                        self_signed=config["self_signed"])
+                                        self_signed=config["self_signed"],
+                                        identity=upstream_identity())
         slave = HiveMindSlaveProtocol(hm=upstream)
         hm_protocol.bind_upstream(slave)
         LOG.info(f"Upstream master: {config['host']}:{config['port']}")

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -8,7 +8,10 @@ from ovos_utils import create_daemon, wait_for_exit_signal
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
 
+from hivemind_bus_client.client import HiveMessageBusClient
+from hivemind_bus_client.fakebus import FakeBus
 from hivemind_bus_client.identity import NodeIdentity
+from hivemind_bus_client.protocol import HiveMindSlaveProtocol
 from hivemind_core.config import get_server_config
 from hivemind_core.database import ClientDatabase
 from hivemind_core.protocol import HiveMindListenerProtocol, ClientCallbacks
@@ -75,6 +78,7 @@ class HiveMindService:
 
     def __post_init__(self) -> None:
         self._presence = None
+        self._upstream = None
         self._status = self._status or ProcessStatus("HiveMind",
                                                      callback_map=StatusCallbackMap(
                                                          on_started=self.started_hook,
@@ -111,6 +115,51 @@ class HiveMindService:
         create_daemon(self._presence.start)
         LOG.info("LocalPresence started")
 
+    def _connect_upstream(self, hm_protocol: HiveMindListenerProtocol
+                          ) -> Optional[HiveMindSlaveProtocol]:
+        """Optionally connect this node to a master above it
+        (HIVEMIND-NODE-1 §3.3/§4).
+
+        Returns the bound ``HiveMindSlaveProtocol``, or None when no upstream
+        is configured — then the node is a top-level master, as before.
+
+        The websocket is opened on a daemon thread. ``connect`` blocks until
+        the handshake completes, so doing it inline would hold up startup for
+        as long as the master is unreachable. The client owns its own reconnect
+        loop, so once started it keeps retrying on its own.
+        """
+        config = get_server_config()["upstream"]
+        if not config["enabled"]:
+            return None
+
+        scheme = "wss://" if config["ssl"] else "ws://"
+        upstream = HiveMessageBusClient(key=config["key"],
+                                        password=config["password"],
+                                        host=scheme + config["host"],
+                                        port=config["port"],
+                                        self_signed=config["self_signed"])
+        slave = HiveMindSlaveProtocol(hm=upstream)
+        hm_protocol.bind_upstream(slave)
+        LOG.info(f"Upstream master: {config['host']}:{config['port']}")
+
+        def connect():
+            try:
+                # `connect` binds the slave to the bus before opening the
+                # socket; the upstream link shares no local OVOS bus
+                upstream.connect(bus=FakeBus(), protocol=slave,
+                                 site_id=self.identity.site_id)
+            except Exception:
+                LOG.exception("Failed to connect to the upstream master, "
+                              "retrying in the background")
+
+        create_daemon(connect)
+        self._upstream = slave
+        return slave
+
+    def _stop_upstream(self) -> None:
+        if self._upstream is not None:
+            self._upstream.hm.close()
+
     def _stop_presence(self) -> None:
         if self._presence is not None:
             self._presence.stop()
@@ -138,6 +187,9 @@ class HiveMindService:
                                        binary_data_protocol=bin_protocol,
                                        agent_protocol=agent_protocol)
 
+        # optionally connect this node to a master above it
+        self._connect_upstream(hm_protocol)
+
         # start network protocols that will carry HiveMessages
         protos = []
         for plug_name, plug_conf in get_server_config()["network_protocol"].items():
@@ -164,4 +216,5 @@ class HiveMindService:
         wait_for_exit_signal()  # block until ctrl+c
 
         self._stop_presence()
+        self._stop_upstream()
         self._status.set_stopping()

--- a/tests/test_upstream_connection.py
+++ b/tests/test_upstream_connection.py
@@ -6,8 +6,12 @@ master. The ``upstream`` config block gives an operator that one bit.
 
 Absent or disabled, the node stays exactly a top-level master.
 """
+import tempfile
 import unittest
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
+
+from json_database import JsonConfigXDG
 
 from hivemind_core.config import _DEFAULT
 from hivemind_core.service import HiveMindService
@@ -31,6 +35,22 @@ def _make_service():
 
 def _config(upstream):
     return {**_DEFAULT, "upstream": upstream}
+
+
+@contextmanager
+def scratch_config_home():
+    """Keep the upstream identity file out of the developer's real
+    ~/.config/hivemind — building it writes to disk.
+
+    ``JsonConfigXDG`` resolves ``xdg_folder`` as a default argument, i.e. once
+    at import time, so patching ``XDG_CONFIG_HOME`` in the environment here
+    would come too late. Redirect the folder explicitly instead.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        with patch("hivemind_core.service.JsonConfigXDG",
+                   lambda name, subfolder: JsonConfigXDG(
+                       name, xdg_folder=tmp, subfolder=subfolder)):
+            yield tmp
 
 
 class TestUpstreamDefaults(unittest.TestCase):
@@ -61,33 +81,77 @@ class TestUpstreamDefaults(unittest.TestCase):
         hm_protocol.bind_upstream.assert_not_called()
 
 
+    def test_enabled_without_credentials_stays_a_top_level_master(self):
+        """Regression, found by live testing: HiveMessageBusClient raises at
+        construction when key or password is missing. Left to propagate, one
+        typo in server.json aborted startup and took every satellite offline.
+        """
+        for missing in ("key", "password"):
+            with self.subTest(missing=missing):
+                service = _make_service()
+                hm_protocol = MagicMock()
+                config = _config({**UPSTREAM, missing: ""})
+
+                with patch("hivemind_core.service.get_server_config",
+                           return_value=config), \
+                        patch("hivemind_core.service.HiveMessageBusClient") as c:
+                    self.assertIsNone(service._connect_upstream(hm_protocol))
+
+                c.assert_not_called()
+                hm_protocol.bind_upstream.assert_not_called()
+
+
 class TestUpstreamConfigured(unittest.TestCase):
     def test_a_configured_node_binds_the_upstream(self):
         service = _make_service()
         hm_protocol = MagicMock()
 
-        with patch("hivemind_core.service.get_server_config",
-                   return_value=_config(UPSTREAM)), \
+        with scratch_config_home(), \
+                patch("hivemind_core.service.get_server_config",
+                      return_value=_config(UPSTREAM)), \
                 patch("hivemind_core.service.HiveMessageBusClient") as client, \
                 patch("hivemind_core.service.create_daemon") as daemon:
             slave = service._connect_upstream(hm_protocol)
 
-        client.assert_called_once_with(key="an-access-key",
-                                       password="a-password",
-                                       host="ws://10.0.0.1",
-                                       port=5678,
-                                       self_signed=True)
+        self.assertEqual(client.call_args.kwargs["key"], "an-access-key")
+        self.assertEqual(client.call_args.kwargs["password"], "a-password")
+        self.assertEqual(client.call_args.kwargs["host"], "ws://10.0.0.1")
+        self.assertEqual(client.call_args.kwargs["port"], 5678)
+        self.assertTrue(client.call_args.kwargs["self_signed"])
         self.assertIs(slave.hm, client.return_value)
         hm_protocol.bind_upstream.assert_called_once_with(slave)
         # connecting happens off the startup thread, so an unreachable
         # upstream can not hold the node down
         daemon.assert_called_once()
 
+    def test_the_upstream_client_gets_its_own_identity_file(self):
+        """Regression, found by live testing against two real nodes.
+
+        ``HiveMessageBusClient`` copies the credentials it is given onto the
+        identity it holds, and the first Noise handshake saves that identity
+        to disk. Handed the node's own identity, it overwrote the node's
+        ``password`` and ``access_key``, and every downstream satellite then
+        failed its handshake with "invalid api key".
+        """
+        service = _make_service()
+
+        with scratch_config_home(), \
+                patch("hivemind_core.service.get_server_config",
+                      return_value=_config(UPSTREAM)), \
+                patch("hivemind_core.service.HiveMessageBusClient") as client, \
+                patch("hivemind_core.service.create_daemon"):
+            service._connect_upstream(MagicMock())
+
+        identity = client.call_args.kwargs["identity"]
+        self.assertTrue(identity.IDENTITY_FILE.path.endswith(
+            "_identity_upstream.json"), identity.IDENTITY_FILE.path)
+
     def test_ssl_selects_the_wss_scheme(self):
         service = _make_service()
 
-        with patch("hivemind_core.service.get_server_config",
-                   return_value=_config({**UPSTREAM, "ssl": True})), \
+        with scratch_config_home(), \
+                patch("hivemind_core.service.get_server_config",
+                      return_value=_config({**UPSTREAM, "ssl": True})), \
                 patch("hivemind_core.service.HiveMessageBusClient") as client, \
                 patch("hivemind_core.service.create_daemon"):
             service._connect_upstream(MagicMock())
@@ -101,8 +165,9 @@ class TestUpstreamConfigured(unittest.TestCase):
         hm_protocol = MagicMock()
         started = []
 
-        with patch("hivemind_core.service.get_server_config",
-                   return_value=_config(UPSTREAM)), \
+        with scratch_config_home(), \
+                patch("hivemind_core.service.get_server_config",
+                      return_value=_config(UPSTREAM)), \
                 patch("hivemind_core.service.HiveMessageBusClient") as client, \
                 patch("hivemind_core.service.create_daemon",
                       side_effect=lambda fn: started.append(fn)):

--- a/tests/test_upstream_connection.py
+++ b/tests/test_upstream_connection.py
@@ -1,0 +1,118 @@
+"""A node can be given an upstream connection from ``server.json``.
+
+``bind_upstream`` already connects a node to a master above it, but only
+Python could reach it, so ``hivemind-core listen`` was always a top-level
+master. The ``upstream`` config block gives an operator that one bit.
+
+Absent or disabled, the node stays exactly a top-level master.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from hivemind_core.config import _DEFAULT
+from hivemind_core.service import HiveMindService
+
+UPSTREAM = {
+    "enabled": True,
+    "host": "10.0.0.1",
+    "port": 5678,
+    "key": "an-access-key",
+    "password": "a-password",
+    "ssl": False,
+    "self_signed": True,
+}
+
+
+def _make_service():
+    service = HiveMindService(db=MagicMock(), identity=MagicMock())
+    service.identity.site_id = "a-site"
+    return service
+
+
+def _config(upstream):
+    return {**_DEFAULT, "upstream": upstream}
+
+
+class TestUpstreamDefaults(unittest.TestCase):
+    def test_the_default_config_has_no_upstream_enabled(self):
+        self.assertFalse(_DEFAULT["upstream"]["enabled"])
+
+    def test_a_node_without_upstream_config_stays_a_top_level_master(self):
+        service = _make_service()
+        hm_protocol = MagicMock()
+        hm_protocol._upstream_hm = None
+
+        with patch("hivemind_core.service.get_server_config",
+                   return_value=_DEFAULT):
+            self.assertIsNone(service._connect_upstream(hm_protocol))
+
+        hm_protocol.bind_upstream.assert_not_called()
+        self.assertIsNone(hm_protocol._upstream_hm)
+
+    def test_a_disabled_upstream_block_binds_nothing(self):
+        service = _make_service()
+        hm_protocol = MagicMock()
+        config = _config({**UPSTREAM, "enabled": False})
+
+        with patch("hivemind_core.service.get_server_config",
+                   return_value=config):
+            self.assertIsNone(service._connect_upstream(hm_protocol))
+
+        hm_protocol.bind_upstream.assert_not_called()
+
+
+class TestUpstreamConfigured(unittest.TestCase):
+    def test_a_configured_node_binds_the_upstream(self):
+        service = _make_service()
+        hm_protocol = MagicMock()
+
+        with patch("hivemind_core.service.get_server_config",
+                   return_value=_config(UPSTREAM)), \
+                patch("hivemind_core.service.HiveMessageBusClient") as client, \
+                patch("hivemind_core.service.create_daemon") as daemon:
+            slave = service._connect_upstream(hm_protocol)
+
+        client.assert_called_once_with(key="an-access-key",
+                                       password="a-password",
+                                       host="ws://10.0.0.1",
+                                       port=5678,
+                                       self_signed=True)
+        self.assertIs(slave.hm, client.return_value)
+        hm_protocol.bind_upstream.assert_called_once_with(slave)
+        # connecting happens off the startup thread, so an unreachable
+        # upstream can not hold the node down
+        daemon.assert_called_once()
+
+    def test_ssl_selects_the_wss_scheme(self):
+        service = _make_service()
+
+        with patch("hivemind_core.service.get_server_config",
+                   return_value=_config({**UPSTREAM, "ssl": True})), \
+                patch("hivemind_core.service.HiveMessageBusClient") as client, \
+                patch("hivemind_core.service.create_daemon"):
+            service._connect_upstream(MagicMock())
+
+        self.assertEqual(client.call_args.kwargs["host"], "wss://10.0.0.1")
+
+    def test_an_unreachable_upstream_does_not_stop_the_node(self):
+        """The connect worker keeps retrying; a failure there is logged, and
+        the node stays up serving its downstream clients."""
+        service = _make_service()
+        hm_protocol = MagicMock()
+        started = []
+
+        with patch("hivemind_core.service.get_server_config",
+                   return_value=_config(UPSTREAM)), \
+                patch("hivemind_core.service.HiveMessageBusClient") as client, \
+                patch("hivemind_core.service.create_daemon",
+                      side_effect=lambda fn: started.append(fn)):
+            client.return_value.connect.side_effect = ConnectionRefusedError(
+                "upstream is down")
+            service._connect_upstream(hm_protocol)
+
+        self.assertEqual(len(started), 1)
+        started[0]()  # the worker must swallow the failure, not raise
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_upstream_connection.py
+++ b/tests/test_upstream_connection.py
@@ -6,14 +6,19 @@ master. The ``upstream`` config block gives an operator that one bit.
 
 Absent or disabled, the node stays exactly a top-level master.
 """
+import json
+import os
+import socket
 import tempfile
+import threading
 import unittest
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 from json_database import JsonConfigXDG
 
-from hivemind_core.config import _DEFAULT
+from hivemind_bus_client.client import HiveMessageBusClient
+from hivemind_core.config import _DEFAULT, get_server_config, upstream_config
 from hivemind_core.service import HiveMindService
 
 UPSTREAM = {
@@ -177,6 +182,162 @@ class TestUpstreamConfigured(unittest.TestCase):
 
         self.assertEqual(len(started), 1)
         started[0]()  # the worker must swallow the failure, not raise
+
+
+#: hand-edited `upstream` blocks an operator can realistically leave behind.
+#: Every one of them used to raise out of `_connect_upstream`, which runs
+#: BEFORE the network protocols start, so the whole node never came up.
+PARTIAL_BLOCKS = {
+    "no ssl/self_signed": {"enabled": True, "host": "h", "port": 1,
+                           "key": "k", "password": "p"},
+    "only enabled/host/port": {"enabled": True, "host": "h", "port": 1},
+    "only enabled": {"enabled": True},
+    "empty block": {},
+    "null": None,
+}
+
+
+class TestPartialUpstreamBlock(unittest.TestCase):
+    """A partial block must not take the node offline.
+
+    ``upstream_config`` deep-merges the block against the defaults, the way
+    the ``policy`` block is deep-merged, so every sub-key the use site indexes
+    is always there.
+    """
+
+    def test_every_partial_block_is_completed_with_the_defaults(self):
+        for label, block in PARTIAL_BLOCKS.items():
+            with self.subTest(block=label):
+                merged = upstream_config({"upstream": block})
+                self.assertEqual(set(merged), set(_DEFAULT["upstream"]))
+                for key, default in _DEFAULT["upstream"].items():
+                    if not isinstance(block, dict) or key not in block:
+                        self.assertEqual(merged[key], default)
+
+    def test_a_missing_block_gives_the_defaults(self):
+        self.assertEqual(upstream_config({}), _DEFAULT["upstream"])
+
+    def test_a_set_sub_key_survives_the_merge(self):
+        merged = upstream_config({"upstream": {"enabled": True, "port": 9}})
+        self.assertTrue(merged["enabled"])
+        self.assertEqual(merged["port"], 9)
+        self.assertEqual(merged["ssl"], _DEFAULT["upstream"]["ssl"])
+
+    def test_get_server_config_merges_the_block(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            folder = os.path.join(tmp, "hivemind-core")
+            os.makedirs(folder)
+            with open(os.path.join(folder, "server.json"), "w") as f:
+                json.dump({"upstream": {"enabled": True, "host": "10.0.0.1"}}, f)
+            with patch.dict(os.environ, {"XDG_CONFIG_HOME": tmp}):
+                upstream = get_server_config()["upstream"]
+        self.assertEqual(set(upstream), set(_DEFAULT["upstream"]))
+        self.assertTrue(upstream["enabled"])
+        self.assertEqual(upstream["host"], "10.0.0.1")
+        self.assertEqual(upstream["port"], _DEFAULT["upstream"]["port"])
+
+    def test_no_partial_block_aborts_startup(self):
+        for label, block in PARTIAL_BLOCKS.items():
+            with self.subTest(block=label):
+                service = _make_service()
+                with scratch_config_home(), \
+                        patch("hivemind_core.service.get_server_config",
+                              return_value={**_DEFAULT, "upstream": block}), \
+                        patch("hivemind_core.service.HiveMessageBusClient"), \
+                        patch("hivemind_core.service.create_daemon"):
+                    service._connect_upstream(MagicMock())  # must not raise
+
+
+class TestUpstreamIsNotThisNode(unittest.TestCase):
+    """An upstream aimed at this node's own listener connects, is rejected,
+    and reconnects every five seconds forever, putting a
+    ``hive.client.connection.error`` on the bus each time. Refuse at startup.
+    """
+
+    LISTENERS = {"hivemind-websocket-plugin": {"host": "0.0.0.0", "port": 5678},
+                 "hivemind-http-plugin": {"host": "127.0.0.1", "port": 5679}}
+
+    def _connect(self, host, port):
+        service = _make_service()
+        hm_protocol = MagicMock()
+        config = {**_DEFAULT,
+                  "network_protocol": self.LISTENERS,
+                  "upstream": {**UPSTREAM, "host": host, "port": port}}
+        with scratch_config_home(), \
+                patch("hivemind_core.service.get_server_config",
+                      return_value=config), \
+                patch("hivemind_core.service.HiveMessageBusClient") as client, \
+                patch("hivemind_core.service.create_daemon"):
+            result = service._connect_upstream(hm_protocol)
+        return result, client, hm_protocol
+
+    def test_loopback_matches_a_listener_bound_to_all_interfaces(self):
+        """The listener is on 0.0.0.0 and the upstream says 127.0.0.1 — the
+        same socket, so comparing the host strings is not enough."""
+        result, client, hm_protocol = self._connect("127.0.0.1", 5678)
+        self.assertIsNone(result)
+        client.assert_not_called()
+        hm_protocol.bind_upstream.assert_not_called()
+
+    def test_every_way_of_naming_this_node_is_refused(self):
+        for host in ("127.0.0.1", "localhost", "0.0.0.0", socket.gethostname()):
+            for port in (5678, 5679):
+                with self.subTest(host=host, port=port):
+                    self.assertIsNone(self._connect(host, port)[0])
+
+    def test_a_loopback_port_nothing_listens_on_is_allowed(self):
+        """Only this node's OWN listeners are refused; another hive node on
+        the same machine is a legitimate master."""
+        result, client, _ = self._connect("127.0.0.1", 5999)
+        self.assertIsNotNone(result)
+        client.assert_called_once()
+
+    def test_a_remote_master_on_the_same_port_is_allowed(self):
+        result, client, _ = self._connect("10.0.0.1", 5678)
+        self.assertIsNotNone(result)
+        client.assert_called_once()
+
+
+class TestAgainstTheRealClient(unittest.TestCase):
+    """Every other test in this file mocks ``HiveMessageBusClient``, so a
+    config block of the wrong SHAPE never reached the code that reads it. One
+    test builds the real client, against an endpoint nothing listens on."""
+
+    UNREACHABLE_PORT = 45999
+
+    def _server_config(self, upstream):
+        return {**_DEFAULT,
+                "network_protocol": {"hivemind-websocket-plugin":
+                                     {"host": "0.0.0.0", "port": 5678}},
+                "upstream": upstream}
+
+    def test_a_real_client_is_built_and_the_node_stays_up(self):
+        service = _make_service()
+        hm_protocol = MagicMock()
+        workers = []
+        upstream = {"enabled": True, "host": "127.0.0.1",
+                    "port": self.UNREACHABLE_PORT,
+                    "key": "an-access-key", "password": "a-password"}
+
+        with scratch_config_home(), \
+                patch("hivemind_core.service.get_server_config",
+                      return_value=self._server_config(upstream)), \
+                patch("hivemind_core.service.create_daemon",
+                      side_effect=workers.append):
+            slave = service._connect_upstream(hm_protocol)
+
+            # the block above has no `ssl` and no `self_signed`: reading it
+            # raised KeyError here before the deep merge, aborting startup
+            self.assertIsNotNone(slave)
+            self.assertIsInstance(slave.hm, HiveMessageBusClient)
+            hm_protocol.bind_upstream.assert_called_once_with(slave)
+
+            # and the worker really tries to reach a dead endpoint without
+            # raising into the caller
+            self.assertEqual(len(workers), 1)
+            worker = threading.Thread(target=workers[0], daemon=True)
+            worker.start()
+            worker.join(timeout=10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **⚠️ This branch is INCOMPLETE. Do not merge.**
> Live testing found two serious faults in this change. Both are fixed locally
> and verified on a real two-node rig, but the commit could not be pushed
> (tooling permission). The pushed branch still contains the regression
> described under "Faults found by live testing". See that section.

## What

`HiveMindListenerProtocol.bind_upstream(slave)` already connects a node to a
master above it, and it works. Nothing in `service.py` or `config.py` exposed
it, so the only way to use it was to write a Python harness — an operator
running `hivemind-core listen` could not express it at all.

This adds the configuration surface. A new top-level `upstream` block:

```json
"upstream": {
  "enabled": false,
  "host": "127.0.0.1",
  "port": 5678,
  "key": "",
  "password": "",
  "ssl": false,
  "self_signed": true
}
```

When enabled, `HiveMindService._connect_upstream` builds a
`HiveMessageBusClient` from those keys, wraps it in a `HiveMindSlaveProtocol`,
calls `bind_upstream`, and connects. The node then forwards downstream
`PROPAGATE`/`ESCALATE` up to that master and fans `BROADCAST`/`PROPAGATE` from
the master back down — HIVEMIND-NODE-1 §3.3 and §4.

The shape follows `presence`: a flat block with `enabled`, sitting next to
`agent_protocol` / `network_protocol` / `binary_protocol`. It is not
plugin-shaped like those three because there is no plugin to select — it is one
connection. `ssl` picks `ws://` or `wss://` for `host`, matching the `ssl` key
the `network_protocol` blocks already use, and `self_signed` maps straight to
the client argument of the same name.

## Faults found by live testing

Neither was reachable from the unit suite, because the unit tests mock
`HiveMessageBusClient`. Both were found by running two real nodes.

**1. The upstream link overwrote the node's own identity.**
`HiveMessageBusClient.init_identity()` copies the credentials it is given onto
the `NodeIdentity` it holds, and the first successful Noise handshake calls
`pin_noise_key()`, which saves that whole identity to disk. Given the node's
own identity, it rewrote `~/.config/hivemind/_identity.json` with the
*upstream's* password and access key — the very values the node presents to its
own downstream clients. Observed on the wire: after enabling the upstream, the
satellite could no longer connect to the downstream node at all.

```
protocol v3 handshake with ...::satellite::... FAILED: handshake failure:
Client provided an invalid api key
```

Enabling this feature silenced every satellite on the node. Fixed: the upstream
link gets its own identity file, `_identity_upstream.json`.

There is a trap worth naming, because it made the first fix a no-op:
`NodeIdentity.__init__` does `identity_file or JsonConfigXDG("_identity", ...)`,
and a `JsonConfigXDG` for a file that does not exist yet is an **empty dict**,
which is falsy — so passing a fresh one silently falls back to the node's own
identity. The file is seeded before it is handed over.

**2. A blank key or password aborted startup.**
`HiveMessageBusClient` raises `RuntimeError("NodeIdentity not set")` at
construction. That happens on the startup thread, so one typo in `server.json`
meant the node never opened its listener:

```
--- still listening? --- NODE DID NOT COME UP
RuntimeError: NodeIdentity not set, please pass key and password or ...
```

Fixed: the credentials are validated first. With either missing, the node logs
an error and stays a top-level master. Serving the downstream clients matters
more than reaching the master; refusing to boot over an upstream typo takes
every satellite offline.

## Live validation

Two real `hivemind-core listen` processes, two real `ovos-messagebus`
instances, one real satellite client, all over real websockets with protocol v3
Noise sessions. The downstream node was configured **purely through
`server.json`** — no Python wiring anywhere.

- upstream master: HiveMind 5793, OVOS bus 8293, `site_id: hq`
- downstream node: HiveMind 5794, OVOS bus 8294, `upstream` block → 127.0.0.1:5793
- satellite: connects to the downstream node on 5794, emits an `ESCALATE`
  carrying a BUS `recognizer_loop:utterance`, targeted at site `hq`

| Scenario | Reached the UPSTREAM master's bus (8293) |
|---|---|
| no `upstream` block (today's behaviour) | **False** — and the master never saw the node connect at all |
| `upstream` block added, node restarted | **True** |
| master killed mid-session | False, no traceback, node kept serving 5794 |
| master restarted, no intervention | **True** — reconnected on its own |
| upstream port unreachable at startup | node came up, listener open, retried in the background |
| `enabled: true`, blank credentials | node came up as a top-level master, logged the error |

The downstream node's connection to the master is a genuine handshake, from
config alone:

```
hivemind_core.service:_connect_upstream - INFO - Upstream master: 127.0.0.1:5793
hivemind_bus_client.protocol:start_noise_handshake - INFO - starting protocol v3 handshake: Noise_XXpsk2_25519_ChaChaPoly_SHA256
```

and on the master:

```
hivemind_core.protocol:handle_noise_handshake_message - INFO - protocol v3 Noise session established with ...::downnode::...
```

After the fixes, the node's own `_identity.json` is never written by the
upstream link, and the satellite connects normally.

## Startup behaviour when the master is unreachable

`HiveMessageBusClient.connect` blocks until the handshake completes, and with
no retry bound it waits forever. So the connect call runs on a daemon thread
(`create_daemon`), the same way `_start_presence` starts presence. The node
finishes startup and serves its downstream clients while the client's own
reconnect loop keeps retrying. Verified live, both at startup and mid-session.
The service closes the client on shutdown.

## Back-compat

**Nobody breaks, and the default path is untouched.**

- `enabled` is `false` in `_DEFAULT`, and `get_server_config` backfills the
  block into existing `server.json` files. An existing deployment builds no
  client, never calls `bind_upstream`, and leaves `_upstream_hm` as `None`.
- Asserted, not assumed: `test_a_node_without_upstream_config_stays_a_top_level_master`
  and `test_a_disabled_upstream_block_binds_nothing`. Confirmed live — with no
  `upstream` block the master log never mentions the node, and the satellite's
  escalate goes nowhere, exactly as today.
- No wire, protocol, or database change. No new dependency: `json_database`,
  `hivemind_bus_client.client` and `.protocol` are already required.
- `_identity_upstream.json` is a new file, created only when the upstream is
  enabled. It never touches `_identity.json`.
- **Who does need to act:** nobody upgrading. Only an operator who *opts in*.
  If they enabled an earlier build of this branch, their node's
  `_identity.json` was overwritten with the upstream credentials and their
  satellites are failing with "invalid api key"; they must restore or
  regenerate the node identity. That is a pre-merge branch state, not a
  released behaviour.

## Adversarial self-check

**What have I not tried?** Live: TLS (`ssl: true`) — only the `ws://`/`wss://`
selection is unit-tested; a self-signed master over `wss` is unverified.
Also untested live: more than two hops, two nodes pointed at the same master,
and a master that accepts the socket but never completes the handshake.

**What does an older peer see?** Nothing changes for peers. The upstream link
is an ordinary `HiveMessageBusClient`, so the master treats the node as a normal
client and negotiates the protocol version as usual — verified against a master
running the same code, which selected v3 Noise.

**What if the upstream disappears mid-session?** Tested by killing the master
with the link established: no traceback, the node kept serving its downstream
clients, and escalates simply stopped reaching the upstream bus.

**What happens on reconnect?** Tested by restarting the master: the client
reconnected on its own and relaying resumed with no restart and no operator
action. `bind_upstream` registers handlers on the client object, not on the
socket, so they survive the reconnect.

**Does the config parse strictly?** Yes — `config["key"]` and friends are
direct lookups, no `getattr`/`.get` defaults, so a malformed block fails
visibly rather than silently behaving as if disabled. `get_server_config`
guarantees the keys exist.

**Could the daemon thread leak on shutdown?** `_stop_upstream` calls
`close()`, which sets the client's stop event and closes the socket.

## Tests

`tests/test_upstream_connection.py`:

- `test_the_default_config_has_no_upstream_enabled`
- `test_a_node_without_upstream_config_stays_a_top_level_master`
- `test_a_disabled_upstream_block_binds_nothing`
- `test_enabled_without_credentials_stays_a_top_level_master` (subtests, regression)
- `test_a_configured_node_binds_the_upstream`
- `test_the_upstream_client_gets_its_own_identity_file` (regression)
- `test_ssl_selects_the_wss_scheme`
- `test_an_unreachable_upstream_does_not_stop_the_node`

The first six were written before the code and proven failing against
`origin/dev`. The two regression tests were written after live testing found
the faults, and fail against the first version of this branch.

The tests redirect `JsonConfigXDG` to a temp dir: building the upstream
identity writes to disk, and an earlier version of the tests created
`~/.config/hivemind/_identity_upstream.json` in the developer's real config.
Note that `JsonConfigXDG` resolves `xdg_folder` as a default argument, i.e.
once at import, so patching `XDG_CONFIG_HOME` in the environment does not work.

- Suite: **214 passed, 1 skipped, 2 subtests passed** (baseline 206 passed, 1 skipped)
- hivemind-test-harness `tests/test_spec_musts.py`: **11 passed, 1 xfailed**
  (baseline), `--timeout=300`

## Not merging

Draft, for the maintainer's call on the config shape.

## AI transparency

Written by Claude Opus under Claude Fable 5 orchestration. The gap was found
while hand-writing a Python harness to test the topology end to end. Both
faults in the first version of this change were found by live-running two real
nodes, and would have shipped green otherwise.


---

# Update — adversarial review

The two fixes are pushed and the blocker is fixed. The review found that a
**partial `upstream` block aborted startup** — the very failure the
missing-credentials branch was written to avoid.

`get_server_config()` backfilled top-level keys only, and `_connect_upstream`
indexes the sub-keys. It runs at `service.py:228`, before the network
protocols start, so a hand-edited block took the node and every satellite it
serves offline:

| block | was |
|---|---|
| no `ssl`/`self_signed` | `KeyError: 'ssl'` |
| only `enabled`/`host`/`port` | `KeyError: 'key'` |
| `"upstream": {}` | `KeyError: 'enabled'` |
| `"upstream": null` | `TypeError: 'NoneType' object is not subscriptable` |

## What changed

- **F5 (blocker).** The `upstream` block is deep-merged against the defaults,
  the way the `policy` block already is. The merge is one function,
  `config.upstream_config()`, called by `get_server_config()` and again at the
  read site — merging an already-merged block changes nothing, and the read
  site is the code that would take the node down. No `.get()` defaults at the
  use sites. A block that is not a dict, `null` included, is replaced by the
  defaults with a warning.
- **F6.** An upstream pointing at one of this node's own listeners is refused
  at startup. It would connect, be rejected, and reconnect every five seconds
  forever — the reconnect counter never backs off, because every attempt does
  connect — putting a `hive.client.connection.error` on the bus each time. A
  listener bound to `0.0.0.0` answers on `127.0.0.1` too, so the comparison is
  "same machine and same port", not "same host string": loopback names,
  wildcard binds, the machine hostname and names that resolve to loopback all
  count. Another hive node on the same machine, on a port this node does not
  listen on, is still a legitimate master.
- **F7.** `upstream_identity()`'s seed docstring now says what the seed is
  for: the file has to exist and be **truthy**, because `NodeIdentity` falls
  back to the node's own `_identity.json` for a falsy one. The value of `name`
  is never read — `HiveMessageBusClient` overwrites it.
- **F8.** Every test mocked `HiveMessageBusClient` *and* `create_daemon`,
  which is why a config-*shape* fault was invisible to the suite. One test now
  builds the real client against an endpoint nothing listens on.
- `docs/configuration.md`: partial blocks are fine, and do not point
  `upstream` at this node.

## Tests

- `TestPartialUpstreamBlock::test_every_partial_block_is_completed_with_the_defaults`
  — the four partial blocks and `null`
- `TestPartialUpstreamBlock::test_a_missing_block_gives_the_defaults`
- `TestPartialUpstreamBlock::test_a_set_sub_key_survives_the_merge`
- `TestPartialUpstreamBlock::test_get_server_config_merges_the_block` — through
  a real `server.json` on disk
- `TestPartialUpstreamBlock::test_no_partial_block_aborts_startup`
- `TestUpstreamIsNotThisNode::test_loopback_matches_a_listener_bound_to_all_interfaces`
- `TestUpstreamIsNotThisNode::test_every_way_of_naming_this_node_is_refused`
- `TestUpstreamIsNotThisNode::test_a_loopback_port_nothing_listens_on_is_allowed`
- `TestUpstreamIsNotThisNode::test_a_remote_master_on_the_same_port_is_allowed`
- `TestAgainstTheRealClient::test_a_real_client_is_built_and_the_node_stays_up`

Fail-on-old, `git stash` of `hivemind_core/service.py`: **15 failed, 16
passed**. Stashing `config.py` as well makes the module fail to import, since
`upstream_config` does not exist there yet. With the fix: **18 passed, 20
subtests passed**.

- Suite: **224 passed, 1 skipped, 20 subtests passed**
- hivemind-test-harness `tests/test_spec_musts.py`: **11 passed, 1 xfailed**,
  `--timeout=300`
