### PR TITLE
fix: drop already-seen floods when forwarding, not only when answering

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -557,6 +557,9 @@ class HiveMindListenerProtocol:
         # Private to this half, unlike ``_seen_flood_ids`` above: see
         # ``handle_ping_message`` for why the node needs both records.
         self._answered_floods: FloodIdCache = FloodIdCache()
+        # Floods this node has already FORWARDED, kept apart from the floods
+        # it has already ANSWERED above. See ``_already_forwarded_flood``.
+        self._forwarded_flood_ids: FloodIdCache = FloodIdCache()
         self._pending_cascades: dict = {}  # query_id -> CascadeCollector
         # guards lookup/creation of _pending_cascades entries: _route_query_response
         # runs both on the tornado thread (direct clients) and on the upstream
@@ -1633,6 +1636,57 @@ class HiveMindListenerProtocol:
                "targets": list(payload.target_peers) or [self._node_id]}
         payload.replace_route(list(payload.route) + [hop])
 
+    @staticmethod
+    def _flood_id(message: HiveMessage) -> str:
+        """The ``flood_id`` a routing message carries, or ``""`` when it carries
+        none.
+
+        The id lives on the innermost payload mapping — a PROPAGATE wraps a PING
+        whose payload is the plain mapping described in MSG-1 §4. Messages that
+        are not floods (a PROPAGATE around a BUS ``Message``, a QUERY, ...) have
+        no such mapping and yield ``""``, which every caller reads as "not a
+        flood, no dedup applies".
+        """
+        inner = message.payload
+        if isinstance(inner, HiveMessage):
+            inner = inner.payload
+        return inner.get("flood_id", "") if isinstance(inner, dict) else ""
+
+    def _already_forwarded_flood(self, message: HiveMessage) -> bool:
+        """HIVEMIND-MSG-1 §4 / NODE-1 §4: a node drops a flood whose ``flood_id``
+        it has already seen. Returns True when this node has already forwarded
+        this flood, and records the id otherwise.
+
+        This is a **second, independent** gate on top of the §5 route-loop check.
+        Route-loop suppression only stops a message that carries this node in its
+        own ``route``; a responsive PING is built fresh by the answering node
+        (empty ``route``, same ``flood_id``), so it looks brand new at every hop.
+        Without this gate a master re-fans every one of the n responses to all
+        n-1 other peers, and the mesh cost of one ping round grows as n(n-1)^2.
+
+        The forwarded ids are tracked **separately** from
+        :attr:`_seen_flood_ids`, which records the floods this node has already
+        *answered*. Answering and forwarding are different decisions taken at
+        different moments: ``handle_ping_message`` answers (and marks the flood
+        answered) *before* the forwarding block below runs, so a shared set would
+        make the node consider every flood already forwarded on first sight and
+        the flood would never leave the node that received it.
+
+        Deduplication is deliberately per-node and not per-peer: once a flood has
+        crossed this node in any direction it has reached everything this node
+        can reach, so a second copy arriving from another peer adds nothing.
+        """
+        flood_id = self._flood_id(message)
+        if not flood_id:
+            return False
+        # FloodIdCache.check() records the id and reports whether it was
+        # already there, so the test and the insert cannot race. Sized from
+        # the client count like the answer caches: every connected peer can
+        # start a flood of its own, and each eviction of a live flood_id buys
+        # a duplicate fan-out.
+        return self._forwarded_flood_ids.check(
+            flood_id, max_size=max(1000, len(self.clients) * 100))
+
     def handle_propagate_message(
             self, message: HiveMessage, client: HiveMindClientConnection
     ):
@@ -1686,6 +1740,14 @@ class HiveMindListenerProtocol:
         if looped:
             LOG.debug("not re-forwarding PROPAGATE already routed through this "
                       f"node {self._node_id} (MSG-1 §5); route={message.route}")
+            return
+
+        # MSG-1 §4: a flood crosses each node once. Local delivery above already
+        # ran (the mapper sees every PING, answered or not); only the fan-out is
+        # dropped for a flood this node has forwarded before.
+        if self._already_forwarded_flood(message):
+            LOG.debug("not re-forwarding PROPAGATE for already seen "
+                      f"flood_id={self._flood_id(message)} (MSG-1 §4)")
             return
 
         # propagate message to other peers (NODE-1 §3.3: keep the envelope, so a
@@ -1873,11 +1935,16 @@ class HiveMindListenerProtocol:
     def _relay_downstream(self, message: HiveMessage) -> None:
         """Fan a routing message received from the upstream master out to every
         downstream client, with NODE-1 §3.4 loop prevention: a message whose
-        route already names this node is not relayed again."""
+        route already names this node is not relayed again, and MSG-1 §4 flood
+        dedup: a flood this node already relayed is not relayed again."""
         if self._is_routing_loop(message):
             LOG.debug(f"not relaying {message.msg_type} already routed through "
                       f"this node {self._node_id} (NODE-1 §3.4); "
                       f"route={message.route}")
+            return
+        if self._already_forwarded_flood(message):
+            LOG.debug(f"not relaying {message.msg_type} for already seen "
+                      f"flood_id={self._flood_id(message)} (MSG-1 §4)")
             return
         self._append_self_hop(message)
         plaintext = message.serialize()

--- a/tests/e2e/test_ping_flood_mesh_e2e.py
+++ b/tests/e2e/test_ping_flood_mesh_e2e.py
@@ -1,0 +1,54 @@
+"""Mesh e2e: MSG-1 §4 flood dedup must not cost a node its reachability.
+
+``handle_propagate_message`` now drops a PROPAGATE whose ``flood_id`` this node
+already forwarded. The risk that buys is over-suppression: if the gate fires on
+the first sight of a flood, a PING never crosses a relay and the mesh stops
+mapping itself. This runs a real two-hop topology and checks the flood still
+lands on the far side, and that a second, different flood lands too.
+"""
+import time
+
+import pytest
+
+pytest.importorskip("hivescope")
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType  # noqa: E402
+from hivescope.topology import TopologyBuilder  # noqa: E402
+
+
+def _ping(flood_id: str, peer: str) -> HiveMessage:
+    inner = HiveMessage(HiveMessageType.PING,
+                        payload={"flood_id": flood_id, "peer": peer,
+                                 "site_id": None, "timestamp": time.time()})
+    return HiveMessage(HiveMessageType.PROPAGATE, payload=inner)
+
+
+def test_each_new_flood_still_crosses_the_relay():
+    """S1 -> M0 -> R0 -> S0, twice, with two different flood ids."""
+    b = TopologyBuilder()
+    m = b.add_master("M0")
+    m.register_satellite("relay-key", password="relay-password")
+    m.register_satellite("sat1-key", password="sat1-password")
+    relay_side = b.add_relay("R0", upstream=m).listener
+    relay_side.register_satellite("sat0-key", password="sat0-password")
+    b.add_satellite("S0", upstream=relay_side)
+    b.add_satellite("S1", upstream=m)
+
+    b.start_all()
+    try:
+        received = []
+        b.get_satellite("S0").shim.emitter.on(
+            HiveMessageType.PROPAGATE, received.append)
+
+        b.get_satellite("S1").send(_ping("flood-1", "S1"))
+        time.sleep(0.5)
+        assert received, "a fresh flood never reached the node below the relay"
+
+        seen_after_first = len(received)
+        b.get_satellite("S1").send(_ping("flood-2", "S1"))
+        time.sleep(0.5)
+        assert len(received) > seen_after_first, (
+            "a second, different flood_id was suppressed — dedup must key on "
+            "the flood id, not on having ever forwarded a PING")
+    finally:
+        b.stop_all()

--- a/tests/test_flood_forward_dedup.py
+++ b/tests/test_flood_forward_dedup.py
@@ -1,0 +1,204 @@
+"""HIVEMIND-MSG-1 §4: a node drops a flood whose ``flood_id`` it has seen.
+
+The rule was only applied when a node *answered* a flood
+(``handle_ping_message``), never when it *forwarded* one. A responsive PING is
+built fresh by the answering node — same ``flood_id``, empty ``route`` — so the
+§5 route-loop check cannot recognise it, and the master re-fanned every response
+to every other peer. One ping round over n satellites then costs the master
+n(n-1)^2 sends.
+
+The star mesh below drives the real ``handle_propagate_message`` and counts what
+the master puts on the wire, so the growth curve is measured, not asserted from
+a formula.
+"""
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.hive_map import FloodIdCache
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_node(node_key: str = "pubkey-A") -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = "master:0.0.0.0"
+    node.identity = MagicMock(public_key=node_key, site_id=None)
+    node.clients = {}
+    node.illegal_callback = None
+    node.propagate_callback = None
+    node.escalate_callback = None
+    node.broadcast_callback = None
+    node._upstream_hm = None
+    # FloodIdCache, not a bare set: the caches are size-bounded and
+    # check-and-insert atomically, and handle_ping_message calls .check()
+    # on them.
+    node._seen_flood_ids = FloodIdCache()
+    node._answered_floods = FloodIdCache()
+    node._forwarded_flood_ids = FloodIdCache()
+    node._last_ping_flood = 0.0
+    # 0 disables the mesh-wide fan-out throttle: this module is about
+    # forward-dedup, and a live throttle would suppress the fan-out these
+    # tests are counting.
+    node.ping_flood_interval = 0.0
+    node.hive_mapper = MagicMock()
+    node.agent_protocol = MagicMock()
+    return node
+
+
+def _make_client(peer: str) -> MagicMock:
+    client = MagicMock()
+    client.peer = peer
+    client.can_propagate = True
+    client.can_escalate = True
+    client.is_admin = True
+    return client
+
+
+def _flood_id_of(message: HiveMessage) -> str:
+    """Read a ``flood_id`` off the wire without going through the code we test."""
+    inner = message.payload
+    if isinstance(inner, HiveMessage):
+        inner = inner.payload
+    return inner.get("flood_id", "") if isinstance(inner, dict) else ""
+
+
+def _ping(flood_id: str, peer: str) -> HiveMessage:
+    inner = HiveMessage(HiveMessageType.PING,
+                        payload={"flood_id": flood_id, "peer": peer})
+    return HiveMessage(HiveMessageType.PROPAGATE, payload=inner)
+
+
+class StarMesh:
+    """A master with ``n`` satellites, each of which answers a flood once.
+
+    "Answers once" mirrors the satellite behaviour the mesh converged on: a node
+    emits its own responsive PING the first time it sees a ``flood_id``, and
+    stays quiet for later copies. Without that the mesh never settles.
+    """
+
+    def __init__(self, n: int):
+        self.master = _make_node()
+        self.sends = 0
+        self.pending = []
+        self.answered = set()  # (peer, flood_id) pairs already answered
+        self.delivered = {}
+        for i in range(n):
+            peer = f"sat::{i}"
+            self.delivered[peer] = []
+            conn = MagicMock()
+            conn.peer = peer
+            conn.send = lambda msg, _plaintext=None, p=peer: self._receive(p, msg)
+            self.master.clients[peer] = conn
+
+    def _receive(self, peer: str, message: HiveMessage) -> None:
+        """A satellite receives one message from the master."""
+        self.sends += 1
+        self.delivered[peer].append(message)
+        flood_id = _flood_id_of(message)
+        if flood_id and (peer, flood_id) not in self.answered:
+            self.answered.add((peer, flood_id))
+            self.pending.append((peer, _ping(flood_id, peer)))
+
+    def run_round(self) -> int:
+        """Every satellite originates one PING; run the mesh to a fixpoint.
+
+        Returns the number of messages the master sent during the round.
+        """
+        self.sends = 0
+        for peer in list(self.master.clients):
+            flood_id = f"flood-{peer}"
+            # an originator does not answer its own flood, but does answer
+            # every flood started by one of its siblings
+            self.answered.add((peer, flood_id))
+            self.pending.append((peer, _ping(flood_id, peer)))
+        while self.pending:
+            peer, message = self.pending.pop(0)
+            self.master.handle_propagate_message(message, _make_client(peer))
+        return self.sends
+
+
+def test_ping_round_cost_stops_growing_quadratically():
+    """The n(n-1)^2 term is gone: cost per round is linear in n per flood.
+
+    Measured on this harness with the forward gate removed: 1000 sends at n=10
+    and 8000 at n=20, i.e. n(2n-1 + (n-1)^2). With the gate: 190 and 780.
+    """
+    counts = {n: StarMesh(n).run_round() for n in (10, 20)}
+
+    # n floods per round, each costing the master (n-1) forwards + n answers
+    assert counts[10] == 10 * (2 * 10 - 1)   # 190, was 1000
+    assert counts[20] == 20 * (2 * 20 - 1)   # 780, was 8000
+
+    # doubling n used to multiply the round cost by 8; it may now only quadruple
+    assert counts[20] < 5 * counts[10]
+
+
+def test_master_forwards_a_flood_once_no_matter_how_many_copies_arrive():
+    mesh = StarMesh(5)
+    master = mesh.master
+    origin = _make_client("sat::0")
+
+    master.handle_propagate_message(_ping("f1", "sat::0"), origin)
+    first_round = mesh.sends
+
+    # the same flood arriving again from a different peer is not re-fanned
+    mesh.sends = 0
+    master.handle_propagate_message(_ping("f1", "sat::1"), _make_client("sat::1"))
+    assert mesh.sends == 0, "an already forwarded flood must not be re-fanned"
+    assert first_round > 0
+
+
+def test_a_new_flood_still_reaches_every_node():
+    """The safety case: dedup must never suppress a flood nobody has seen."""
+    mesh = StarMesh(6)
+    master = mesh.master
+    master.handle_propagate_message(_ping("f1", "sat::0"), _make_client("sat::0"))
+
+    for peer, received in mesh.delivered.items():
+        if peer == "sat::0":
+            continue
+        assert received, f"{peer} never saw the flood"
+
+    # a second, genuinely different flood is not mistaken for the first
+    mesh.sends = 0
+    master.handle_propagate_message(_ping("f2", "sat::1"), _make_client("sat::1"))
+    assert mesh.sends > 0, "a new flood_id must still be forwarded"
+
+
+def test_message_without_flood_id_is_always_forwarded():
+    """Untagged traffic keeps working exactly as before — no dedup applies."""
+    mesh = StarMesh(3)
+    master = mesh.master
+    inner = HiveMessage(HiveMessageType.BUS,
+                        payload=Message("speak", {"utterance": "hi"}))
+
+    for _ in range(3):
+        mesh.sends = 0
+        msg = HiveMessage(HiveMessageType.PROPAGATE, payload=inner)
+        msg.update_source_peer("sat::0")
+        msg.update_hop_data()
+        master.handle_propagate_message(msg, _make_client("sat::0"))
+        assert mesh.sends == 2, "a message with no flood_id must never be dropped"
+
+
+def test_relay_downstream_drops_an_already_relayed_flood():
+    """The upstream -> downstream relay path carries floods too."""
+    node = _make_node("relay-key")
+    sent = []
+    conn = MagicMock()
+    conn.peer = "sat::0"
+    # send(message, plaintext): the relay serializes once for the whole
+    # fan-out, so the stub takes and discards the second argument.
+    conn.send = lambda msg, _plaintext=None: sent.append(msg)
+    node.clients["sat::0"] = conn
+
+    node._relay_downstream(_ping("f1", "origin"))
+    assert len(sent) == 1
+
+    node._relay_downstream(_ping("f1", "origin"))
+    assert len(sent) == 1, "relay must not re-fan an already relayed flood"
+
+    node._relay_downstream(_ping("f2", "origin"))
+    assert len(sent) == 2, "a new flood must still be relayed"


### PR DESCRIPTION
## The defect

`handle_propagate_message` re-fanned an incoming PROPAGATE to every other peer,
gated only by MSG-1 §5 route-loop suppression. It never looked at `flood_id`.

Route-loop suppression cannot catch a responsive PING. `handle_ping_message`
builds the answer as a **fresh** `HiveMessage` — same `flood_id`, empty `route`
— so it looks brand new at every hop. The master therefore re-fanned each of
the n responses to all n-1 other peers.

MSG-1 §4 and NODE-1 §4 both say a node drops a flood whose `flood_id` it has
already seen. Shipped code applied that rule only when **answering** a flood,
never when **forwarding** one. Spec and code agree on the rule; the code
under-implements it, so there was nothing to decide against the spec here.

## Measured cost

A ping round = every satellite originates one PING. Master sends per round,
measured by the harness in `tests/test_flood_forward_dedup.py`:

| n  | before | after |
|----|--------|-------|
| 10 | 1000   | 190   |
| 20 | 8000   | 780   |

Before: `n * (2n-1 + (n-1)^2)`. After: `n * (2n-1)`. The `(n-1)^2` forwarding
term is gone, which is what dominated the total — #205 and the responsive-send
work cut a node's own sends but left this term untouched.

## Shared or separate seen-state

**Separate.** `_seen_flood_ids` records floods this node already *answered*;
the new `_forwarded_flood_ids` records floods it already *forwarded*.

Reusing one set would break the mesh outright. `handle_ping_message` runs
*before* the forwarding block in `handle_propagate_message` and marks the
flood seen there. A shared set would make the forward gate fire on the very
first sight of every flood, and no PING would ever leave the node that
received it. The two decisions are taken at different moments about different
actions, so they need different state.

Dedup is per-node, not per-peer: once a flood has crossed this node in any
direction it has reached everything this node can reach, so a later copy from
another peer adds nothing.

## Other message types

- **`_relay_downstream`** (used by `propagate_from_master`): fans an upstream
  PROPAGATE to every downstream client and had the identical gap. Gated, same
  cache. `query_from_master` also uses it; QUERY carries no `flood_id`, so the
  gate is inert there.
- **ESCALATE**: forwards to exactly one destination (the upstream master).
  Fan-out of 1 cannot amplify, and ESCALATE carries no `flood_id`. Not gated.
- **CASCADE / QUERY**: request/response with a return path, payload is a bus
  `Message` with no `flood_id`. A gate would be dead code. Not gated.
- **BROADCAST**: single hop, never re-broadcast by recipients, cannot cycle.
  Not gated.

## Safety

- A message with **no** `flood_id` is never dropped — `_flood_id` returns `""`
  and the gate returns False. Pinned by a test.
- Route-loop suppression is untouched; this is an additional gate.
- Local delivery still runs on **every** arrival, looped or deduped. The
  `HiveMapper` and `hive.ping.received` see every responsive PING exactly as
  before, so mesh mapping is unaffected — only the re-fan is dropped.

One intentional behaviour change: a satellite no longer receives its siblings'
responsive PINGs re-fanned by the master. That re-fan *was* the storm. Mapping
lives on the master, which still sees every response.

## Tests

`tests/test_flood_forward_dedup.py` drives the real `handle_propagate_message`
over a simulated star mesh and counts what the master puts on the wire:
growth curve at n=10/20, forward-once, no-`flood_id` always forwards, and
`_relay_downstream` dedup.

`tests/e2e/test_ping_flood_mesh_e2e.py` is the safety case on a real hivescope
two-hop topology: a fresh flood must still cross the relay, and a second,
different `flood_id` must not be suppressed by the first.

Full suite: 294 passed, 3 skipped, 1 xpassed.
(`test_fifo_order_relay_chain` xpasses on `dev` too — BUS traffic, no
`flood_id`, unrelated to this change.)

## Conflicts

Rebased on `origin/dev` @ fb923e3. #196 and #208 are both still OPEN and both
rewrite `handle_ping_message` and `_seen_flood_ids` (including the
`FloodIdCache` swap). This PR deliberately does **not** touch either, to keep
the conflict surface at zero — it only adds a separate cache and a gate on the
forward path. When #196/#208 land, `_forwarded_flood_ids` should be converted
to `FloodIdCache` alongside `_seen_flood_ids`; the bound here is the same
hardcoded 1000 the answering cache uses today.
