### PR TITLE
fix: a node emits at most one responsive PING flood per interval

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -96,6 +96,15 @@ _DEFAULT = {
         ],
     },
 
+    # Minimum seconds between two responsive PING floods emitted by this node.
+    # Answering a flood costs one send per connected peer, and every satellite
+    # floods on its own schedule, so with no floor here the node's fan-out work
+    # grows with the square of the mesh size. Inside the window the node still
+    # answers the peer that pinged it — directly, one send — so that peer's map
+    # is never wrong; only the mesh-wide fan-out waits. Keep this well under the
+    # satellites' own ping period, or a node's entry in remote maps goes stale.
+    "ping_flood_interval": 30,
+
     # Debounce for the synchronous client-db last_seen write. update_last_seen
     # runs on every inbound message, inline on the tornado IOLoop thread; the
     # JSON backend's commit() rewrites the entire client store on each call.

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -448,6 +448,15 @@ class HiveMindListenerProtocol:
     hive_mapper: HiveMapper = dataclasses.field(default_factory=HiveMapper)
     policy_chain: Optional[PolicyChain] = None
 
+    # Throttle state for the mesh-wide responsive PING flood. Both are
+    # declared as fields with plain (immutable) defaults, not just assigned in
+    # __post_init__, so that a test fixture built with ``object.__new__``
+    # finds working values instead of raising AttributeError on the ping path.
+    # __post_init__ still overwrites ping_flood_interval from config, so
+    # operator config keeps winning.
+    _last_ping_flood: float = field(default=0.0, init=False, repr=False)
+    ping_flood_interval: float = field(default=30.0, init=False)
+
     # below are optional callbacks to handle payloads
     # receives the payload + HiveMindClient that sent it
     escalate_callback = None  # slave asked to escalate payload
@@ -479,13 +488,15 @@ class HiveMindListenerProtocol:
         # last for the lifetime of this listener (the Client DB model has no
         # pubkey column yet).
         self.trusted_pubkeys: dict = {}  # client.key -> PEM public key
-        # Already-answered PING floods (MSG-1 §4). Set-like, FIFO-evicting.
+        # Already-answered PING floods (MSG-1 §4). Set-like, FIFO-evicting:
+        # a dedup miss re-triggers a whole flood, so an eviction that drops a
+        # live flood_id amplifies the very traffic this cache exists to stop.
         # bind_upstream hands this exact object to the upstream slave
         # protocol so a node with an upstream keeps ONE flood cache, not one
         # per protocol object.
         self._seen_flood_ids: FloodIdCache = FloodIdCache()
-        # Floods this listener half has already fanned out downstream. Private
-        # to this half, unlike ``_seen_flood_ids`` above: see
+        # Floods this listener half has already decided how to answer.
+        # Private to this half, unlike ``_seen_flood_ids`` above: see
         # ``handle_ping_message`` for why the node needs both records.
         self._answered_floods: FloodIdCache = FloodIdCache()
         self._pending_cascades: dict = {}  # query_id -> CascadeCollector
@@ -493,6 +504,10 @@ class HiveMindListenerProtocol:
         self.last_seen_update_interval = _non_negative_float(
             get_server_config().get("last_seen_update_interval", 0),
             0.0,
+        )
+        self.ping_flood_interval = _non_negative_float(
+            get_server_config().get("ping_flood_interval", 30),
+            30.0,
         )
         self.agent_protocol.hm_protocol = self
         if not self.binary_data_protocol:
@@ -1560,9 +1575,11 @@ class HiveMindListenerProtocol:
         """Handle an inner PING message received inside a PROPAGATE wrapper.
 
         Feeds the PING into the local ``HiveMapper``, emits ``hive.ping.received``
-        on the agent bus, then — if this ``flood_id`` has not been seen before —
-        builds and sends this node's own responsive PING (same ``flood_id``) to
-        all peers and upstream.
+        on the agent bus for each newly observed peer, then — if this
+        ``flood_id`` has not been seen before — answers with this node's own
+        PING carrying the same ``flood_id``. That answer fans out to all peers
+        and upstream at most once per ``ping_flood_interval`` seconds; inside
+        the window it goes to the asking peer alone.
 
         Args:
             message: Inner PING HiveMessage (route already transferred from outer
@@ -1576,18 +1593,26 @@ class HiveMindListenerProtocol:
 
         flood_id = ping_payload.get("flood_id", "")
 
-        # Always feed mapper (register sender info)
-        self.hive_mapper.on_ping(message, received_at=time.time())
+        # The mapper is the topology view, so it must see arrivals the dedup
+        # gate below drops: each one names a different peer and carries a
+        # different route. It keeps its own (flood_id, peer) index and answers
+        # False for an arrival it has already folded in.
+        new_to_map = self.hive_mapper.on_ping(message, received_at=time.time())
 
-        # Surface every observed PING on the agent bus (discovery/telemetry).
-        # Fires for satellite-originated and flood-cycle pings alike, before the
-        # dedup gate below.
-        self.agent_protocol.bus.emit(Message("hive.ping.received", {
-            "flood_id": flood_id,
-            "peer": ping_payload.get("peer"),
-            "site_id": ping_payload.get("site_id"),
-            "timestamp": ping_payload.get("timestamp"),
-        }))
+        # Surface observed PINGs on the agent bus (discovery/telemetry), gated
+        # on the mapper's novelty answer so one send goes out per (flood_id,
+        # peer) instead of one per arrival. A peer that reaches us over several
+        # mesh paths is the same observation each time, and repeating it puts
+        # the mesh's fan-out factor onto the agent bus. Still ahead of the
+        # dedup gate: a flood we already answered keeps carrying peers we have
+        # never seen, and those are the discoveries.
+        if new_to_map:
+            self.agent_protocol.bus.emit(Message("hive.ping.received", {
+                "flood_id": flood_id,
+                "peer": ping_payload.get("peer"),
+                "site_id": ping_payload.get("site_id"),
+                "timestamp": ping_payload.get("timestamp"),
+            }))
 
         # Flood-loop prevention (MSG-1 §4): answer a flood at most once.
         #
@@ -1602,14 +1627,17 @@ class HiveMindListenerProtocol:
         #   * ``_seen_flood_ids`` — shared with the upstream slave protocol
         #     (see bind_upstream). It says "a half of this node already sent
         #     the answer upstream", so the master never sees two.
-        #   * ``_answered_floods`` — private to this half. It says "the
-        #     downstream fan-out already happened", so repeat arrivals from
-        #     several clients do not re-flood.
-        if not flood_id or self._answered_floods.check(flood_id):
+        #   * ``_answered_floods`` — private to this half. It says "this half
+        #     already decided how to answer this flood", so repeat arrivals
+        #     from several clients neither re-flood nor re-answer.
+        #
+        # Both caches grow with the client count, because every connected peer
+        # can start a flood of its own. A fixed 1000 thrashes on a large mesh,
+        # and each eviction of a live flood_id buys a duplicate flood.
+        flood_cache_size = max(1000, len(self.clients) * 100)
+        if not flood_id or self._answered_floods.check(flood_id,
+                                                       max_size=flood_cache_size):
             return
-        # atomic across both halves: whoever wins owes upstream the answer,
-        # the loser already has one in flight from its other half
-        owes_upstream = not self._seen_flood_ids.check(flood_id)
 
         # Build our own responsive PING with the same flood_id.
         # ``peer`` is the map key; ``public_key`` is the node's stable
@@ -1625,6 +1653,40 @@ class HiveMindListenerProtocol:
         }
         own_ping_inner = HiveMessage(HiveMessageType.PING, own_ping_payload)
         own_ping_outer = HiveMessage(HiveMessageType.PROPAGATE, payload=own_ping_inner)
+
+        # Every satellite floods on its own schedule, and each flood costs this
+        # node one send per peer, so unthrottled the node's work per round grows
+        # with the square of the mesh size — the point where a large site stops
+        # completing rounds at all. At most one mesh-wide fan-out per
+        # ping_flood_interval seconds; the peers that ask inside that window are
+        # answered directly instead, one send each.
+        #
+        # This check comes BEFORE the ``_seen_flood_ids`` claim below, and the
+        # order is load-bearing. That claim means "this node owes the master an
+        # answer for this flood, and the other half must not send a second
+        # one". Claiming it and then returning here would leave the answer owed
+        # by nobody: the throttled half never sends it, and the slave half is
+        # suppressed because the claim is shared. The master would silently
+        # stop seeing this node. Taking the throttle first leaves the claim
+        # untouched, so nothing is promised that is not then sent.
+        #
+        # The accepted cost is that a throttled flood carries no answer of ours
+        # upstream at all. That is the point of the throttle, and the next
+        # unthrottled flood re-announces this node.
+        now = time.time()
+        if now - self._last_ping_flood < self.ping_flood_interval:
+            LOG.debug(f"answering PING flood_id={flood_id} to {client.peer} only; "
+                      f"next mesh-wide flood in "
+                      f"{self.ping_flood_interval - (now - self._last_ping_flood):.1f}s")
+            client.send(own_ping_outer)
+            return
+        self._last_ping_flood = now
+
+        # Past the throttle, so this really is a mesh-wide answer. Atomic
+        # across both halves: whoever wins owes upstream the answer, the loser
+        # already has one in flight from its other half.
+        owes_upstream = not self._seen_flood_ids.check(flood_id,
+                                                       max_size=flood_cache_size)
 
         LOG.debug(f"Sending responsive PING for flood_id={flood_id}")
 

--- a/tests/e2e/test_ping_flood_scale.py
+++ b/tests/e2e/test_ping_flood_scale.py
@@ -1,0 +1,127 @@
+"""A node emits at most one responsive PING flood per interval.
+
+PING is a flood: a node that receives one answers with its own PING carrying
+the same ``flood_id``, sent to every peer and upstream (HIVEMIND-NODE-1 §4).
+Satellites ping on their own schedules, so with ``n`` satellites on one node
+the node used to perform ``n`` fan-outs of ``n`` sends per round — quadratic,
+and the point where a large site stops completing rounds at all.
+
+The flood_id cache does not help: each satellite originates a *different*
+flood_id, so each one is legitimately new. What is capped here is the node's
+own emission rate, across floods.
+
+A satellite that pings inside the window is not ignored. It still gets this
+node's answering PING, sent directly to it, so its map is correct and its
+keepalive is served — it just does not make the node fan out to everyone else.
+"""
+import time
+import uuid
+
+import pytest
+
+pytest.importorskip("hivescope")
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType  # noqa: E402
+from hivescope.scenarios import star_topology  # noqa: E402
+
+NUM_SATELLITES = 6
+
+
+def _ping_from(satellite) -> str:
+    flood_id = str(uuid.uuid4())
+    inner = HiveMessage(HiveMessageType.PING, {
+        "flood_id": flood_id,
+        "peer": satellite.name,
+        "site_id": None,
+        "timestamp": time.time(),
+    })
+    satellite.send(HiveMessage(HiveMessageType.PROPAGATE, payload=inner))
+    return flood_id
+
+
+def _count_own_pings(protocol):
+    """Record how many peers each flood_id was answered to, by flood_id.
+
+    Only the node's *own* responsive PINGs are counted — the forwarding of a
+    satellite's PROPAGATE to the other peers is ordinary PROPAGATE routing and
+    is not what this limiter governs.
+    """
+    counts = {}
+
+    for conn in protocol.clients.values():
+        original = conn.send
+
+        def recording(message, _original=original):
+            payload = message.payload
+            if (message.msg_type == HiveMessageType.PROPAGATE
+                    and isinstance(payload, HiveMessage)
+                    and payload.msg_type == HiveMessageType.PING
+                    and payload.payload.get("peer") == protocol._node_id):
+                flood_id = payload.payload["flood_id"]
+                counts[flood_id] = counts.get(flood_id, 0) + 1
+            return _original(message)
+
+        conn.send = recording
+
+    return counts
+
+
+@pytest.fixture
+def star():
+    builder = star_topology(num_satellites=NUM_SATELLITES)
+    builder.start_all()
+    yield builder
+    builder.stop_all()
+
+
+def test_many_satellites_pinging_together_produce_one_flood(star):
+    master = star.get_master("M0")
+    master.hm_protocol.ping_flood_interval = 3600.0
+    counts = _count_own_pings(master.hm_protocol)
+
+    flood_ids = [_ping_from(star.get_satellite(f"S{i}"))
+                 for i in range(NUM_SATELLITES)]
+
+    fanned_out = [fid for fid, n in counts.items() if n > 1]
+    assert len(fanned_out) == 1
+
+    # every satellite is still answered — the ones inside the window directly
+    assert set(counts) == set(flood_ids)
+    for fid in flood_ids:
+        if fid != fanned_out[0]:
+            assert counts[fid] == 1
+    assert counts[fanned_out[0]] == NUM_SATELLITES
+
+
+def test_a_ping_after_the_window_floods_again(star):
+    master = star.get_master("M0")
+    master.hm_protocol.ping_flood_interval = 0.05
+    counts = _count_own_pings(master.hm_protocol)
+
+    first = _ping_from(star.get_satellite("S0"))
+    time.sleep(0.1)
+    second = _ping_from(star.get_satellite("S1"))
+
+    assert counts[first] == NUM_SATELLITES
+    assert counts[second] == NUM_SATELLITES
+
+
+def test_the_limiter_never_drops_a_satellites_ping(star):
+    """Inside the window the asking satellite still receives our PING."""
+    master = star.get_master("M0")
+    master.hm_protocol.ping_flood_interval = 3600.0
+
+    _ping_from(star.get_satellite("S0"))  # consumes the window
+
+    satellite = star.get_satellite("S1")
+    received = []
+    satellite.slave_protocol.hm.on(
+        HiveMessageType.PROPAGATE, lambda m: received.append(m)
+    )
+    _ping_from(satellite)
+
+    answers = [m for m in received
+               if isinstance(m.payload, HiveMessage)
+               and m.payload.msg_type == HiveMessageType.PING
+               and m.payload.payload.get("peer") == master.hm_protocol._node_id]
+    assert answers

--- a/tests/test_mesh_routing_conformance.py
+++ b/tests/test_mesh_routing_conformance.py
@@ -23,6 +23,7 @@ from unittest.mock import MagicMock
 from ovos_bus_client.message import Message
 from hivemind_bus_client.hive_map import FloodIdCache
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from hivemind_bus_client.hive_map import FloodIdCache
 
 from hivemind_core.protocol import HiveMindListenerProtocol
 
@@ -262,6 +263,8 @@ def test_responsive_ping_is_also_sent_upstream():
     node.hive_mapper = MagicMock()
     node._seen_flood_ids = FloodIdCache()
     node._answered_floods = FloodIdCache()
+    node._last_ping_flood = 0.0
+    node.ping_flood_interval = 0.0
     node.agent_protocol = MagicMock()
     sent = _wire_peers(node, "sat::1")
     captured = _upstream(node)

--- a/tests/test_node_provenance.py
+++ b/tests/test_node_provenance.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 from ovos_bus_client.message import Message
 from hivemind_bus_client.hive_map import FloodIdCache
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from hivemind_bus_client.hive_map import FloodIdCache
 
 from hivemind_core.protocol import HiveMindListenerProtocol
 
@@ -34,6 +35,8 @@ def _make_node() -> HiveMindListenerProtocol:
     node.agent_protocol = MagicMock()
     node._seen_flood_ids = FloodIdCache()
     node._answered_floods = FloodIdCache()
+    node._last_ping_flood = 0.0
+    node.ping_flood_interval = 0.0
     node._upstream_hm = None
     return node
 

--- a/tests/test_ping_flood_cache.py
+++ b/tests/test_ping_flood_cache.py
@@ -1,0 +1,124 @@
+"""The PING flood_id cache: FIFO eviction, sized for the client count.
+
+A dedup miss is not a dropped message — it makes the node answer a flood it
+has already answered, which is a whole extra fan-out across the mesh. The
+cache is therefore load-bearing for the scale fix, and two properties matter:
+
+* eviction drops the **oldest** flood_id. The previous ``set.pop()`` dropped an
+  arbitrary one, so a flood_id registered a moment ago could go while a stale
+  one stayed.
+* the cap grows with the number of connected clients. Every client can start a
+  flood of its own, so a fixed 1000 thrashes exactly on the meshes that can
+  least afford the extra floods.
+"""
+import uuid
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.hive_map import FloodIdCache, HiveMapper
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_node(num_clients: int) -> HiveMindListenerProtocol:
+    """A listener with *num_clients* connected peers, built without the
+    dataclass __post_init__ (no config, no database, no agent connection)."""
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = "master:0.0.0.0"
+    node.identity = MagicMock(public_key="node-pubkey", site_id=None)
+    node.clients = {f"peer{i}": MagicMock() for i in range(num_clients)}
+    node.hive_mapper = HiveMapper()
+    node.agent_protocol = MagicMock()
+    node._upstream_hm = None
+    node._seen_flood_ids = FloodIdCache()
+    node._answered_floods = FloodIdCache()
+    node._last_ping_flood = 0.0
+    # The throttle is disabled here on purpose. This module is about the
+    # flood_id cache, and the throttle runs *before* the _seen_flood_ids
+    # claim (see handle_ping_message), so a non-zero interval would throttle
+    # every flood after the first and the cache would stay almost empty —
+    # the tests below would then be measuring the limiter, not eviction.
+    node.ping_flood_interval = 0.0
+    return node
+
+
+def _ping(flood_id: str, peer: str = "sat") -> HiveMessage:
+    return HiveMessage(HiveMessageType.PING, {
+        "flood_id": flood_id,
+        "peer": peer,
+        "site_id": None,
+        "timestamp": 0.0,
+    })
+
+
+def _feed(node, flood_ids):
+    client = next(iter(node.clients.values()))
+    for i, fid in enumerate(flood_ids):
+        node.handle_ping_message(_ping(fid, peer=f"sat{i}"), client)
+
+
+def test_burst_larger_than_the_old_fixed_cap_still_dedups():
+    """20 clients size the cache at 2000, so a 1500-flood burst evicts nothing.
+
+    The same burst against the old fixed 1000-entry set had already dropped a
+    third of it, and every dropped id buys a duplicate flood.
+    """
+    node = _make_node(num_clients=20)
+    flood_ids = [str(uuid.uuid4()) for _ in range(1500)]
+    _feed(node, flood_ids)
+
+    assert len(node._seen_flood_ids) == 1500
+    assert all(fid in node._seen_flood_ids for fid in flood_ids)
+
+
+def test_eviction_is_oldest_first():
+    """Past the cap, the ids that go are the ones registered first."""
+    node = _make_node(num_clients=1)  # floor of 1000 applies
+    flood_ids = [str(uuid.uuid4()) for _ in range(1010)]
+    _feed(node, flood_ids)
+
+    assert len(node._seen_flood_ids) == 1000
+    assert not any(fid in node._seen_flood_ids for fid in flood_ids[:10])
+    assert all(fid in node._seen_flood_ids for fid in flood_ids[10:])
+
+
+def test_cap_grows_with_client_count():
+    """More clients, more concurrent floods, more room before eviction."""
+    node = _make_node(num_clients=30)  # 30 * 100 = 3000
+    flood_ids = [str(uuid.uuid4()) for _ in range(2500)]
+    _feed(node, flood_ids)
+
+    assert len(node._seen_flood_ids) == 2500
+
+
+def test_a_repeated_flood_id_is_answered_once():
+    node = _make_node(num_clients=3)
+    client = next(iter(node.clients.values()))
+    flood_id = str(uuid.uuid4())
+
+    node.handle_ping_message(_ping(flood_id, peer="sat-a"), client)
+    sends_after_first = sum(c.send.call_count for c in node.clients.values())
+
+    node.handle_ping_message(_ping(flood_id, peer="sat-b"), client)
+    assert sum(c.send.call_count for c in node.clients.values()) == sends_after_first
+
+
+def test_bus_emit_is_one_per_flood_and_peer_not_one_per_arrival():
+    """The agent bus sees each (flood_id, peer) observation once.
+
+    The emit used to run on every arrival, ahead of every gate, so a peer that
+    reached the node over several mesh paths multiplied agent-bus traffic by
+    the mesh fan-out. A new peer inside an already-answered flood is still a
+    discovery and must still be emitted.
+    """
+    node = _make_node(num_clients=1)
+    client = next(iter(node.clients.values()))
+    flood_id = str(uuid.uuid4())
+
+    node.handle_ping_message(_ping(flood_id, peer="sat-a"), client)
+    node.handle_ping_message(_ping(flood_id, peer="sat-a"), client)  # echo
+    node.handle_ping_message(_ping(flood_id, peer="sat-b"), client)  # new peer
+
+    emitted = [c.args[0] for c in node.agent_protocol.bus.emit.call_args_list]
+    peers = [m.data["peer"] for m in emitted if m.msg_type == "hive.ping.received"]
+    assert peers == ["sat-a", "sat-b"]

--- a/tests/test_ping_flood_throttle_upstream.py
+++ b/tests/test_ping_flood_throttle_upstream.py
@@ -1,0 +1,124 @@
+"""The PING flood throttle must not strand the upstream answer.
+
+``ping_flood_interval`` caps how often this node fans a responsive PING out
+across the mesh. ``_seen_flood_ids`` is shared with the upstream slave half
+(see ``bind_upstream``) and means "this node owes the master an answer for
+this flood, and the other half must not send a second one".
+
+Those two features interact, and the order they run in is the whole point of
+this module. If the throttle claimed ``_seen_flood_ids`` and then returned,
+the answer would be owed by nobody: the throttled half never sends it, and
+the slave half stays suppressed because the claim is shared. The master would
+silently stop seeing this node — no error, no dropped message, just a node
+that quietly falls out of the hive map.
+
+So the throttle is taken first and leaves the claim untouched.
+"""
+import uuid
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.hive_map import FloodIdCache, HiveMapper
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_node(interval: float, num_clients: int = 3) -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = "master:0.0.0.0"
+    node.identity = MagicMock(public_key="node-pubkey", site_id=None)
+    node.clients = {f"peer{i}": MagicMock() for i in range(num_clients)}
+    node.hive_mapper = HiveMapper()
+    node.agent_protocol = MagicMock()
+    node._upstream_hm = None
+    node._seen_flood_ids = FloodIdCache()
+    node._answered_floods = FloodIdCache()
+    node._last_ping_flood = 0.0
+    node.ping_flood_interval = interval
+    return node
+
+
+def _ping(flood_id: str, peer: str = "sat") -> HiveMessage:
+    return HiveMessage(HiveMessageType.PING, {
+        "flood_id": flood_id,
+        "peer": peer,
+        "site_id": None,
+        "timestamp": 0.0,
+    })
+
+
+class TestThrottledFloodLeavesTheUpstreamClaimAlone:
+    """The regression this module exists for."""
+
+    def test_a_throttled_flood_does_not_claim_the_upstream_answer(self):
+        node = _make_node(interval=3600.0)
+        client = node.clients["peer0"]
+
+        first = str(uuid.uuid4())
+        node.handle_ping_message(_ping(first), client)
+        # the first flood is not throttled, so it does claim
+        assert first in node._seen_flood_ids
+
+        # a second flood arrives inside the window and is throttled
+        second = str(uuid.uuid4())
+        node.handle_ping_message(_ping(second), client)
+
+        assert second not in node._seen_flood_ids, (
+            "a throttled flood must not claim the shared upstream slot: the "
+            "throttled half never sends the answer, and the slave half is "
+            "suppressed by the claim, so the master never hears from this node"
+        )
+
+    def test_the_throttled_flood_still_answers_the_asking_peer(self):
+        node = _make_node(interval=3600.0)
+        asker = node.clients["peer0"]
+        node.handle_ping_message(_ping(str(uuid.uuid4())), asker)
+        before = asker.send.call_count
+
+        node.handle_ping_message(_ping(str(uuid.uuid4())), asker)
+
+        assert asker.send.call_count == before + 1, \
+            "the peer that asked inside the window is still answered directly"
+
+    def test_a_throttled_flood_does_not_fan_out_to_other_peers(self):
+        node = _make_node(interval=3600.0)
+        asker = node.clients["peer0"]
+        other = node.clients["peer1"]
+        node.handle_ping_message(_ping(str(uuid.uuid4())), asker)
+        before = other.send.call_count
+
+        node.handle_ping_message(_ping(str(uuid.uuid4())), asker)
+
+        assert other.send.call_count == before, \
+            "the mesh-wide fan-out is exactly what the throttle defers"
+
+
+class TestAnUnthrottledFloodStillBehaves:
+    """Positive controls, so the assertions above cannot pass vacuously."""
+
+    def test_an_unthrottled_flood_claims_and_fans_out(self):
+        node = _make_node(interval=0.0)
+        asker = node.clients["peer0"]
+        other = node.clients["peer1"]
+
+        flood_id = str(uuid.uuid4())
+        node.handle_ping_message(_ping(flood_id), asker)
+
+        assert flood_id in node._seen_flood_ids
+        assert other.send.call_count == 1
+
+
+class TestRepeatArrivalsOfOneFlood:
+    """MSG-1 §4: a flood is answered at most once per half, throttle aside."""
+
+    def test_the_same_flood_id_twice_is_answered_once(self):
+        node = _make_node(interval=0.0)
+        asker = node.clients["peer0"]
+        other = node.clients["peer1"]
+
+        flood_id = str(uuid.uuid4())
+        node.handle_ping_message(_ping(flood_id), asker)
+        node.handle_ping_message(_ping(flood_id), asker)
+
+        assert other.send.call_count == 1, \
+            "the second arrival of the same flood must not re-flood"


### PR DESCRIPTION
## The bug

When a satellite pings, this node answers with its own PING and sends that
answer to **every** connected peer plus upstream. Each satellite floods on its
own schedule with its own `flood_id`, so the flood cache never suppresses any
of them — they are all legitimately new. With `n` satellites, one ping round
costs the node `n` fan-outs of `n` sends.

Measured with the hivescope in-process star topology, counting the node's own
responsive PING sends per round:

| satellites | before | after |
|---|---|---|
| 10 | 100 | 19 |
| 20 | 400 | 39 |

`n²` becomes `2n - 1`: one mesh-wide fan-out (`n` sends), plus one direct send
for each satellite that asked inside the window.

## What changed

**A node fans out at most one responsive PING per `ping_flood_interval`
seconds** (new key in `hivemind_core/config.py`, default 30). PING semantics
are unchanged; only the node's own emission rate is capped.

**A satellite that pings inside the window is not ignored.** It still gets this
node's answering PING, carrying its `flood_id`, sent **directly to it** — one
send instead of a mesh-wide fan-out. Its map entry for this node is therefore
correct and its keepalive is served. What it does not do is make this node
re-announce itself to every other peer, which those peers already learned in
the last flood, at most `ping_flood_interval` ago. The satellite's own PING
still propagates across the mesh through ordinary PROPAGATE routing, untouched.

30 seconds is chosen to sit well under the ping period a satellite uses, so no
node's map entry can age past one interval, while capping the node at two
fan-outs a minute no matter how many satellites are connected.

**The agent-bus emit is per observation, not per arrival.** `hive.ping.received`
used to fire on every PING arrival, ahead of every gate, so the mesh fan-out
factor landed on the OVOS bus. It now fires when `HiveMapper.on_ping` reports
the arrival as new — one emit per `(flood_id, peer)`. The mapper still sees
**every** arrival: it is the topology view, each arrival names a different peer
and carries a different route, and it keeps its own index. The emit stays ahead
of the flood dedup gate, because a flood this node already answered keeps
carrying peers it has never seen, and those are the discoveries the emit exists
to surface.

**The flood cache is now `FloodIdCache`.** The plain `set` was evicted with
`set.pop()`, which removes an arbitrary element — the "FIFO-ish" comment was
wrong, and a `flood_id` registered a moment ago could go while a stale one
stayed. The cap also grows with the client count (`max(1000, len(clients) *
100)`): every client can start a flood of its own, so a fixed 1000 thrashes
exactly on the meshes that can least afford it. A dedup miss is not a dropped
message — it makes the node answer a flood twice, so it is self-amplifying.

## Overlap with #196 — please sequence

#196 also converts `_seen_flood_ids` to `FloodIdCache` and also bumps the
`hivemind_bus_client` floor to `0.11.0a2`. **These two PRs conflict** on:

* `hivemind_core/protocol.py` — the `hive_map` import, the `_seen_flood_ids`
  init in `__post_init__`, and the dedup/eviction block in
  `handle_ping_message`
* `pyproject.toml` — the `hivemind_bus_client` pin

This PR deliberately does **not** touch `bind_upstream` and does **not** add
`public_key` to the responsive PING payload — that half is #196's and is not
duplicated here. Merge #196 first and this branch rebases onto it cleanly.

## Known remaining wall (not this PR)

The measurement above also shows total master sends per round barely moving
(8380 → 8019 at n=20). The dominant term is elsewhere: a satellite's responsive
PING arrives as a fresh PROPAGATE and `handle_propagate_message` fans it out to
every other peer, because forwarding is gated only by route-loop suppression,
never by `flood_id`. That is `n(n-1)²` sends per round. HIVEMIND-MSG-1 §4 says
nodes drop messages whose `flood_id` they have already seen — the shipped code
applies that to answering a flood but not to forwarding one. Separate defect,
separate PR.

## Tests

* `tests/e2e/test_ping_flood_scale.py` (hivescope) — `n` satellites pinging
  inside one window produce one fan-out and `n-1` direct answers; a ping after
  the window floods again; the satellite that pings inside the window still
  receives our PING.
* `tests/test_ping_flood_cache.py` — a 1500-flood burst that would have thrashed
  the old 1000-cap set now dedups intact; eviction is oldest-first; the cap
  grows with the client count; the bus emit is per `(flood_id, peer)`.
* `tests/test_node_provenance.py` and `tests/test_mesh_routing_conformance.py`
  hand-build nodes with `_seen_flood_ids = set()`; updated to `FloodIdCache`
  plus the two limiter fields.

Full suite: 291 passed, 3 skipped, 1 xpassed (the xpass is pre-existing on
`dev`).
