### PR TITLE
perf: derive the noise PSK once per password and node

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -6,6 +6,7 @@ import json
 import os
 import time
 import uuid
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
 from typing import Union, List, Dict, Optional, Callable, Literal
@@ -29,7 +30,7 @@ try:
                                            NOISE_PATTERN_KK, NoiseTransport,
                                            NoiseHandshakeFailed, NoiseTransportFailed,
                                            build_prologue, noise_protocol_name,
-                                           start_noise_handshake)
+                                           start_noise_handshake, derive_psk)
 except ImportError:
     # hivemind_bus_client without the protocol v3 noise module: the server
     # degrades gracefully to the legacy (v2 and below) handshake and never
@@ -57,6 +58,9 @@ except ImportError:
         raise NoiseHandshakeFailed("protocol v3 (Noise) support unavailable")
 
     def start_noise_handshake(*args, **kwargs):  # pragma: no cover
+        raise NoiseHandshakeFailed("protocol v3 (Noise) support unavailable")
+
+    def derive_psk(*args, **kwargs):  # pragma: no cover
         raise NoiseHandshakeFailed("protocol v3 (Noise) support unavailable")
 from hivemind_core.database import ClientDatabase
 from hivemind_bus_client.hive_map import FloodIdCache, HiveMapper
@@ -464,6 +468,9 @@ class HiveMindListenerProtocol:
         # routinely build one with a placeholder ``identity`` and never open
         # a connection.
         self._identity_rsa_key = None
+        # Derived Noise PSKs, keyed by the client password (see noise_psk
+        # below). Never logged and never exposed on any wire or error path.
+        self._noise_psks: "OrderedDict[tuple, bytes]" = OrderedDict()
         self.clients = {}
         # TOFU pinning store for INTERCOM origin authentication
         # (HIVEMIND-CRYPTO-1 §5). Maps a client's access key to the PEM
@@ -526,6 +533,37 @@ class HiveMindListenerProtocol:
         if self._identity_rsa_key is None:
             self._identity_rsa_key = HandShake(self.identity.private_key).private_key
         return self._identity_rsa_key
+
+    # how many distinct passwords keep a derived PSK in memory at once
+    NOISE_PSK_CACHE_SIZE = 256
+
+    def noise_psk(self, password: Union[str, bytes]) -> bytes:
+        """The Noise pre-shared key for ``password``, derived at most once.
+
+        derive_psk runs argon2id (time_cost=3, 64 MiB) and measured
+        152-333ms per call on the single IOLoop thread that serves every
+        connected client. It is cacheable because its salt is
+        SHA-256(node_id): the result depends only on the password and this
+        node's id, both constant for the life of the node, so the same pair
+        always yields the same key.
+
+        Keyed on the password (and this node's id) rather than on the node
+        id alone: Client rows carry their own password, so two clients may
+        legitimately present different ones, and handing a client another
+        client's PSK would silently break its handshake.
+        """
+        if isinstance(password, str):
+            password = password.encode("utf-8")
+        key = (password, self._node_id)
+        psk = self._noise_psks.get(key)
+        if psk is None:
+            psk = derive_psk(password, node_id=self._node_id)
+            self._noise_psks[key] = psk
+            while len(self._noise_psks) > self.NOISE_PSK_CACHE_SIZE:
+                self._noise_psks.popitem(last=False)
+        else:
+            self._noise_psks.move_to_end(key)
+        return psk
 
     def _with_builtin_policies(self, chain: PolicyChain) -> PolicyChain:
         """Return ``chain`` with the non-removable builtin policies first.
@@ -1060,7 +1098,8 @@ class HiveMindListenerProtocol:
             try:
                 client.noise_handshake = start_noise_handshake(
                     initiator=False, pattern=pattern, suite=suite,
-                    password=client.pswd_handshake.password,
+                    psk=self.noise_psk(client.pswd_handshake.password),
+                    password=None,
                     node_id=self._node_id, prologue=prologue,
                     key_path=self.identity.noise_key,
                     remote_pubkey=pinned if pattern == NOISE_PATTERN_KK else None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,13 @@ dependencies = [
     # 0.11.0a2 adds FloodIdCache and HiveMindSlaveProtocol.bind_flood_cache,
     # which bind_upstream calls so a node with an upstream answers a PING
     # flood exactly once (HIVEMIND-NODE-1 §4) — an in-process API, not wire
-    # compatibility. 1.0.0a1 raises the floor further because protocol.py
-    # also calls bind_flood_cache post-THIRDPRTY-removal (wire code 11 was
-    # dropped in the same release). The server still degrades gracefully to
-    # the legacy handshake against older clients on the wire.
-    "hivemind_bus_client>=1.0.0a1,<2.0.0",
+    # compatibility. 1.0.3a1 raises the floor further: it adds the
+    # keyword-only ``psk`` argument to start_noise_handshake, which lets this
+    # node derive each Noise PSK once per (password, node_id) instead of once
+    # per connection (argon2id, ~217ms and 64 MiB each time). The server still
+    # degrades gracefully to the legacy handshake against older clients on the
+    # wire.
+    "hivemind_bus_client>=1.0.3a1,<2.0.0",
     "ovos_utils>=0.0.33,<1.0.0",
     "pybase64",
     # 0.9.0a1 added AbstractDB.get_client_by_api_key, which ClientDatabase calls

--- a/tests/e2e/test_protocol_v3_matrix.py
+++ b/tests/e2e/test_protocol_v3_matrix.py
@@ -11,6 +11,7 @@ End-to-end over a real websocket, real master + real client:
 """
 
 import time
+from unittest.mock import patch
 
 import pytest
 from ovos_bus_client.message import Message
@@ -241,5 +242,66 @@ def test_replayed_v3_transport_message_is_rejected():
         time.sleep(0.5)
         assert len(seen) == 1, "replayed message was delivered twice"
         client.close()
+    finally:
+        b.stop_all()
+
+
+# ──────────────────────────────────────── cached Noise PSK ──
+
+
+def test_v3_handshake_derives_the_psk_once_across_reconnects():
+    """The server derives one PSK for a password, then reuses it verbatim."""
+    b, m = _master()
+    try:
+        b.start_all()
+        with patch.object(server_protocol, "derive_psk",
+                          wraps=server_protocol.derive_psk) as spy:
+            for _ in range(3):
+                client = _make_client(m.network_protocol.url,
+                                      "matrix-key", "matrix-pwd")
+                client.connect(site_id="matrix-site")
+                client.wait_for_handshake(timeout=10)
+                assert client.noise_transport is not None
+                _assert_round_trip(client, m)
+                client.close()
+                assert _wait_for(lambda: not m.connected_peers())
+
+        assert spy.call_count == 1, "the PSK was re-derived per connection"
+    finally:
+        b.stop_all()
+
+
+def test_two_passwords_get_two_psks_and_both_handshakes_succeed():
+    """The cache is keyed per password, so neither client gets the other's."""
+    b = TopologyBuilder()
+    m = b.add_master("M0", use_loopback=True)
+    m.register_satellite("alice-key", password="alice-pwd",
+                         allowed_types=["recognizer_loop:utterance"])
+    m.register_satellite("bob-key", password="bob-pwd",
+                         allowed_types=["recognizer_loop:utterance"])
+    try:
+        b.start_all()
+        alice = _make_client(m.network_protocol.url, "alice-key", "alice-pwd",
+                             name="alice")
+        alice.connect(site_id="matrix-site")
+        alice.wait_for_handshake(timeout=10)
+        assert alice.noise_transport is not None
+
+        bob = _make_client(m.network_protocol.url, "bob-key", "bob-pwd",
+                           name="bob")
+        bob.connect(site_id="matrix-site")
+        bob.wait_for_handshake(timeout=10)
+        assert bob.noise_transport is not None
+
+        psks = list(m.hm_protocol._noise_psks.values())
+        assert len(psks) == 2
+        assert psks[0] != psks[1]
+
+        # both sessions really work; round-trip one of them with the other
+        # gone so _assert_round_trip addresses an unambiguous peer
+        alice.close()
+        assert _wait_for(lambda: len(m.connected_peers()) == 1)
+        _assert_round_trip(bob, m)
+        bob.close()
     finally:
         b.stop_all()

--- a/tests/test_noise_psk_cache.py
+++ b/tests/test_noise_psk_cache.py
@@ -1,0 +1,125 @@
+"""The Noise PSK must be derived once per password, not once per connection.
+
+Regression coverage for the fix: handle_noise_handshake_message used to pass
+``password=`` to ``start_noise_handshake``, so every accepted connection ran
+``derive_psk`` -- argon2id with time_cost=3 and a 64 MiB arena, measured
+152-333ms -- on the single tornado IOLoop thread that serves every connected
+client.
+
+The salt is SHA-256(node_id), so the derived key depends only on the password
+and this node's id. Both are constant for the life of the node, which makes
+the result cacheable. The cache is keyed on the password as well as the node
+id: Client rows carry their own password, so handing a client the PSK derived
+from another client's password would silently break its handshake.
+"""
+import tempfile
+import unittest
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from hivemind_bus_client.identity import NodeIdentity
+
+import hivemind_core.protocol as protocol_module
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_protocol(identity_path, node_id="node-A"):
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.return_value = agent.bus
+    agent.callbacks = MagicMock()
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = MagicMock(allowed_types=[], is_admin=False)
+
+    identity = NodeIdentity()
+    identity.private_key = identity_path
+
+    proto = HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                     require_crypto=False,
+                                     handshake_enabled=False,
+                                     identity=identity)
+    patcher = patch.object(HiveMindListenerProtocol, "_node_id",
+                           new_callable=PropertyMock, return_value=node_id)
+    patcher.start()
+    return proto, patcher
+
+
+class TestNoisePSKCache(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.protocol, patcher = _make_protocol(f"{self._tmpdir.name}/node.pem")
+        self.addCleanup(patcher.stop)
+
+    def test_derived_once_across_many_connections(self):
+        with patch.object(protocol_module, "derive_psk",
+                          wraps=protocol_module.derive_psk) as spy:
+            psks = [self.protocol.noise_psk("site-password") for _ in range(10)]
+
+        self.assertEqual(spy.call_count, 1)
+        self.assertEqual(len(set(psks)), 1)
+
+    def test_different_passwords_get_different_psks(self):
+        alice = self.protocol.noise_psk("alice-password")
+        bob = self.protocol.noise_psk("bob-password")
+
+        self.assertNotEqual(alice, bob)
+        # and each client keeps getting its own key back, not the other's
+        self.assertEqual(self.protocol.noise_psk("alice-password"), alice)
+        self.assertEqual(self.protocol.noise_psk("bob-password"), bob)
+
+    def test_matches_an_uncached_derivation(self):
+        from poorman_handshake.noise import derive_psk
+
+        self.assertEqual(self.protocol.noise_psk("site-password"),
+                         derive_psk(b"site-password", node_id="node-A"))
+
+    def test_str_and_bytes_passwords_share_one_entry(self):
+        with patch.object(protocol_module, "derive_psk",
+                          wraps=protocol_module.derive_psk) as spy:
+            text = self.protocol.noise_psk("site-password")
+            raw = self.protocol.noise_psk(b"site-password")
+
+        self.assertEqual(text, raw)
+        self.assertEqual(spy.call_count, 1)
+
+    def test_cache_stays_bounded(self):
+        limit = HiveMindListenerProtocol.NOISE_PSK_CACHE_SIZE
+        fake = patch.object(protocol_module, "derive_psk",
+                            side_effect=lambda pwd, node_id: pwd.ljust(32, b"."))
+        with fake:
+            for i in range(limit + 50):
+                self.protocol.noise_psk(f"password-{i}")
+
+        self.assertEqual(len(self.protocol._noise_psks), limit)
+        # the oldest entries were evicted, the newest are still there
+        self.assertNotIn((b"password-0", "node-A"), self.protocol._noise_psks)
+        self.assertIn((f"password-{limit + 49}".encode(), "node-A"),
+                      self.protocol._noise_psks)
+
+    def test_recently_used_entries_survive_eviction(self):
+        limit = HiveMindListenerProtocol.NOISE_PSK_CACHE_SIZE
+        fake = patch.object(protocol_module, "derive_psk",
+                            side_effect=lambda pwd, node_id: pwd.ljust(32, b"."))
+        with fake:
+            self.protocol.noise_psk("long-lived")
+            for i in range(limit):
+                self.protocol.noise_psk(f"password-{i}")
+                self.protocol.noise_psk("long-lived")
+
+        self.assertIn((b"long-lived", "node-A"), self.protocol._noise_psks)
+
+    def test_the_password_never_reaches_the_logs(self):
+        lines = []
+        with patch.object(protocol_module.LOG, "debug", lines.append), \
+                patch.object(protocol_module.LOG, "info", lines.append), \
+                patch.object(protocol_module.LOG, "warning", lines.append), \
+                patch.object(protocol_module.LOG, "error", lines.append):
+            psk = self.protocol.noise_psk("very-secret-password")
+
+        self.assertEqual(lines, [])
+        self.assertEqual(len(psk), 32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`handle_noise_handshake_message` passed `password=` to `start_noise_handshake`, so `NoiseHandShake.__init__` ran `derive_psk(password, node_id=node_id)` on **every accepted connection**. That is argon2id with `time_cost=3` and a 64 MiB arena, on the single tornado IOLoop thread that serves every connected client.

The salt is `SHA-256(node_id)`, so the derived key depends only on `(password, node_id)` — both constant for the life of the node. It was recomputed and thrown away per connect.

## Fix

`HiveMindListenerProtocol.noise_psk(password)` derives the key once and caches it, and the call site passes `psk=` instead of `password=`.

- The cache key is **`(password, node_id)`**, not the node id alone. `Client` rows carry their own password, so two clients may legitimately present different ones; a node-id-only key would hand a client the wrong PSK and silently break its handshake.
- The cache is an LRU `OrderedDict` bounded at 256 entries, so a stream of distinct passwords cannot grow it without limit.
- Neither the password nor the derived key is logged, returned on an error path, or put on the wire.

## Numbers

`start_noise_handshake(initiator=False, XXpsk2/25519_ChaChaPoly_SHA256)`, 6 runs each, same host:

| | median | min | max |
|---|---|---|---|
| `password=` (before) | 217.1 ms | 201.9 | 270.3 |
| `psk=` (after) | 0.2 ms | 0.2 | 0.3 |

`derive_psk` alone measures 171 ms median (167-192). The saving is that full amount per connect after the first, plus one 64 MiB allocation.

## Tests

`tests/test_noise_psk_cache.py`
- the PSK is derived once across 10 calls (spy on `derive_psk`, call count is 1)
- **two different passwords get two different PSKs**, and each keeps getting its own back
- the cached value equals an independent uncached `derive_psk`
- `str` and `bytes` spellings of one password share one entry
- the cache stays at 256 entries under 306 distinct passwords, oldest evicted, recently used survive
- no log line is emitted while deriving

`tests/e2e/test_protocol_v3_matrix.py` (real websocket, real master and client)
- three sequential v3 connects with the same password: full handshake and BUS round-trip each time, `derive_psk` called exactly once
- two clients with different passwords both complete the Noise handshake, the cache holds two distinct keys, and the session still round-trips

Full suite: 306 passed, 3 skipped, 1 xpassed. The xpass (`test_fifo_order_relay_chain`) is pre-existing and unrelated.

## Dependency floor

`hivemind_bus_client>=1.0.3a1,<2.0.0`. The keyword-only `psk` argument landed in **1.0.3a1** — note that 1.0.2a1 does not have it, and 1.0.2a2 was never published. The old ceiling `<1.0.0` had to move as well.

This repo has no lockfile and no generated constraints file, and the CI workflow installs straight from the declared floors, so there is nothing to relock.

## Overlap with open PRs

Rebased onto `origin/dev` after #196 merged. The `hivemind_bus_client` floor comment conflicted and was merged by hand: the `>=0.11.0a2` FloodIdCache rationale from #196 is kept alongside the new `psk` rationale, under the single higher floor `>=1.0.3a1`. #208 is still open and also touches this pin — whichever merges second needs the same one-line resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Improved Noise handshake security with password-based pre-shared key derivation.
  * Reused derived keys for reconnecting sessions while keeping cache size bounded.
  * Supported both text and byte-form passwords consistently.
  * Preserved secure handshakes and message exchange across reconnects and multiple passwords.

* **Compatibility**
  * Updated the bus client compatibility requirement for improved protocol support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->