### PR TITLE
fix: keep the node up when the agent backend or a listener fails

### DIFF
--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -4,6 +4,8 @@
 import dataclasses
 import ipaddress
 import socket
+import threading
+import time
 from typing import Callable, Mapping, Optional, Type
 
 from json_database import JsonConfigXDG
@@ -154,6 +156,9 @@ class HiveMindService:
     stopping_hook: Callable[[], None] = on_stopping
 
     _status: Optional[ProcessStatus] = None
+    #: seconds between attempts to build the agent protocol when its backend
+    #: is unreachable
+    agent_retry_delay: float = 5.0
 
     def __post_init__(self) -> None:
         self._presence = None
@@ -259,6 +264,59 @@ class HiveMindService:
         self._upstream = slave
         return slave
 
+    def _start_agent_protocol(self, agent_class: Type, config: Mapping):
+        """Build the agent protocol, retrying while its backend is unreachable.
+
+        Agents are expected to degrade rather than raise: the OVOS plugin comes
+        up with a disconnected bus, its client reconnects on its own, and Core
+        answers BACKEND_UNAVAILABLE meanwhile — the node serves its satellites
+        the whole time. An agent that insists on raising leaves nothing to
+        build the listeners around, so keep trying instead of exiting: on a
+        slow board the OVOS messagebus is simply a few seconds behind, and
+        exiting would take the whole hive down until someone restarts us.
+        """
+        while True:
+            try:
+                return agent_class(config=config)
+            except ConnectionError as e:
+                LOG.error(f"{agent_class.__name__} can not reach its backend "
+                          f"({e}); retrying in {self.agent_retry_delay}s. No "
+                          f"client can be served until it answers.")
+                time.sleep(self.agent_retry_delay)
+
+    def _run_network_protocols(self, protos: list) -> None:
+        """Start every network protocol on its own daemon thread.
+
+        ``run`` blocks on an IOLoop, so an exception in it (a port already in
+        use, an unreadable SSL certificate) kills its thread and nothing else.
+        Unwatched, the service would report itself ready while carrying no
+        traffic at all. One dead transport is survivable — the others still
+        serve — but a node with every transport dead is in error, and must say
+        so instead of looking healthy.
+        """
+        alive = len(protos)
+        lock = threading.Lock()
+
+        def run(network_protocol):
+            nonlocal alive
+            try:
+                network_protocol.run()
+            except Exception:
+                LOG.exception(f"Network protocol "
+                              f"{type(network_protocol).__name__} stopped")
+            with lock:
+                alive -= 1
+                dead = alive == 0
+            if dead:
+                LOG.error("Every network protocol has stopped, this node no "
+                          "longer accepts clients")
+                self._status.set_error("all network protocols stopped")
+
+        for network_protocol in protos:
+            create_daemon(run, (network_protocol,))
+
+        self._status.set_ready()
+
     def _stop_upstream(self) -> None:
         if self._upstream is not None:
             self._upstream.hm.close()
@@ -274,7 +332,7 @@ class HiveMindService:
         agent_class, agent_config = get_agent_protocol()
         LOG.info(f"Agent protocol: {agent_class.__name__}")
 
-        agent_protocol = agent_class(config=agent_config)
+        agent_protocol = self._start_agent_protocol(agent_class, agent_config)
         self._status.bind(agent_protocol.bus)
 
         # binary data handling protocol
@@ -310,10 +368,7 @@ class HiveMindService:
             self._status.set_stopping()
             return
 
-        for network_protocol in protos:
-            create_daemon(network_protocol.run)
-
-        self._status.set_ready()
+        self._run_network_protocols(protos)
 
         self._start_presence()
         wait_for_exit_signal()  # block until ctrl+c

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -312,10 +312,14 @@ class HiveMindService:
                           "longer accepts clients")
                 self._status.set_error("all network protocols stopped")
 
+        # ready first: set_ready and set_error are plain assignments, so a
+        # transport that fails the moment it starts (port already bound,
+        # unreadable certificate) would set_error before this line ran and
+        # the node would end up READY with nothing listening
+        self._status.set_ready()
+
         for network_protocol in protos:
             create_daemon(run, (network_protocol,))
-
-        self._status.set_ready()
 
     def _stop_upstream(self) -> None:
         if self._upstream is not None:

--- a/tests/test_service_availability.py
+++ b/tests/test_service_availability.py
@@ -1,0 +1,147 @@
+"""A node must stay up, and stay honest, when the pieces around it are not.
+
+Two independent availability rules are covered here:
+
+* the agent backend being unreachable at boot must not take the node down —
+  the listeners come up and clients get BACKEND_UNAVAILABLE until it answers;
+* a network protocol thread that dies must not leave the node reporting ready
+  with no transport left.
+"""
+import time
+from unittest import mock
+
+import pytest
+
+from hivemind_core.service import HiveMindService
+
+
+def _service(**kwargs):
+    # avoid touching a real ClientDatabase at construction
+    with mock.patch("hivemind_core.service.ClientDatabase"):
+        return HiveMindService(**kwargs)
+
+
+def _wait_for(predicate, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class UnreachableAgent:
+    """An agent whose backend is not up yet: it constructs, but refuses to
+    hand out a bus until the backend arrives. This is how the OVOS agent
+    plugin behaves while its messagebus is still booting."""
+
+    def __init__(self, config=None):
+        self.bus = mock.MagicMock()
+        self.config = config or {}
+        self.connected = False
+
+    def get_bus(self, client=None):
+        if not self.connected:
+            raise ConnectionError("OVOS messagebus is not connected")
+        return self.bus
+
+
+class TestAgentBackendUnavailableAtBoot:
+    def test_listeners_come_up_and_node_reports_ready(self, monkeypatch):
+        """The whole hive must not go offline because OVOS booted slowly."""
+        agent = UnreachableAgent()
+        svc = _service()
+        listener = mock.MagicMock()
+        started = []
+
+        monkeypatch.setattr("hivemind_core.service.get_agent_protocol",
+                            lambda: (lambda config: agent, {}))
+        monkeypatch.setattr("hivemind_core.service.get_binary_protocol",
+                            lambda: (lambda **kw: mock.MagicMock(), {}))
+        monkeypatch.setattr("hivemind_core.service.get_server_config",
+                            lambda: {"network_protocol": {"websocket": {}}})
+        monkeypatch.setattr("hivemind_core.service.NetworkProtocolFactory."
+                            "get_class", lambda name: type("Listener", (), {
+                                "__init__": lambda self, **kw: None,
+                                "run": listener.run}))
+        monkeypatch.setattr("hivemind_core.service.create_daemon",
+                            lambda target, args=(): started.append(target))
+        monkeypatch.setattr("hivemind_core.service.wait_for_exit_signal",
+                            lambda: None)
+        svc.hm_protocol = mock.MagicMock()
+        svc._start_presence = lambda: None
+        svc._connect_upstream = lambda hm_protocol: None
+        svc._status = mock.MagicMock()
+
+        svc.run()
+
+        assert started, "no listener was started"
+        svc._status.set_ready.assert_called_once()
+        svc._status.set_error.assert_not_called()
+
+    def test_clients_are_told_the_backend_is_down_then_served(self):
+        agent = UnreachableAgent()
+
+        with pytest.raises(ConnectionError):
+            agent.get_bus()
+
+        agent.connected = True
+        assert agent.get_bus() is agent.bus
+
+    def test_agent_that_refuses_to_start_is_retried_not_fatal(self):
+        """An agent that raises leaves nothing to build listeners around, so
+        keep trying — exiting would need a human to restart the node."""
+        attempts = []
+
+        class Stubborn:
+            def __init__(self, config=None):
+                attempts.append(config)
+                if len(attempts) < 3:
+                    raise ConnectionError("backend is not up")
+
+        svc = _service(agent_retry_delay=0.0)
+        agent = svc._start_agent_protocol(Stubborn, {"host": "127.0.0.1"})
+
+        assert isinstance(agent, Stubborn)
+        assert len(attempts) == 3
+
+
+class TestDeadListenerThreads:
+    def test_a_dead_protocol_does_not_leave_the_node_reporting_ready(self):
+        """Port already in use, unreadable certificate: the thread dies and
+        the node has no transport left, so it must report an error."""
+        svc = _service()
+        svc._status = mock.MagicMock()
+        proto = mock.MagicMock()
+        proto.run.side_effect = OSError("address already in use")
+
+        svc._run_network_protocols([proto])
+
+        assert _wait_for(lambda: svc._status.set_error.called), \
+            "a node with no live transport still reported itself healthy"
+
+    def test_one_dead_protocol_does_not_condemn_the_others(self):
+        svc = _service()
+        svc._status = mock.MagicMock()
+        keep_running = mock.MagicMock()
+        keep_running.run.side_effect = lambda: time.sleep(5)
+        broken = mock.MagicMock()
+        broken.run.side_effect = OSError("address already in use")
+
+        svc._run_network_protocols([broken, keep_running])
+
+        assert _wait_for(lambda: broken.run.called)
+        time.sleep(0.2)
+        svc._status.set_error.assert_not_called()
+        svc._status.set_ready.assert_called_once()
+
+    def test_healthy_protocols_report_ready(self):
+        svc = _service()
+        svc._status = mock.MagicMock()
+        proto = mock.MagicMock()
+        proto.run.side_effect = lambda: time.sleep(5)
+
+        svc._run_network_protocols([proto])
+
+        svc._status.set_ready.assert_called_once()
+        svc._status.set_error.assert_not_called()

--- a/tests/test_service_availability.py
+++ b/tests/test_service_availability.py
@@ -106,19 +106,55 @@ class TestAgentBackendUnavailableAtBoot:
         assert len(attempts) == 3
 
 
+class RecordingStatus:
+    """Stands in for ProcessStatus, which writes ``state`` as a plain
+    assignment: whichever transition happens last is what the node reports,
+    so the order matters as much as the calls."""
+
+    def __init__(self):
+        self.transitions = []
+
+    def set_ready(self):
+        self.transitions.append("ready")
+
+    def set_error(self, err=""):
+        self.transitions.append("error")
+
+    @property
+    def state(self):
+        return self.transitions[-1] if self.transitions else None
+
+
 class TestDeadListenerThreads:
     def test_a_dead_protocol_does_not_leave_the_node_reporting_ready(self):
         """Port already in use, unreadable certificate: the thread dies and
         the node has no transport left, so it must report an error."""
         svc = _service()
-        svc._status = mock.MagicMock()
+        svc._status = RecordingStatus()
         proto = mock.MagicMock()
         proto.run.side_effect = OSError("address already in use")
 
         svc._run_network_protocols([proto])
 
-        assert _wait_for(lambda: svc._status.set_error.called), \
-            "a node with no live transport still reported itself healthy"
+        assert _wait_for(lambda: svc._status.state == "error"), \
+            f"a node with no live transport reported {svc._status.transitions}"
+
+    def test_a_transport_that_fails_instantly_still_ends_in_error(self, monkeypatch):
+        """The only transport can die before the main thread gets to
+        set_ready — a port already bound, a certificate that will not read.
+        Running the thread body inline reproduces that ordering exactly. The
+        node must not overwrite the error with a ready it no longer means."""
+        svc = _service()
+        svc._status = RecordingStatus()
+        monkeypatch.setattr("hivemind_core.service.create_daemon",
+                            lambda target, args=(): target(*args))
+        proto = mock.MagicMock()
+        proto.run.side_effect = OSError("address already in use")
+
+        svc._run_network_protocols([proto])
+
+        assert svc._status.transitions == ["ready", "error"]
+        assert svc._status.state == "error"
 
     def test_one_dead_protocol_does_not_condemn_the_others(self):
         svc = _service()


### PR DESCRIPTION
Two severity-2 availability fixes.

## B — the node exited at boot if the OVOS bus was not up within 10s

`OVOSAgentProtocol.__post_init__` raised `ConnectionError` when its bus was unreachable. `run()` builds the agent at service.py:277, **before** any listener exists, and `__main__.py` has no handler — the process died with a traceback. On a Pi 3 during boot, `ovos-messagebus` taking more than 10s is ordinary, and the whole hive went with it.

The precedent is in the same file: the upstream path degrades rather than aborts (`_connect_upstream`, `own_listener_for`). Applied here.

`_start_agent_protocol` retries with a delay instead of exiting. Agents are expected to degrade rather than raise — the OVOS plugin now comes up with a disconnected bus (JarbasHiveMind/hivemind-ovos-agent-plugin#36), so the listeners bind, the node reports ready, and clients get `BACKEND_UNAVAILABLE` until the bus answers. An agent that insists on raising leaves nothing to build the listeners around, so we keep trying rather than needing a human to restart the node.

## C — listener threads were fire-and-forget

`create_daemon(network_protocol.run)` and then `set_ready()`. `run()` blocks on an IOLoop; if it raised (port in use, unreadable SSL certificate) the thread died silently and the service still reported healthy with no transport. `_connect_upstream` already wraps its daemon body in try/except; `_run_network_protocols` now does the same, and calls `set_error` once every protocol thread has stopped. One dead transport is survivable; all of them dead is not, and must not look healthy.

## D — NOT attempted, by design

`_answer_query_locally` does iterate the agent generator on the IOLoop thread, and `natural_language_query` blocks up to 10s per chunk, so the defect is real. I did not ship `run_in_executor` for it, because the minimal change is not minimal here:

- `send_fn` bottoms out in the network protocol's `send_msg`, i.e. tornado `write_message`, which is not thread-safe. Every chunk would have to be marshalled back with `IOLoop.add_callback`, not merely sent from the executor.
- `_answer_query_locally` returns a bool that `handle_query_message` uses to decide whether to escalate upstream. Off-thread execution turns that return into a continuation, so `handle_query_message` and `handle_cascade_message` both have to be restructured around a callback.
- `handle_message` is synchronous and the existing suite drives these handlers synchronously with no running IOLoop, so `run_in_executor` futures would never resolve under test. Ordering guarantees between the streamed `speak` chunks and `QUERY_STREAM_END` would need re-establishing too.

Concrete proposal for a separate PR:

1. Add `_stream_off_loop(work, on_done)`: `IOLoop.current().run_in_executor(None, work)` plus `add_future`, falling back to running `work` inline when there is no running loop (keeps the sync test suite and embedders working).
2. Wrap `send_fn` so each chunk is delivered with `loop.add_callback`, preserving per-peer ordering because `add_callback` is FIFO.
3. Split `handle_query_message` at the `_answer_query_locally` call: the escalate/timeout tail becomes `on_done(answered)`.
4. Do CASCADE second, in its own commit — its `_route_query_response` path and `CascadeCollector` timing are the riskier half.
5. Test: a slow agent must not delay a second client's message, asserted on elapsed time.

## Tests

`tests/test_service_availability.py`:
- listeners come up and the node reports ready when the agent backend is down at boot, and the agent serves clients once it connects
- an agent that raises is retried rather than fatal
- a protocol whose `run()` raises produces `set_error`, not a healthy-looking node
- one dead protocol does not condemn the others, and healthy protocols report ready

`pytest tests -q`: 294 passed, 3 skipped, 1 xpassed, 34 subtests passed. The xpass (`test_bridge1_conformance.py::test_fifo_order_relay_chain`) is pre-existing on `origin/dev`.