### PR TITLE
fix: iterate a snapshot of clients during fan-out

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1311,10 +1311,11 @@ class HiveMindListenerProtocol:
 
         # broadcast message to other peers (NODE-1 §3.3: keep the envelope)
         fwd = self._rewrap(message, payload)
-        for peer in self.clients:
-            if peer == client.peer:
+        # snapshot: disconnects/reconnects mutate self.clients from other threads
+        for conn in list(self.clients.values()):
+            if conn.peer == client.peer:
                 continue
-            self.clients[peer].send(fwd)
+            conn.send(fwd)
 
     def _unpack_message(self, message: HiveMessage, client: HiveMindClientConnection):
         # propagate message to other peers
@@ -1460,10 +1461,10 @@ class HiveMindListenerProtocol:
         # propagate message to other peers (NODE-1 §3.3: keep the envelope, so a
         # peer receives a PROPAGATE it can fan out again instead of a bare BUS)
         fwd = self._rewrap(message, payload)
-        for peer in self.clients:
-            if peer == client.peer:
+        for conn in list(self.clients.values()):
+            if conn.peer == client.peer:
                 continue
-            self.clients[peer].send(fwd)
+            conn.send(fwd)
 
         # forward upstream to the master this node relays to (no-op at top level)
         self.propagate_to_master(fwd)
@@ -1526,7 +1527,7 @@ class HiveMindListenerProtocol:
 
         # NODE-1 §4: a PING fans out across the whole mesh — downstream peers
         # and upstream alike, so a master learns of nodes below a relay
-        for conn in self.clients.values():
+        for conn in list(self.clients.values()):
             conn.send(own_ping_outer)
         self.propagate_to_master(own_ping_outer)
 
@@ -1552,7 +1553,7 @@ class HiveMindListenerProtocol:
                       f"route={message.route}")
             return
         self._append_self_hop(message)
-        for conn in self.clients.values():
+        for conn in list(self.clients.values()):
             conn.send(message)
 
     def broadcast_from_master(self, message: HiveMessage) -> None:
@@ -1563,7 +1564,7 @@ class HiveMindListenerProtocol:
         directly connected downstream nodes, never re-broadcast by recipients.
         It only ever travels upstream-to-downstream, so it cannot cycle.
         """
-        for conn in self.clients.values():
+        for conn in list(self.clients.values()):
             conn.send(message)
 
     def propagate_from_master(self, message: HiveMessage) -> None:
@@ -1735,16 +1736,19 @@ class HiveMindListenerProtocol:
             except Exception:
                 LOG.exception(f"cascade_select_callback error for query_id={query_id}")
             return
-        # Default routing: forward toward the originator
-        if originator_peer in self.clients:
-            self.clients[originator_peer].send(message)
+        # Default routing: forward toward the originator. get() + None-check
+        # instead of "in" + index: a disconnect between the two would KeyError.
+        conn = self.clients.get(originator_peer)
+        if conn is not None:
+            conn.send(message)
             return
         # route-aware return: send to the downstream hop on the path back to
         # the originator (from the request's recorded route) instead of flooding
         for hop in reversed(message.route or []):
             src = hop.get("source")
-            if src and src != sender and src in self.clients:
-                self.clients[src].send(message)
+            conn = self.clients.get(src) if src and src != sender else None
+            if conn is not None:
+                conn.send(message)
                 return
         # no return path: the originator is not ours and the route names no
         # peer we can reach. Fanning the response downstream would hand one
@@ -1866,10 +1870,10 @@ class HiveMindListenerProtocol:
             return
 
         cascade_fwd = self._rewrap(message, payload, metadata)
-        for peer in self.clients:
-            if peer == client.peer:
+        for conn in list(self.clients.values()):
+            if conn.peer == client.peer:
                 continue
-            self.clients[peer].send(cascade_fwd)
+            conn.send(cascade_fwd)
         self.cascade_to_master(cascade_fwd)
 
     def handle_escalate_message(

--- a/tests/test_clients_race.py
+++ b/tests/test_clients_race.py
@@ -1,0 +1,97 @@
+"""Regression test for a reproduced concurrency bug in fan-out.
+
+``self.clients`` is a plain dict, mutated on the tornado IOLoop thread
+(connect/reconnect/disconnect) while fan-out on other threads (the OVOS bus
+thread, the upstream slave thread) iterated it directly. With ~30 satellites
+plus one reconnecting, that raced into
+``RuntimeError: dictionary changed size during iteration``. The exception
+escaped ``on_message``, so tornado tore down the *sender's* websocket -- one
+satellite got disconnected because a different satellite reconnected, and the
+broadcast only reached some peers.
+
+Fan-out now iterates a ``list(self.clients.values())`` snapshot, so a
+concurrent mutation can no longer raise mid-iteration.
+"""
+import sys
+import threading
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+DEFAULT_PEER = "master:0.0.0.0"
+NUM_SATELLITES = 30
+
+
+def _make_node() -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = DEFAULT_PEER
+    node.identity = MagicMock(public_key="pubkey-master", site_id=None)
+    node.clients = {}
+    node.illegal_callback = None
+    node.broadcast_callback = None
+    return node
+
+
+def _make_client(peer: str) -> MagicMock:
+    client = MagicMock()
+    client.peer = peer
+    client.is_admin = True
+    client.can_broadcast = True
+    return client
+
+
+def _broadcast() -> HiveMessage:
+    inner = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {"utterance": "hi"}))
+    return HiveMessage(HiveMessageType.BROADCAST, payload=inner)
+
+
+def test_fan_out_survives_concurrent_client_mutation():
+    node = _make_node()
+    sent = {}
+    for i in range(NUM_SATELLITES):
+        peer = f"sat-{i}"
+        conn = MagicMock()
+        conn.peer = peer
+        conn.send = lambda m, box=sent.setdefault(peer, []): box.append(m)
+        node.clients[peer] = conn
+    pre_existing_peers = set(node.clients)
+
+    sender = _make_client("sat-sender")
+    node.clients[sender.peer] = sender
+
+    stop = threading.Event()
+
+    def reconnect_storm(mutator_id):
+        # other satellites reconnecting: pop + re-add an entry in a tight
+        # loop, racing the fan-out below on this thread while it iterates
+        # on the main thread
+        while not stop.is_set():
+            peer = f"sat-reconnecting-{mutator_id}"
+            node.clients.pop(peer, None)
+            conn = MagicMock()
+            conn.peer = peer
+            conn.send = lambda m: None
+            node.clients[peer] = conn
+
+    # lower the GIL switch interval so the mutator threads interleave with
+    # the fan-out loop far more often, making the race reliable in a test
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    threads = [threading.Thread(target=reconnect_storm, args=(i,), daemon=True)
+               for i in range(8)]
+    for t in threads:
+        t.start()
+    try:
+        for _ in range(2000):
+            node.handle_broadcast_message(_broadcast(), sender)
+    finally:
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+        sys.setswitchinterval(old_interval)
+
+    for peer in pre_existing_peers:
+        assert sent[peer], f"{peer} never received the broadcast"


### PR DESCRIPTION
## Summary
- `self.clients` is a plain dict mutated on the tornado IOLoop thread (connect, stale-peer cleanup, disconnect) while fan-out iterated it directly from other threads (the OVOS bus thread, the upstream slave thread).
- Reproduced with ~30 satellites plus one reconnecting: `RuntimeError: dictionary changed size during iteration`. The exception escaped `on_message`, so tornado tore down the SENDER's websocket -- one satellite got disconnected because a different satellite reconnected, and the broadcast only reached some peers.
- All six fan-out loops now iterate `list(self.clients.values())`, a snapshot immune to concurrent mutation.
- The originator-routing lookup in `_route_query_response` moved from an `in` check followed by an index (racy: a `pop` between the two raises `KeyError`) to a single `self.clients.get()` with a `None` guard.

## Test plan
- [x] Added `tests/test_clients_race.py`: spawns 8 mutator threads hammering `self.clients` while a fan-out runs, asserting no exception and full delivery. Verified it reliably raises `RuntimeError` against the pre-fix code and passes against the fix.
- [x] `pytest tests -q -p no:ovoscope -p no:recording --timeout=300` — 284 passed, 3 skipped, 1 pre-existing unrelated xpass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message broadcasting, propagation, pinging, relaying, and forwarding during simultaneous client connections or disconnections.
  * Prevented errors when routing query responses while connections change.

* **Tests**
  * Added coverage for concurrent reconnects and repeated broadcasts to ensure existing connections continue receiving messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->