### PR TITLE
fix: send INTERCOM as text on a binarize connection (WIRE-1 §4.3)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -25,7 +25,7 @@ from ovos_utils.log import LOG
 from hivemind_core.config import get_server_config
 from hivemind_bus_client.identity import NodeIdentity
 from hivemind_bus_client.message import HiveMessage, HiveMessageType, HiveMindBinaryPayloadType
-from hivemind_bus_client.serialization import decode_bitstring, get_bitstring
+from hivemind_bus_client.serialization import BINARY_ENCODABLE_TYPES, decode_bitstring, get_bitstring
 from hivemind_bus_client.encryption import (SupportedEncodings, SupportedCiphers,
                                             decrypt_from_json, encrypt_as_json,
                                             decrypt_bin, encrypt_bin,
@@ -303,10 +303,16 @@ class HiveMindClientConnection:
 
             _log.debug("sending to %s: %s", self.peer, message.msg_type)
 
+            # WIRE-1 §4.3: a type with no assigned 5-bit code (INTERCOM) travels
+            # as a text frame even on a connection that negotiated binarize. The
+            # receiver accepts both forms on the same connection.
+            binarize = ((self.binarize or is_bin)
+                        and message.msg_type in BINARY_ENCODABLE_TYPES)
+
             if self.noise_transport is not None:
                 # protocol v3: every message (HELLO/HANDSHAKE included) is a Noise
                 # transport message — there is no cleartext v3 session (§3.4.5)
-                if self.binarize or is_bin:
+                if binarize:
                     payload = get_bitstring(hive_type=message.msg_type,
                                             payload=message.payload,
                                             hivemeta=message.metadata,
@@ -320,7 +326,7 @@ class HiveMindClientConnection:
                 HiveMessageType.HANDSHAKE,
                 HiveMessageType.HELLO,
             ]:
-                if self.binarize or is_bin:
+                if binarize:
                     payload = get_bitstring(hive_type=message.msg_type,
                                             payload=message.payload,
                                             hivemeta=message.metadata,

--- a/tests/test_intercom_on_binarize.py
+++ b/tests/test_intercom_on_binarize.py
@@ -1,0 +1,77 @@
+"""INTERCOM framing on a binarize connection (HIVEMIND-WIRE-1 §4.3).
+
+WIRE-1 §4.2 assigns a 5-bit message-type code to twelve types. INTERCOM has
+none, so §4.3 requires it to travel as a text frame even when the connection
+negotiated binary framing, and requires a receiver to accept both forms on the
+same connection.
+
+The client side has always honoured this (``hivemind_bus_client.client`` gates
+on ``BINARY_ENCODABLE_TYPES``). The server did not: it binarized whatever it
+sent as soon as ``binarize`` was set, and ``get_bitstring`` raises for a type
+with no code, so a server could not send an INTERCOM at all to a binarize
+client. These tests pin the server side of §4.3.
+"""
+
+import os
+import unittest
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+
+from hivemind_bus_client import HiveMessage, HiveMessageType
+from hivemind_core.protocol import HiveMindClientConnection
+
+
+def _binarize_client(**kwargs):
+    client = HiveMindClientConnection(
+        key="test-key",
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        handshake=MagicMock(),
+        **kwargs,
+    )
+    client.name = "test-client"
+    client.binarize = True
+    return client
+
+
+def _intercom():
+    return HiveMessage(HiveMessageType.INTERCOM,
+                       payload={"ciphertext": "deadbeef",
+                                "target_public_key": "peer-pubkey"})
+
+
+class TestIntercomTextOnBinarizeConnection(unittest.TestCase):
+    """WIRE-1 §4.3: a codeless type stays text on a binary-framing link."""
+
+    def test_intercom_is_sent_as_text_when_binarize_negotiated(self):
+        client = _binarize_client()
+        client.send(_intercom())
+        payload, is_bin = client.send_msg.call_args[0]
+        assert is_bin is False
+        assert HiveMessage.deserialize(payload).msg_type == HiveMessageType.INTERCOM
+
+    def test_intercom_is_sent_as_text_on_an_encrypted_binarize_connection(self):
+        client = _binarize_client()
+        client.crypto_key = os.urandom(16)
+        client.send(_intercom())
+        payload, is_bin = client.send_msg.call_args[0]
+        assert is_bin is False
+        assert isinstance(payload, str)
+
+    def test_intercom_is_sent_as_text_on_a_noise_binarize_connection(self):
+        client = _binarize_client()
+        client.noise_transport = MagicMock()
+        client.noise_transport.encrypt_frame.return_value = b"noise-frame"
+        client.send(_intercom())
+        framed = client.noise_transport.encrypt_frame.call_args[0][0]
+        assert HiveMessage.deserialize(framed).msg_type == HiveMessageType.INTERCOM
+
+    def test_a_coded_type_still_binarizes_on_the_same_connection(self):
+        # both forms coexist on one connection: BUS has a code, INTERCOM has not
+        client = _binarize_client()
+        client.crypto_key = os.urandom(16)
+        client.send(HiveMessage(HiveMessageType.BUS,
+                                payload=Message("speak", {"utterance": "hi"})))
+        _, is_bin = client.send_msg.call_args[0]
+        assert is_bin is True


### PR DESCRIPTION
## The defect

WIRE-1 §4.2 assigns a 5-bit message-type code to twelve types. INTERCOM has none, so §4.3 requires it to travel as a **text** frame even on a connection that negotiated binary framing, and requires a receiver to accept both forms on one connection.

`HiveMindClientConnection.send` binarized whatever it sent as soon as `self.binarize` was set. `hivemind_bus_client/serialization.py` **raises** `ValueError` for a type with no code. A server therefore could not send an INTERCOM to a binarize client at all — on both the v2 AEAD path and the v3 Noise path.

The client has always honoured §4.3 (`hivemind_bus_client/client.py`, `async_client.py`, `http_client.py` all gate on `BINARY_ENCODABLE_TYPES`). Only the server did not.

## The fix

Apply the client's existing gate server-side. One expression, both send paths:

```python
binarize = (self.binarize or is_bin) and message.msg_type in BINARY_ENCODABLE_TYPES
```

No new mechanism, no new constant.

## Backwards compatibility

**Additive and safe.** No peer can depend on the current behaviour, because the current behaviour is an exception on the server — the frame is never sent. After the change a frame that was previously never emitted starts being emitted, in the form every client already constructs for its own INTERCOMs. No version gate is needed.

## Pinning test

`tests/test_intercom_on_binarize.py`, docstring citing WIRE-1 §4.3:

- INTERCOM stays text on a binarize connection (plain, AEAD, and Noise transport)
- a coded type (BUS) still binarizes on the same connection, so both forms coexist as §4.3 requires

**Red then green:** with the production change reverted, the AEAD and Noise cases fail; restored, all four pass.

## Test runs

`~/.venvs/ovos/bin/python -m pytest tests -q -p no:ovoscope -p no:recording --timeout=900`

- unmodified `origin/dev`: 25 failed, 274 passed, 2 skipped, 1 xpassed
- this branch: 25 failed, 278 passed, 2 skipped, 1 xpassed

Identical failure set. The 25 are pre-existing (session-pipeline, e2e bridge/query/v3-matrix).

## Source

Item WIRE-1 §4.3 of the 2026-08-04 spec/implementation conformance baseline, which classed it "the single most concrete code bug found".