### PR TITLE
fix: correct the misleading admin-bypass note in add-client output

### DIFF
--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -190,12 +190,12 @@ def add_client(name, access_key, password, crypto_key, admin, metadata, allow_we
             "WARNING: Encryption Key is deprecated, only use if your client does not support password"
         )
 
-        if not user.is_admin and not user.allowed_types:
+        if not user.allowed_types:
             print(
                 "\nNOTE: Allowed message types is empty — this client will be DENIED on every message.\n"
                 "      Grant access explicitly, e.g.:\n"
                 f"      hivemind-core allow-msg recognizer_loop:utterance {user.client_id}\n"
-                "      (admin clients bypass the whitelist; use 'make-admin' if appropriate)"
+                "      (admin status does not exempt a client from the message type whitelist)"
             )
 
 

--- a/tests/test_client_metadata.py
+++ b/tests/test_client_metadata.py
@@ -357,3 +357,17 @@ def test_cli_blacklist_skill_writes_metadata_without_deprecation():
     assert result.exit_code == 0, result.output
     assert "eprecat" not in result.output
     assert fake_db.get_client_by_api_key("ak").metadata["skill_blacklist"] == ["skill-weather"]
+
+
+def test_cli_add_client_warns_on_empty_allowed_types_even_for_admin():
+    runner = CliRunner()
+    fake_db = make_client_db()
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=_patched_db_ctx(fake_db)):
+        result = runner.invoke(
+            add_client,
+            ["--name", "satellite", "--access-key", "k", "--password", "pw",
+             "--allow-weak-password", "--admin", "true"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "will be DENIED on every message" in result.output
+    assert "admin status does not exempt" in result.output


### PR DESCRIPTION
## Summary
- `add-client`'s empty-`allowed_types` warning told the operator "admin clients bypass the whitelist; use 'make-admin' if appropriate." That is false: verified against `hivemind_core/policy.py` on origin/dev — `MessageTypeACLPolicy.review` has no admin branch at all (only `DefaultSessionPolicy.review` checks `client.is_admin`, and that policy governs the reserved `session_id == "default"`, unrelated to `allowed_types`). `review_binary` confirms the same deny-by-default gate applies to binary payloads too.
- Running `make-admin` on a silently-denied client does not fix anything; the real remedy is `allow-msg`.
- Fixed the guard (`not user.is_admin and not user.allowed_types` → `not user.allowed_types`, since the warning is unconditionally correct regardless of admin status) and reworded the note. No stale sample output found elsewhere in docs.

## Test plan
- [x] Added `test_cli_add_client_warns_on_empty_allowed_types_even_for_admin`
- [x] `~/.venvs/ovos/bin/python -m pytest tests -q -p no:ovoscope -p no:recording --timeout=600` — 298 passed, 3 skipped (1 pre-existing unrelated xpass in `test_bridge1_conformance.py`, not touched by this change)