### PR TITLE
perf: cut per-peer cost in message fan-out

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
 import json
+import logging
 import os
 import time
 import uuid
@@ -72,6 +73,15 @@ from hivemind_core.policy import (BACKEND_UNAVAILABLE, MALFORMED_PAYLOAD,
 from poorman_handshake import HandShake, PasswordHandShake
 from poorman_handshake.asymmetric.utils import decrypt_RSA, load_RSA_key, verify_RSA
 from Cryptodome.PublicKey import RSA
+
+#: Stdlib logger used ONLY in ``HiveMindClientConnection.send()``'s per-peer hot
+#: path. ``ovos_utils.log.LOG.debug`` is a classmethod that calls
+#: ``inspect.stack()`` before checking the log level, so a *suppressed* call
+#: still costs 3+ orders of magnitude more than stdlib, which checks the level
+#: first. Measured at ~570ms of ~816ms in a 1000-peer fan-out. Everywhere else
+#: in this file keeps using ovos ``LOG`` on purpose, so it routes into OVOS's
+#: logging setup — do not "fix" this one back to match.
+_log = logging.getLogger(__name__)
 
 #: HIVEMIND-MSG-1 §4: the payload of these message types IS a nested
 #: ``HiveMessage``. Every other type carries a bus ``Message``, binary data or
@@ -253,15 +263,23 @@ class HiveMindClientConnection:
         # this is how ovos refers to connected nodes in message.context
         return f"{self.name}::{self.sess.session_id}{self._peer_suffix}"
 
-    def send(self, message: HiveMessage):
+    def send(self, message: HiveMessage, plaintext: Optional[str] = None):
+        """Send ``message`` to this peer.
+
+        ``plaintext`` lets a fan-out caller pass a pre-serialized
+        ``message.serialize()`` result, computed once for the whole fan-out
+        instead of once per peer (serialization is not cheap and does not
+        depend on the peer). Encryption still happens per peer below, since
+        each connection has its own crypto state.
+        """
         is_bin = message.msg_type == HiveMessageType.BINARY
         if not is_bin and message.msg_type == HiveMessageType.BUS:
             _payload_type = (message.payload.get("type")
                              if isinstance(message.payload, dict)
                              else message.payload.msg_type)
-            LOG.debug(f"mycroft_type {_payload_type}")
+            _log.debug("mycroft_type %s", _payload_type)
 
-        LOG.debug(f"sending to {self.peer}: {message.msg_type}")
+        _log.debug("sending to %s: %s", self.peer, message.msg_type)
 
         if self.noise_transport is not None:
             # protocol v3: every message (HELLO/HANDSHAKE included) is a Noise
@@ -272,7 +290,7 @@ class HiveMindClientConnection:
                                         hivemeta=message.metadata,
                                         binary_type=message.bin_type).bytes
             else:
-                payload = message.serialize()
+                payload = plaintext if plaintext is not None else message.serialize()
             self.send_msg(self.noise_transport.encrypt_frame(payload), True)
             return
 
@@ -285,20 +303,20 @@ class HiveMindClientConnection:
                                         payload=message.payload,
                                         hivemeta=message.metadata,
                                         binary_type=message.bin_type).bytes
-                LOG.debug(f"unencrypted binary payload size: {len(payload)} bytes")
+                _log.debug("unencrypted binary payload size: %d bytes", len(payload))
                 payload = encrypt_bin(key=self.crypto_key, plaintext=payload, cipher=self.cipher)
                 is_bin = True
             else:
-                plaintext = message.serialize()
-                LOG.debug(f"unencrypted payload size: {len(plaintext)} bytes")
+                plaintext = plaintext if plaintext is not None else message.serialize()
+                _log.debug("unencrypted payload size: %d bytes", len(plaintext))
                 payload = encrypt_as_json(
                     key=self.crypto_key, plaintext=plaintext,
                     cipher=self.cipher, encoding=self.encoding
                 )  # json string
-            LOG.debug(f"encrypted payload size: {len(payload)} bytes")
+            _log.debug("encrypted payload size: %d bytes", len(payload))
         else:
-            payload = message.serialize()
-            LOG.debug(f"sent unencrypted!")
+            payload = plaintext if plaintext is not None else message.serialize()
+            _log.debug("sent unencrypted!")
 
         self.send_msg(payload, is_bin)
 
@@ -1412,10 +1430,14 @@ class HiveMindListenerProtocol:
         # broadcast message to other peers (NODE-1 §3.3: keep the envelope)
         fwd = self._rewrap(message, payload)
         # snapshot: disconnects/reconnects mutate self.clients from other threads
+        plaintext = fwd.serialize()
         for conn in list(self.clients.values()):
             if conn.peer == client.peer:
                 continue
-            conn.send(fwd)
+            try:
+                conn.send(fwd, plaintext)
+            except Exception:
+                LOG.exception(f"failed to forward to {conn.peer}")
 
     def _unpack_message(self, message: HiveMessage, client: HiveMindClientConnection):
         # propagate message to other peers
@@ -1561,10 +1583,14 @@ class HiveMindListenerProtocol:
         # propagate message to other peers (NODE-1 §3.3: keep the envelope, so a
         # peer receives a PROPAGATE it can fan out again instead of a bare BUS)
         fwd = self._rewrap(message, payload)
+        plaintext = fwd.serialize()
         for conn in list(self.clients.values()):
             if conn.peer == client.peer:
                 continue
-            conn.send(fwd)
+            try:
+                conn.send(fwd, plaintext)
+            except Exception:
+                LOG.exception(f"failed to forward to {conn.peer}")
 
         # forward upstream to the master this node relays to (no-op at top level)
         self.propagate_to_master(fwd)
@@ -1693,8 +1719,17 @@ class HiveMindListenerProtocol:
         # NODE-1 §4: a PING fans out across the whole mesh — downstream peers
         # and upstream alike, so a master learns of nodes below a relay and a
         # satellite still sees the relay it is attached to.
+        #
+        # The envelope is serialized once and handed to every peer: the
+        # plaintext is identical for all of them, only the per-connection
+        # encryption differs. One peer failing to send must not cost the
+        # others their PING, so each send is isolated.
+        plaintext = own_ping_outer.serialize()
         for conn in list(self.clients.values()):
-            conn.send(own_ping_outer)
+            try:
+                conn.send(own_ping_outer, plaintext)
+            except Exception:
+                LOG.exception(f"failed to send PING to {conn.peer}")
         if owes_upstream:
             self.propagate_to_master(own_ping_outer)
 
@@ -1737,8 +1772,12 @@ class HiveMindListenerProtocol:
                       f"route={message.route}")
             return
         self._append_self_hop(message)
+        plaintext = message.serialize()
         for conn in list(self.clients.values()):
-            conn.send(message)
+            try:
+                conn.send(message, plaintext)
+            except Exception:
+                LOG.exception(f"failed to relay to {conn.peer}")
 
     def broadcast_from_master(self, message: HiveMessage) -> None:
         """Fan a BROADCAST received from the upstream master out to all
@@ -1748,8 +1787,12 @@ class HiveMindListenerProtocol:
         directly connected downstream nodes, never re-broadcast by recipients.
         It only ever travels upstream-to-downstream, so it cannot cycle.
         """
+        plaintext = message.serialize()
         for conn in list(self.clients.values()):
-            conn.send(message)
+            try:
+                conn.send(message, plaintext)
+            except Exception:
+                LOG.exception(f"failed to broadcast to {conn.peer}")
 
     def propagate_from_master(self, message: HiveMessage) -> None:
         """Fan a PROPAGATE received from the upstream master out to all
@@ -2058,10 +2101,14 @@ class HiveMindListenerProtocol:
             return
 
         cascade_fwd = self._rewrap(message, payload, metadata)
+        plaintext = cascade_fwd.serialize()
         for conn in list(self.clients.values()):
             if conn.peer == client.peer:
                 continue
-            conn.send(cascade_fwd)
+            try:
+                conn.send(cascade_fwd, plaintext)
+            except Exception:
+                LOG.exception(f"failed to forward to {conn.peer}")
         self.cascade_to_master(cascade_fwd)
 
     def handle_escalate_message(

--- a/tests/test_clients_race.py
+++ b/tests/test_clients_race.py
@@ -55,7 +55,9 @@ def test_fan_out_survives_concurrent_client_mutation():
         peer = f"sat-{i}"
         conn = MagicMock()
         conn.peer = peer
-        conn.send = lambda m, box=sent.setdefault(peer, []): box.append(m)
+        # send() takes an optional pre-serialized plaintext from the fan-out
+        # caller; swallow it here so the stub keeps recording just the message.
+        conn.send = lambda m, _plaintext=None, box=sent.setdefault(peer, []): box.append(m)
         node.clients[peer] = conn
     pre_existing_peers = set(node.clients)
 
@@ -73,7 +75,7 @@ def test_fan_out_survives_concurrent_client_mutation():
             node.clients.pop(peer, None)
             conn = MagicMock()
             conn.peer = peer
-            conn.send = lambda m: None
+            conn.send = lambda m, _plaintext=None: None
             node.clients[peer] = conn
 
     # lower the GIL switch interval so the mutator threads interleave with

--- a/tests/test_fanout_resilience.py
+++ b/tests/test_fanout_resilience.py
@@ -1,0 +1,87 @@
+"""Regression tests for the fan-out hot path in
+``HiveMindListenerProtocol.handle_broadcast_message``.
+
+Before this fix, a single peer raising out of ``HiveMindClientConnection.send``
+(e.g. a ``binarize=True`` client whose metadata exceeds the WIRE-1 binary cap,
+or a peer in a broken crypto state) escaped the fan-out loop and every peer
+ordered after it in ``self.clients`` never received the message. One bad
+client silenced a broadcast to the whole mesh.
+
+It also checks the message is serialized once per fan-out, not once per peer:
+``HiveMessage.serialize()`` re-runs ``json.dumps``/``json.loads`` and route
+filtering on every call, so doing it per peer wastes 10-40ms across a
+1000-peer fan-out for no reason -- the plaintext does not depend on the peer.
+"""
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_protocol():
+    proto = object.__new__(HiveMindListenerProtocol)
+    proto.peer = "master:0.0.0.0"
+    proto.identity = MagicMock(public_key="pubkey-master", site_id=None)
+    proto.clients = {}
+    proto.illegal_callback = MagicMock()
+    proto.broadcast_callback = MagicMock()
+    return proto
+
+
+def _make_admin_client(peer: str) -> MagicMock:
+    client = MagicMock()
+    client.peer = peer
+    client.is_admin = True
+    client.can_broadcast = True
+    return client
+
+
+def _broadcast() -> HiveMessage:
+    inner = HiveMessage(HiveMessageType.BUS,
+                        payload=Message("speak", {"utterance": "hi"}))
+    return HiveMessage(HiveMessageType.BROADCAST, payload=inner)
+
+
+def test_one_raising_peer_does_not_block_delivery_to_others():
+    proto = _make_protocol()
+    originator = _make_admin_client("origin::0")
+    bad = _make_admin_client("bad::1")
+    bad.send.side_effect = ValueError("metadata exceeds WIRE-1 binary cap")
+    good_before = _make_admin_client("good-before::2")
+    good_after = _make_admin_client("good-after::3")
+
+    proto.clients = {
+        originator.peer: originator,
+        good_before.peer: good_before,
+        bad.peer: bad,
+        good_after.peer: good_after,
+    }
+
+    proto.handle_broadcast_message(_broadcast(), originator)
+
+    good_before.send.assert_called_once()
+    good_after.send.assert_called_once()
+    bad.send.assert_called_once()
+
+
+def test_fanout_serializes_once_not_once_per_peer():
+    proto = _make_protocol()
+    originator = _make_admin_client("origin::0")
+    peers = [_make_admin_client(f"peer::{i}") for i in range(5)]
+    proto.clients = {originator.peer: originator,
+                     **{p.peer: p for p in peers}}
+
+    with patch.object(HiveMessage, "serialize",
+                      wraps=HiveMessage.serialize, autospec=True) as spy:
+        proto.handle_broadcast_message(_broadcast(), originator)
+
+    assert spy.call_count == 1, \
+        f"expected message.serialize() once per fan-out, called {spy.call_count} times"
+
+    for p in peers:
+        p.send.assert_called_once()
+        args, _ = p.send.call_args
+        assert len(args) == 2 and isinstance(args[1], str), \
+            "each peer must receive the shared pre-serialized plaintext"

--- a/tests/test_fanout_resilience.py
+++ b/tests/test_fanout_resilience.py
@@ -73,12 +73,27 @@ def test_fanout_serializes_once_not_once_per_peer():
     proto.clients = {originator.peer: originator,
                      **{p.peer: p for p in peers}}
 
-    with patch.object(HiveMessage, "serialize",
-                      wraps=HiveMessage.serialize, autospec=True) as spy:
+    # NOTE: deliberately NOT using patch.object(..., autospec=True, wraps=...)
+    # here. On Python 3.10, autospec's signature-checking wrapper around a
+    # `wraps`-forwarded call returns a MagicMock instead of the real
+    # function's return value (fixed upstream in 3.11), which made
+    # HiveMessage.serialize() appear to return a non-str object. That was a
+    # mocking-library gotcha, not a fan-out behavior difference -- so we
+    # count calls with a plain forwarding function instead, which is
+    # version-independent.
+    original_serialize = HiveMessage.serialize
+    call_count = 0
+
+    def _counting_serialize(self):
+        nonlocal call_count
+        call_count += 1
+        return original_serialize(self)
+
+    with patch.object(HiveMessage, "serialize", _counting_serialize):
         proto.handle_broadcast_message(_broadcast(), originator)
 
-    assert spy.call_count == 1, \
-        f"expected message.serialize() once per fan-out, called {spy.call_count} times"
+    assert call_count == 1, \
+        f"expected message.serialize() once per fan-out, called {call_count} times"
 
     for p in peers:
         p.send.assert_called_once()

--- a/tests/test_mesh_routing_conformance.py
+++ b/tests/test_mesh_routing_conformance.py
@@ -57,7 +57,7 @@ def _wire_peers(node, *peers):
     sent = {p: [] for p in peers}
     for p in peers:
         conn = MagicMock()
-        conn.send = lambda m, box=sent[p]: box.append(m)
+        conn.send = lambda m, *a, box=sent[p]: box.append(m)
         node.clients[p] = conn
     return sent
 

--- a/tests/test_node_provenance.py
+++ b/tests/test_node_provenance.py
@@ -64,7 +64,7 @@ def test_responsive_ping_announces_the_node_key():
     node = _make_node()
     sent = []
     conn = _client()
-    conn.send = sent.append
+    conn.send = lambda m, *a: sent.append(m)
     node.clients = {conn.peer: conn}
     node.propagate_to_master = lambda msg: None
 

--- a/tests/test_query_response_isolation.py
+++ b/tests/test_query_response_isolation.py
@@ -33,7 +33,7 @@ def _wire_peers(node, *peers):
     sent = {p: [] for p in peers}
     for p in peers:
         conn = MagicMock()
-        conn.send = lambda m, box=sent[p]: box.append(m)
+        conn.send = lambda m, *a, box=sent[p]: box.append(m)
         node.clients[p] = conn
     return sent
 

--- a/tests/test_route_loop_suppression.py
+++ b/tests/test_route_loop_suppression.py
@@ -75,7 +75,7 @@ def test_propagate_appends_self_hop_keyed_on_public_key():
     node = _make_node("pubkey-A")
     sent = []
     conn = MagicMock()
-    conn.send = lambda m: sent.append(m)
+    conn.send = lambda m, *a: sent.append(m)
     node.clients = {"downstream::9": conn}
 
     msg = _propagate("hi")
@@ -108,7 +108,7 @@ def test_multirelay_chain_delivers_under_shared_default_peer():
     delivered = {}
 
     def wire(src_node, dst_node, edge):
-        def send(payload):
+        def send(payload, *a):
             outer = HiveMessage(HiveMessageType.PROPAGATE, payload=payload)
             outer.replace_route(payload.route)
             queue.append((dst_node, outer, edge))
@@ -146,7 +146,7 @@ def test_looped_propagate_delivers_locally_but_is_not_reforwarded():
     node = _make_node("pubkey-A")
     sent = []
     conn = MagicMock()
-    conn.send = lambda m: sent.append(m)
+    conn.send = lambda m, *a: sent.append(m)
     node.clients = {"downstream::9": conn}
 
     msg = _propagate("loop")
@@ -173,7 +173,7 @@ def test_propagate_ring_terminates():
     forwards = {"pubkey-A": 0, "pubkey-B": 0, "pubkey-C": 0}
 
     def wire(src_node, dst_node, edge):
-        def send(payload):
+        def send(payload, *a):
             forwards[src_node.identity.public_key] += 1
             outer = HiveMessage(HiveMessageType.PROPAGATE, payload=payload)
             outer.replace_route(payload.route)
@@ -261,7 +261,7 @@ def test_cascade_appends_self_hop_and_drops_on_loop():
     node = _cascade_node("pubkey-K")
     sent, upstream = [], []
     conn = MagicMock()
-    conn.send = lambda m: sent.append(m)
+    conn.send = lambda m, *a: sent.append(m)
     node.clients = {"downstream::9": conn}
     node._upstream_hm = MagicMock()
     node._upstream_hm.emit = lambda m: upstream.append(m)
@@ -282,7 +282,7 @@ def test_cascade_appends_self_hop_and_drops_on_loop():
     node2 = _cascade_node("pubkey-K")
     sent2, upstream2 = [], []
     conn2 = MagicMock()
-    conn2.send = lambda m: sent2.append(m)
+    conn2.send = lambda m, *a: sent2.append(m)
     node2.clients = {"downstream::9": conn2}
     node2._upstream_hm = MagicMock()
     node2._upstream_hm.emit = lambda m: upstream2.append(m)


### PR DESCRIPTION
## Summary
- `HiveMindClientConnection.send()` made 3-4 `LOG.debug` calls per peer. `ovos_utils.log.LOG.debug` runs `inspect.stack()` before checking the log level, so a suppressed call cost 3+ orders of magnitude more than it should — measured ~570ms of ~816ms in a 1000-peer fan-out. Switched the hot-path calls to a module-level stdlib logger with lazy `%s` formatting.
- None of the six fan-out loops guarded the per-peer `send()`. One peer raising (e.g. a `binarize=True` client whose metadata exceeds the WIRE-1 binary cap, or a peer in a broken crypto state) escaped the loop and silenced delivery to every peer ordered after it. Each loop now wraps its per-peer send in try/except and logs+continues.
- `send()` called `message.serialize()` once per peer even though the plaintext doesn't depend on the peer (only encryption does, which stays per-peer). Measured 9.8-41us per call depending on route depth, ~10-40ms of pure waste per 1000-peer fan-out. `send()` now accepts an optional pre-serialized plaintext, computed once per fan-out.

## Test plan
- [x] New regression test: a raising peer no longer blocks delivery to the rest of the mesh
- [x] New regression test: `serialize()` runs once per fan-out, not once per peer
- [x] Full suite: `pytest tests -q -p no:ovoscope -p no:recording --timeout=300` → 285 passed, 3 skipped, 1 xpassed (pre-existing, unrelated)