### PR TITLE
fix: three races and a missing relay announcement in the PING and CASCADE paths

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -484,6 +484,10 @@ class HiveMindListenerProtocol:
         # protocol so a node with an upstream keeps ONE flood cache, not one
         # per protocol object.
         self._seen_flood_ids: FloodIdCache = FloodIdCache()
+        # Floods this listener half has already fanned out downstream. Private
+        # to this half, unlike ``_seen_flood_ids`` above: see
+        # ``handle_ping_message`` for why the node needs both records.
+        self._answered_floods: FloodIdCache = FloodIdCache()
         self._pending_cascades: dict = {}  # query_id -> CascadeCollector
         self._last_seen_updates: dict = {}  # client.key -> last persisted timestamp
         self.last_seen_update_interval = _non_negative_float(
@@ -769,9 +773,9 @@ class HiveMindListenerProtocol:
         except:
             LOG.exception("error on disconnect agent callback")
 
-        if client.peer in self.clients:
-            self.clients.pop(client.peer)
-        if not any(conn.key == client.key for conn in self.clients.values()):
+        self.clients.pop(client.peer, None)
+        # snapshot: a reconnect on another thread can insert while we iterate
+        if not any(conn.key == client.key for conn in list(self.clients.values())):
             self._last_seen_updates.pop(client.key, None)
         client.disconnect()
         context = {"source": client.peer}
@@ -1586,12 +1590,26 @@ class HiveMindListenerProtocol:
         }))
 
         # Flood-loop prevention (MSG-1 §4): answer a flood at most once.
-        # ``_seen_flood_ids`` is shared with the upstream slave protocol when
-        # this node has one (see bind_upstream), so the two halves of one
-        # node answer once between them, not once each.
-        if not flood_id or flood_id in self._seen_flood_ids:
+        #
+        # "Once" is once per node, not once per direction. NODE-1 §4 says a
+        # responsive PING is itself PROPAGATE-wrapped and fans out across the
+        # mesh, so the node's single answer must reach downstream clients AND
+        # upstream. Suppressing this whole half because the slave half already
+        # answered upstream leaves the relay missing from the hive map of the
+        # very clients attached to it.
+        #
+        # So the node keeps two records:
+        #   * ``_seen_flood_ids`` — shared with the upstream slave protocol
+        #     (see bind_upstream). It says "a half of this node already sent
+        #     the answer upstream", so the master never sees two.
+        #   * ``_answered_floods`` — private to this half. It says "the
+        #     downstream fan-out already happened", so repeat arrivals from
+        #     several clients do not re-flood.
+        if not flood_id or self._answered_floods.check(flood_id):
             return
-        self._seen_flood_ids.add(flood_id)
+        # atomic across both halves: whoever wins owes upstream the answer,
+        # the loser already has one in flight from its other half
+        owes_upstream = not self._seen_flood_ids.check(flood_id)
 
         # Build our own responsive PING with the same flood_id.
         # ``peer`` is the map key; ``public_key`` is the node's stable
@@ -1611,10 +1629,12 @@ class HiveMindListenerProtocol:
         LOG.debug(f"Sending responsive PING for flood_id={flood_id}")
 
         # NODE-1 §4: a PING fans out across the whole mesh — downstream peers
-        # and upstream alike, so a master learns of nodes below a relay
+        # and upstream alike, so a master learns of nodes below a relay and a
+        # satellite still sees the relay it is attached to.
         for conn in list(self.clients.values()):
             conn.send(own_ping_outer)
-        self.propagate_to_master(own_ping_outer)
+        if owes_upstream:
+            self.propagate_to_master(own_ping_outer)
 
     def bind_upstream(self, slave) -> None:
         """Bind a ``HiveMindSlaveProtocol`` as this node's upstream connection,
@@ -1628,10 +1648,15 @@ class HiveMindListenerProtocol:
         different identities, because the slave answers as its connection
         peer and the listener as its public key. The flood's originator then
         records two nodes where there is one. Sharing ``_seen_flood_ids``
-        makes the first half to see a ``flood_id`` suppress the other, which
-        is what HIVEMIND-NODE-1 §4 requires: the **node** takes part exactly
-        once. A node with no upstream never gets here and still answers
-        exactly once, through the listener.
+        makes the first half to see a ``flood_id`` claim the upstream answer
+        and suppress the other, which is what HIVEMIND-NODE-1 §4 requires:
+        the **node** takes part exactly once. A node with no upstream never
+        gets here and still answers exactly once, through the listener.
+
+        Sharing the cache settles the *upstream* answer only. The downstream
+        fan-out stays with the listener either way — see
+        ``handle_ping_message`` — because a relay must appear in the hive map
+        of its own clients, not only in its master's.
         """
         self._upstream_hm = slave.hm
         slave.bind_flood_cache(self._seen_flood_ids)
@@ -1800,11 +1825,16 @@ class HiveMindListenerProtocol:
         sender = client.peer if client else None
         metadata = message.metadata or {}
         originator_peer = metadata.get("originator_peer", "")
+        # One lookup serves both the CASCADE gate below and the default route
+        # at the end. An "in" check followed by an index would KeyError if the
+        # originator disconnected between the two, and that KeyError travels up
+        # to the websocket handler and drops the *responder's* connection.
+        originator_conn = self.clients.get(originator_peer)
         # CASCADE disambiguation: collect responses for a select callback at
         # the originating node, letting it pick a winner progressively.
         if (message.msg_type == HiveMessageType.CASCADE
                 and self.cascade_select_callback is not None
-                and originator_peer in self.clients):
+                and originator_conn is not None):
             query_id = metadata.get("query_id", "")
             if query_id not in self._pending_cascades:
                 # AGENT-1 §4.3: bound the collector map. It counts concurrent
@@ -1817,7 +1847,7 @@ class HiveMindListenerProtocol:
             collector = self._pending_cascades[query_id]
             collector.add_response(message)
             try:
-                bus = self.get_bus(self.clients[originator_peer])
+                bus = self.get_bus(originator_conn)
             except ConnectionError as e:
                 # keep the collector: the responses stay queued and the next
                 # one retries once the agent bus is back
@@ -1833,9 +1863,8 @@ class HiveMindListenerProtocol:
             except Exception:
                 LOG.exception(f"cascade_select_callback error for query_id={query_id}")
             return
-        # Default routing: forward toward the originator. get() + None-check
-        # instead of "in" + index: a disconnect between the two would KeyError.
-        conn = self.clients.get(originator_peer)
+        # Default routing: forward toward the originator.
+        conn = originator_conn
         if conn is not None:
             conn.send(message)
             return

--- a/tests/test_clients_dict_races.py
+++ b/tests/test_clients_dict_races.py
@@ -1,0 +1,144 @@
+"""Two more places where ``self.clients`` was read without a snapshot.
+
+``self.clients`` is mutated on the tornado IOLoop thread while other threads
+read it. An exception raised out of a read escapes ``on_message`` or
+``on_close``, and tornado then tears down a websocket that did nothing wrong.
+
+The fan-out loops were fixed earlier; these two were not:
+
+* ``_route_query_response`` gated a CASCADE on ``originator_peer in
+  self.clients`` and then indexed ``self.clients[originator_peer]``. A
+  disconnect between the two raised ``KeyError``, which the surrounding
+  ``except ConnectionError`` did not catch, and the *responder* lost its
+  connection.
+* ``handle_client_disconnected`` iterated ``self.clients.values()`` live while
+  a reconnect could insert, raising ``RuntimeError`` out of ``on_close``.
+"""
+import sys
+import threading
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+ORIGINATOR = "sat-originator"
+
+
+def _node() -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = "master:0.0.0.0"
+    node.identity = MagicMock(public_key="pubkey-master", site_id=None)
+    node.clients = {}
+    node._pending_cascades = {}
+    node._upstream_hm = None
+    node.cascade_select_callback = None
+    return node
+
+
+def _cascade_response(query_id: str) -> HiveMessage:
+    inner = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {"utterance": "hi"}))
+    return HiveMessage(HiveMessageType.CASCADE, payload=inner,
+                       metadata={"originator_peer": ORIGINATOR,
+                                 "query_id": query_id})
+
+
+def _responder() -> MagicMock:
+    responder = MagicMock()
+    responder.peer = "sat-responder"
+    return responder
+
+
+class DisconnectOnLookup(dict):
+    """Client table where the peer disconnects the instant it is looked up.
+
+    This pins the interleaving down instead of racing for it: the window
+    between a membership test and an index is one bytecode wide, so a
+    threaded test hits it only by luck. Reading the table twice is the bug,
+    whether or not a scheduler obliges.
+    """
+
+    def __contains__(self, peer):
+        found = dict.__contains__(self, peer)
+        self.pop(peer, None)
+        return found
+
+    def get(self, peer, default=None):
+        conn = dict.get(self, peer, default)
+        self.pop(peer, None)
+        return conn
+
+
+def test_cascade_response_survives_the_originator_disconnecting():
+    """The originator vanishing must not take the responder down with it.
+
+    A ``KeyError`` here is not caught by the ``except ConnectionError`` around
+    ``get_bus``; it escapes to tornado's ``on_message`` and closes the
+    *responder's* websocket. Only ``cascade_select_callback`` reaches this
+    gate, which is why the plain-routing tests never covered it.
+    """
+    node = _node()
+    node.clients = DisconnectOnLookup()
+    node.cascade_select_callback = MagicMock(return_value=None)
+    node.get_bus = MagicMock(return_value=MagicMock())
+    responder = _responder()
+
+    originator = MagicMock()
+    originator.peer = ORIGINATOR
+    node.clients[ORIGINATOR] = originator
+
+    node._route_query_response(_cascade_response("q1"), responder)
+
+    assert responder.disconnect.call_count == 0
+
+
+def test_disconnect_survives_a_concurrent_reconnect():
+    """``handle_client_disconnected`` reads the client table on the way out."""
+    node = _node()
+    node.callbacks = MagicMock()
+    node.binary_data_protocol = MagicMock()
+    node.agent_protocol = MagicMock()
+    node._last_seen_updates = {}
+    node._emit_lifecycle = MagicMock()
+
+    # a long client table makes the un-snapshotted `any()` below spend enough
+    # bytecodes iterating for a concurrent insert to land inside it
+    for i in range(300):
+        stable = MagicMock()
+        stable.peer = f"sat-stable-{i}"
+        stable.key = f"key-stable-{i}"
+        node.clients[stable.peer] = stable
+
+    stop = threading.Event()
+
+    def reconnect_storm(mutator_id):
+        peer = f"sat-reconnecting-{mutator_id}"
+        while not stop.is_set():
+            node.clients.pop(peer, None)
+            conn = MagicMock()
+            conn.peer = peer
+            conn.key = f"key-{mutator_id}"
+            node.clients[peer] = conn
+
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    threads = [threading.Thread(target=reconnect_storm, args=(i,), daemon=True)
+               for i in range(8)]
+    for t in threads:
+        t.start()
+    try:
+        for i in range(600):
+            leaving = MagicMock()
+            leaving.peer = f"sat-leaving-{i}"
+            leaving.key = "key-leaving"
+            leaving.is_admin = True
+            leaving.sess.session_id = f"sess-{i}"
+            node.clients[leaving.peer] = leaving
+            # a raise here escapes to tornado's on_close
+            node.handle_client_disconnected(leaving)
+    finally:
+        stop.set()
+        for t in threads:
+            t.join(timeout=5)
+        sys.setswitchinterval(old_interval)

--- a/tests/test_mesh_routing_conformance.py
+++ b/tests/test_mesh_routing_conformance.py
@@ -21,6 +21,7 @@ Five related routing defects are pinned here:
 from unittest.mock import MagicMock
 
 from ovos_bus_client.message import Message
+from hivemind_bus_client.hive_map import FloodIdCache
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 
 from hivemind_core.protocol import HiveMindListenerProtocol
@@ -259,7 +260,8 @@ def test_relayed_cascade_keeps_target_site():
 def test_responsive_ping_is_also_sent_upstream():
     node = _make_node()
     node.hive_mapper = MagicMock()
-    node._seen_flood_ids = set()
+    node._seen_flood_ids = FloodIdCache()
+    node._answered_floods = FloodIdCache()
     node.agent_protocol = MagicMock()
     sent = _wire_peers(node, "sat::1")
     captured = _upstream(node)

--- a/tests/test_node_provenance.py
+++ b/tests/test_node_provenance.py
@@ -16,6 +16,7 @@ distinct public keys — and pin every one of those fields to the public key.
 from unittest.mock import MagicMock
 
 from ovos_bus_client.message import Message
+from hivemind_bus_client.hive_map import FloodIdCache
 from hivemind_bus_client.message import HiveMessage, HiveMessageType
 
 from hivemind_core.protocol import HiveMindListenerProtocol
@@ -31,7 +32,8 @@ def _make_node() -> HiveMindListenerProtocol:
     node.clients = {}
     node.hive_mapper = MagicMock()
     node.agent_protocol = MagicMock()
-    node._seen_flood_ids = set()
+    node._seen_flood_ids = FloodIdCache()
+    node._answered_floods = FloodIdCache()
     node._upstream_hm = None
     return node
 

--- a/tests/test_ping_flood_dedup.py
+++ b/tests/test_ping_flood_dedup.py
@@ -12,6 +12,12 @@ key. Every relay therefore added a phantom node to the originator's hive map.
 
 ``bind_upstream`` is where the two halves are already wired together, so that
 is where they are given one shared flood cache.
+
+Sharing settles the *upstream* answer only. A node answers a flood once, but
+"once" is one responsive PING that reaches both directions — NODE-1 §4 makes
+the answer a PROPAGATE that fans out across the mesh. The listener half
+therefore always fans the answer downstream, or a relay would be missing from
+the hive map of the clients attached to it.
 """
 from unittest.mock import MagicMock
 
@@ -33,6 +39,7 @@ def _listener() -> HiveMindListenerProtocol:
     node.hive_mapper = HiveMapper()
     node.agent_protocol = MagicMock()
     node._seen_flood_ids = FloodIdCache()
+    node._answered_floods = FloodIdCache()
     node._upstream_hm = None
     return node
 
@@ -69,26 +76,60 @@ class TestBindUpstreamSharesTheFloodCache:
         assert slave.hive_mapper._seen_flood_ids is node._seen_flood_ids, (
             "the two halves of one node must share one flood cache")
 
-    def test_listener_suppressed_after_the_slave_answered(self):
-        """The upstream half saw the flood first; the listener must stay quiet.
+    def test_listener_does_not_repeat_the_upstream_answer(self):
+        """The upstream half saw the flood first; only it answers upstream.
 
         This is the real relay path: the flood arrives from upstream, the
         slave answers it, then the downstream answers come back through the
-        listener carrying the same flood_id.
+        listener carrying the same flood_id. A second answer upstream would
+        map one node as two (NODE-1 §4).
+        """
+        node, slave = _listener(), _slave()
+        node.bind_upstream(slave)
+        node.clients = {"satellite::1": MagicMock()}
+
+        slave.handle_ping(_ping("f1"))
+        assert slave._emit.call_count == 1, "the node must answer upstream once"
+
+        node.handle_ping_message(_ping("f1"), _client())
+
+        assert slave.hm.emit.call_count == 0, (
+            "the upstream answer for flood f1 is already in flight")
+
+    def test_relay_still_announces_itself_downstream(self):
+        """A relay must appear in the hive map of its own clients.
+
+        S -> R -> M, flood from M: R's slave answers upstream, but R still
+        owes its downstream client S a responsive PING. Without it S maps M
+        and never maps R, the node it is directly attached to.
         """
         node, slave = _listener(), _slave()
         node.bind_upstream(slave)
         conn = MagicMock()
         node.clients = {"satellite::1": conn}
 
+        slave.handle_ping(_ping("f1"))          # R answers M
+        node.handle_ping_message(_ping("f1"), _client())   # S's answer arrives
+
+        assert conn.send.call_count == 1, (
+            "the relay must fan its own responsive PING downstream, or it is "
+            "absent from its client's hive map")
+        payload = conn.send.call_args[0][0].payload.payload
+        assert payload["flood_id"] == "f1"
+        assert payload["public_key"] == NODE_KEY
+
+    def test_downstream_fan_out_happens_only_once(self):
+        """Repeat arrivals of one flood must not re-flood the clients."""
+        node, slave = _listener(), _slave()
+        node.bind_upstream(slave)
+        conn = MagicMock()
+        node.clients = {"satellite::1": conn}
+
         slave.handle_ping(_ping("f1"))
-        assert slave._emit.call_count == 1, "the node must answer once"
+        for _ in range(3):
+            node.handle_ping_message(_ping("f1"), _client())
 
-        node.handle_ping_message(_ping("f1"), _client())
-
-        assert conn.send.call_count == 0, (
-            "this node already took part in flood f1 through its upstream "
-            "half; answering again maps one node as two (NODE-1 §4)")
+        assert conn.send.call_count == 1
 
     def test_slave_suppressed_after_the_listener_answered(self):
         """Same rule in the other direction: a downstream-originated flood."""
@@ -166,3 +207,4 @@ class TestResponsivePingIdentity:
         for i in range(1100):
             node.handle_ping_message(_ping(f"f{i}"), _client())
         assert len(node._seen_flood_ids) <= 1000
+        assert len(node._answered_floods) <= 1000


### PR DESCRIPTION
Four defects found by an adversarial review of code merged today. All four are verified against `origin/dev`.

## 1. `_route_query_response` keeps the exact race #201 removed

The CASCADE branch gated on `originator_peer in self.clients` and then indexed `self.clients[originator_peer]` a few lines later. A disconnect between the two raises `KeyError`. The surrounding `except ConnectionError` does not catch it, so it escapes `_route_query_response` -> `handle_message` -> tornado `on_message`, and tornado tears down the **responder's** websocket — the failure #201 existed to remove.

Only `cascade_select_callback` reaches that gate, and nothing in CI sets it, which is why the suite stayed green.

One `self.clients.get(originator_peer)` now serves the gate, `get_bus`, and the default route at the end of the method.

## 2. A seventh un-snapshotted iteration over `self.clients`

`handle_client_disconnected` iterated `self.clients.values()` live to decide whether the leaving key still has a connection, on the disconnect path, while another thread can insert. `RuntimeError` out of `on_close`. It now iterates a `list(...)` snapshot.

#201 surveyed fan-out loops, not the bug class. I swept the whole file: this was the only remaining un-snapshotted iteration. The adjacent `if peer in self.clients: self.clients.pop(peer)` became `pop(peer, None)` while there.

## 3. The flood dedup was not atomic

`handle_ping_message` did `flood_id in self._seen_flood_ids` then `.add(flood_id)`. The cache is shared with the slave half, which runs on a different thread, so both halves could read "not seen" for one flood and answer it under two identities — the symptom #196 was written to fix.

The lock belongs in the shared object, so it went into `FloodIdCache`: **JarbasHiveMind/hivemind-websocket-client#173**. Core now calls `check()`, which is test-and-register under that lock.

## 4. A relay stopped announcing itself downstream

NODE-1 §4: a responsive PING is itself `PROPAGATE`-wrapped and fans out across the mesh. A node answers a flood once, but "once" is **one PING that reaches both directions**, not one direction picked by whichever thread saw the flood first.

Sharing the cache suppressed the whole listener half once the slave half had answered. In S -> R -> M with a flood from M: R answers upstream, R's listener returns early, and S never receives a PING from R. S maps M and does not map the relay it is directly attached to. Before #196 it did.

### The decision

The implementation read "takes part exactly once" as "emits in exactly one direction". I read it as one responsive PING, fanned both ways, and followed shipped behavior over the spec repo (which is AI-generated). Two reasons:

- The spec text itself is about **dropping repeat inbound floods**, not about limiting where one answer goes: "each recipient replies with its own `PING` ... and nodes drop messages whose `flood_id` they have already seen". Nothing there says the reply is one-directional.
- Shipped behavior before #196 sent it both ways. #196 was fixing double-identity mapping, and losing the downstream announcement was collateral, not intent.

So the node now keeps two records:

- `_seen_flood_ids` — shared with the slave half. Settles the **upstream** answer, so the master never sees two.
- `_answered_floods` — private to the listener half. Says the **downstream** fan-out already happened, so repeat arrivals from several clients do not re-flood.

## Tests

New `tests/test_clients_dict_races.py`:
- `test_cascade_response_survives_the_originator_disconnecting` — deterministic. The client table disconnects the peer the instant it is looked up, which pins the interleaving instead of racing for it; the window is one bytecode wide and a threaded test hits it only by luck.
- `test_disconnect_survives_a_concurrent_reconnect` — 8 reconnect threads against a 300-entry table.

Both were confirmed to fail against the unfixed code (`KeyError` and `RuntimeError` respectively).

`tests/test_ping_flood_dedup.py`:
- `test_relay_still_announces_itself_downstream` — the F4 gap. Every existing test in that file asserted suppression; none asserted a relay stays in its downstream's map.
- `test_downstream_fan_out_happens_only_once`
- `test_listener_suppressed_after_the_slave_answered` is now `test_listener_does_not_repeat_the_upstream_answer` — same rule, applied to the upstream direction where it belongs.

Full suite: **302 passed, 2 skipped, 1 xpassed**.

## Notes for review

- **Floor pin.** The atomicity of #3 depends on the client PR landing. `check()` itself already exists at the current floor, so nothing breaks meanwhile, but `hivemind_bus_client` needs a floor bump plus a relock once #173 releases.
- **Existing pin looks wrong on dev.** `pyproject.toml` pins `hivemind_bus_client>=0.11.0a2,<1.0.0`, but the client repo is at `1.0.3a1` and that is what the venv has. Pre-existing, not touched here.
- **`object.__new__` fixtures.** Adding `_answered_floods` broke `test_mesh_routing_conformance.py` and `test_node_provenance.py`, whose fixtures bypass the constructor. That is the fourth attribute today to break this pattern. I patched the two fixtures and left it there — class-level defaults on the dataclass are the durable fix and belong in their own PR.
- `tests/e2e/test_bridge1_conformance.py::test_fifo_order_relay_chain` XPASSes on dev, unrelated to this branch.