### PR TITLE
docs: remove THIRDPRTY from the message-type table

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,6 @@ messages). Responses from the agent travel back through the same path.
 | `CASCADE` | server → satellite(s) | Scatter/gather: distributes a query across children |
 | `INTERCOM` | bidirectional | Signed/encrypted end-to-end peer message |
 | `BINARY` | bidirectional | Raw bytes (audio, image, file). Crosses the same `allowed_types` gate as `BUS` |
-| `THIRDPRTY` | bidirectional | User-land message. HiveMind carries it and does nothing else with it |
 
 ### QUERY / CASCADE streaming
 


### PR DESCRIPTION
Part of the removal of the `THIRDPRTY` message type (client library: JarbasHiveMind/hivemind-websocket-client#160).

hivemind-core never had a dispatch branch for `THIRDPRTY`. `handle_message` has no case for it and no code path in this repo referenced it, so the only change here is the row in `docs/architecture.md`.

Nothing in the tree produced the type, so nothing loses a feature.