### PR TITLE
fix: hold the send lock across encrypt and enqueue

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -5,6 +5,7 @@ import dataclasses
 import json
 import logging
 import os
+import threading
 import time
 import uuid
 from collections import OrderedDict
@@ -217,6 +218,18 @@ class HiveMindClientConnection:
     # ``name::session_id`` string. See ``handle_hello_message``.
     _peer_suffix: str = field(default="", init=False, repr=False)
 
+    # Serialises ``send``. The IOLoop thread, the ovos messagebus thread and
+    # the upstream slave thread all send on the same connection, and a v3
+    # Noise frame is only decryptable in the order its nonce was assigned, so
+    # encryption and enqueueing must happen as one atomic step.
+    #
+    # Re-entrant because a synchronous in-process transport (the hivescope
+    # loopback) delivers to the peer from inside ``send_msg`` and the peer
+    # answers on the same thread. That nested send always encrypts after the
+    # outer frame was handed over, so it cannot invert the nonce sequence.
+    _send_lock: threading.RLock = field(default_factory=threading.RLock,
+                                        init=False, repr=False)
+
     def resolve_user(self, db, ttl: float = 5.0,
                      force: bool = False) -> Optional[Client]:
         """Return the cached DB row for this connection, refetching at
@@ -274,54 +287,60 @@ class HiveMindClientConnection:
         instead of once per peer (serialization is not cheap and does not
         depend on the peer). Encryption still happens per peer below, since
         each connection has its own crypto state.
+
+        The lock is held across encrypt *and* enqueue. The Noise transport and
+        the AES counters are per-connection mutable state, so releasing it
+        between the two would let a second thread encrypt against the same
+        counter and interleave frames on the wire.
         """
-        is_bin = message.msg_type == HiveMessageType.BINARY
-        if not is_bin and message.msg_type == HiveMessageType.BUS:
-            _payload_type = (message.payload.get("type")
-                             if isinstance(message.payload, dict)
-                             else message.payload.msg_type)
-            _log.debug("mycroft_type %s", _payload_type)
+        with self._send_lock:
+            is_bin = message.msg_type == HiveMessageType.BINARY
+            if not is_bin and message.msg_type == HiveMessageType.BUS:
+                _payload_type = (message.payload.get("type")
+                                 if isinstance(message.payload, dict)
+                                 else message.payload.msg_type)
+                _log.debug("mycroft_type %s", _payload_type)
 
-        _log.debug("sending to %s: %s", self.peer, message.msg_type)
+            _log.debug("sending to %s: %s", self.peer, message.msg_type)
 
-        if self.noise_transport is not None:
-            # protocol v3: every message (HELLO/HANDSHAKE included) is a Noise
-            # transport message — there is no cleartext v3 session (§3.4.5)
-            if self.binarize or is_bin:
-                payload = get_bitstring(hive_type=message.msg_type,
-                                        payload=message.payload,
-                                        hivemeta=message.metadata,
-                                        binary_type=message.bin_type).bytes
+            if self.noise_transport is not None:
+                # protocol v3: every message (HELLO/HANDSHAKE included) is a Noise
+                # transport message — there is no cleartext v3 session (§3.4.5)
+                if self.binarize or is_bin:
+                    payload = get_bitstring(hive_type=message.msg_type,
+                                            payload=message.payload,
+                                            hivemeta=message.metadata,
+                                            binary_type=message.bin_type).bytes
+                else:
+                    payload = plaintext if plaintext is not None else message.serialize()
+                self.send_msg(self.noise_transport.encrypt_frame(payload), True)
+                return
+
+            if self.crypto_key and message.msg_type not in [
+                HiveMessageType.HANDSHAKE,
+                HiveMessageType.HELLO,
+            ]:
+                if self.binarize or is_bin:
+                    payload = get_bitstring(hive_type=message.msg_type,
+                                            payload=message.payload,
+                                            hivemeta=message.metadata,
+                                            binary_type=message.bin_type).bytes
+                    _log.debug("unencrypted binary payload size: %d bytes", len(payload))
+                    payload = encrypt_bin(key=self.crypto_key, plaintext=payload, cipher=self.cipher)
+                    is_bin = True
+                else:
+                    plaintext = plaintext if plaintext is not None else message.serialize()
+                    _log.debug("unencrypted payload size: %d bytes", len(plaintext))
+                    payload = encrypt_as_json(
+                        key=self.crypto_key, plaintext=plaintext,
+                        cipher=self.cipher, encoding=self.encoding
+                    )  # json string
+                _log.debug("encrypted payload size: %d bytes", len(payload))
             else:
                 payload = plaintext if plaintext is not None else message.serialize()
-            self.send_msg(self.noise_transport.encrypt_frame(payload), True)
-            return
+                _log.debug("sent unencrypted!")
 
-        if self.crypto_key and message.msg_type not in [
-            HiveMessageType.HANDSHAKE,
-            HiveMessageType.HELLO,
-        ]:
-            if self.binarize or is_bin:
-                payload = get_bitstring(hive_type=message.msg_type,
-                                        payload=message.payload,
-                                        hivemeta=message.metadata,
-                                        binary_type=message.bin_type).bytes
-                _log.debug("unencrypted binary payload size: %d bytes", len(payload))
-                payload = encrypt_bin(key=self.crypto_key, plaintext=payload, cipher=self.cipher)
-                is_bin = True
-            else:
-                plaintext = plaintext if plaintext is not None else message.serialize()
-                _log.debug("unencrypted payload size: %d bytes", len(plaintext))
-                payload = encrypt_as_json(
-                    key=self.crypto_key, plaintext=plaintext,
-                    cipher=self.cipher, encoding=self.encoding
-                )  # json string
-            _log.debug("encrypted payload size: %d bytes", len(payload))
-        else:
-            payload = plaintext if plaintext is not None else message.serialize()
-            _log.debug("sent unencrypted!")
-
-        self.send_msg(payload, is_bin)
+            self.send_msg(payload, is_bin)
 
     @property
     def crypto_required(self) -> bool:

--- a/tests/test_send_thread_safety.py
+++ b/tests/test_send_thread_safety.py
@@ -1,0 +1,78 @@
+"""Concurrent ``HiveMindClientConnection.send`` must not reorder v3 frames.
+
+A protocol v3 (Noise) session assigns a strictly sequential nonce per
+outgoing frame, so the order in which frames reach the socket must match the
+order in which they were encrypted. Three distinct threads send on the same
+connection (the IOLoop thread, the ovos messagebus thread and the upstream
+slave thread); if any of them is preempted between encrypting and enqueueing,
+the peer's ``decrypt_frame`` fails the AEAD check and drops the session.
+"""
+
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from hivemind_bus_client import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindClientConnection
+
+
+class FakeNoiseTransport:
+    """Mimics NoiseTransport's locking: the nonce is assigned under a lock
+    which is released before the frame is handed back to the caller."""
+
+    def __init__(self, yield_after_encrypt=True):
+        self._send_lock = threading.Lock()
+        self._nonce = 0
+        self._yield_after_encrypt = yield_after_encrypt
+
+    def encrypt_frame(self, payload):
+        with self._send_lock:
+            nonce = self._nonce
+            self._nonce += 1
+        if self._yield_after_encrypt:
+            time.sleep(0)
+        return nonce
+
+
+class TestConcurrentSendOrdering(unittest.TestCase):
+    def test_v3_frames_reach_the_socket_in_nonce_order(self):
+        sent = []
+        sent_lock = threading.Lock()
+
+        def send_msg(payload, is_bin):
+            with sent_lock:
+                sent.append(payload)
+
+        client = HiveMindClientConnection(
+            key="test-key",
+            send_msg=send_msg,
+            disconnect=MagicMock(),
+            hm_protocol=MagicMock(),
+        )
+        client.noise_transport = FakeNoiseTransport()
+
+        message = HiveMessage(HiveMessageType.BUS, payload={"type": "speak"})
+        frames_per_thread = 200
+        start = threading.Barrier(3)
+
+        def sender():
+            start.wait()
+            for _ in range(frames_per_thread):
+                client.send(message)
+
+        threads = [threading.Thread(target=sender) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(sent), 3 * frames_per_thread)
+        inversions = [(a, b) for a, b in zip(sent, sent[1:]) if b != a + 1]
+        self.assertEqual(inversions, [],
+                         f"frames left send() out of nonce order: {inversions[:5]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`HiveMindClientConnection.send()` did:

```python
self.send_msg(self.noise_transport.encrypt_frame(payload), True)
```

`NoiseTransport.encrypt_frame` locks nonce assignment internally, but the caller releases that lock before the frame reaches the socket. The atomic unit must be encrypt **and** enqueue, not encrypt alone. Thread A takes nonce N, is preempted, thread B takes N+1 and calls `send_msg` first.

Three threads send on the same connection: the tornado IOLoop thread, the ovos messagebus thread (`hivemind_ovos_agent_plugin` handle_send / handle_internal_mycroft) and the upstream slave thread.

One inversion is fatal, not a hiccup. The peer's `decrypt_frame` raises `NoiseTransportFailed`, and `decode` treats it as fatal and disconnects, logging "tampered, replayed or out-of-order" — indistinguishable from an attack.

Measured with a real connection and a fake transport that copies NoiseTransport's locking: 1 out-of-order pair per 600 frames with three sender threads and no artificial yield; 47 per 600 with a `time.sleep(0)` in the window.

Scope is v3 / Noise only. The v2 path (`encrypt_as_json` / `encrypt_bin`) carries a fresh random nonce per frame, so reordering there is harmless at the crypto layer. This is a v3 regression.

## Fix

`HiveMindClientConnection` gets its own lock, held across the whole body of `send()`. One lock per connection, so there is no cross-connection contention. The v2 branch is inside it too: it keeps the method uniform and costs nothing, since the lock is never contended by other connections.

The lock is **not** held across a blocking write. Every transport marshals the write onto its own loop — the websocket protocol's `do_send` calls `self.loop.add_callback(_write)`, which returns immediately.

## The lock is re-entrant, on purpose

A synchronous in-process transport re-enters `send()` on the same thread: hivescope's loopback delivers to the peer from inside `send_msg`, and the peer answers on that same thread (`handle_new_client` -> `send` -> `send_msg` -> `_receive_raw` -> peer `handle_handshake` -> back into `send`). A plain `Lock` deadlocks the whole e2e suite there.

An `RLock` is safe for the ordering guarantee: the nested send only starts after the outer frame was already handed to the transport, so it always encrypts later and enqueues later. It cannot invert the nonce sequence.

## Test

`tests/test_send_thread_safety.py` runs three threads sending 200 frames each on one connection and asserts the nonce sequence observed at the transport is monotonic.

Verified red against the unfixed code (reverted `protocol.py`, ran, restored):

```
AssertionError: Lists differ: [(8, 10), (10, 9), (9, 12), (12, 11), ...] != []
1 failed
```

## Results

```
290 passed, 2 skipped, 1 xpassed, 34 subtests passed in 294.22s
```

The xpass (`test_fifo_order_relay_chain`) is pre-existing on `dev`.
