### PR TITLE
docs: correct claims that no longer match the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Commands:
   blacklist-escalate   deny ESCALATE messages from a client
   allow-propagate      allow PROPAGATE messages from a client
   blacklist-propagate  deny PROPAGATE messages from a client
+  allow-broadcast      allow BROADCAST messages from a client
+  blacklist-broadcast  deny BROADCAST messages from a client
   delete-client        remove credentials for a client
   list-clients         list clients and credentials
   listen               start listening for HiveMind connections
@@ -300,7 +302,7 @@ $ hivemind-core list-clients
 Rename a registered client.
 
 ```bash
-$ hivemind-core rename-client "new name" 1
+$ hivemind-core rename-client 1 --name "new name"
 ```
 
 - **When to use**:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,8 +49,8 @@ messages). Responses from the agent travel back through the same path.
 | `BUS` | bidirectional | Wraps an OVOS `Message`; the most common type |
 | `SHARED_BUS` | server → satellite | Bus event pushed to satellite |
 | `BROADCAST` | satellite → server | Deliver to all connected satellites |
-| `PROPAGATE` | satellite → server | Forward upstream to the parent server |
-| `ESCALATE` | satellite → server | Forward up the relay chain |
+| `PROPAGATE` | bidirectional | Fan out to every other connected peer **and** upstream, keeping the `PROPAGATE` envelope (`_rewrap`) so each peer can fan it out again |
+| `ESCALATE` | satellite → server | Forward upstream only, up the relay chain. It is never fanned out sideways |
 | `PING` | bidirectional | Topology discovery flood. Each node answers with its own PING carrying the same `flood_id`. There is no PONG |
 | `QUERY` | satellite → server | Natural-language query. The server streams answer chunks |
 | `CASCADE` | server → satellite(s) | Scatter/gather: distributes a query across children |
@@ -59,8 +59,12 @@ messages). Responses from the agent travel back through the same path.
 
 ### QUERY / CASCADE streaming
 
-A `QUERY` message triggers `AgentProtocol.natural_language_query(utterance, lang)`, a
-generator that yields string answer chunks followed by a final `None` sentinel.
+A `QUERY` message triggers `AgentProtocol.answer_query(utterance, lang, client=...)`, a
+generator that yields string answer chunks followed by a final `None` sentinel. The
+`client` argument lets a multiplexing agent pick the right per-key sub-agent. Its default
+implementation delegates to the backend primitive
+`natural_language_query(utterance, lang)`, which is the abstract method a plugin
+implements.
 Each chunk is forwarded to the satellite as it arrives. A `hive.query.complete` control
 message is sent when the generator exhausts. If the agent yields `None` immediately (no
 answer), the server escalates the query upstream.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -168,6 +168,10 @@ hivemind-core blacklist-propagate 1
 
 Control whether a client may send `BROADCAST` HiveMessages.
 
+> The client must also be admin. BROADCAST is gated on `is_admin` **and**
+> `can_broadcast`, so granting this to a non-admin changes nothing — the CLI
+> prints a note saying so.
+
 ```bash
 hivemind-core allow-broadcast 1
 hivemind-core blacklist-broadcast 1

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -20,6 +20,8 @@ Commands:
   blacklist-escalate  Deny ESCALATE messages from a client
   allow-propagate     Allow PROPAGATE messages from a client
   blacklist-propagate Deny PROPAGATE messages from a client
+  allow-broadcast     Allow BROADCAST messages from a client
+  blacklist-broadcast Deny BROADCAST messages from a client
   blacklist-skill     Add a skill to OVOSAgentPolicy's skill_blacklist (via metadata)
   allow-skill         Remove a skill from OVOSAgentPolicy's skill_blacklist (via metadata)
   blacklist-intent    Add an intent to OVOSAgentPolicy's intent_blacklist (via metadata)
@@ -91,7 +93,7 @@ hivemind-core list-clients
 ## `rename-client`
 
 ```bash
-hivemind-core rename-client "new name" 1
+hivemind-core rename-client 1 --name "new name"
 ```
 
 ---
@@ -158,6 +160,17 @@ Control whether a client may send `PROPAGATE` HiveMessages.
 ```bash
 hivemind-core allow-propagate 1
 hivemind-core blacklist-propagate 1
+```
+
+---
+
+## `allow-broadcast` / `blacklist-broadcast`
+
+Control whether a client may send `BROADCAST` HiveMessages.
+
+```bash
+hivemind-core allow-broadcast 1
+hivemind-core blacklist-broadcast 1
 ```
 
 ---

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -191,6 +191,10 @@ hivemind-core blacklist-propagate [NODE_ID]
 
 Control whether a client may send `BROADCAST` messages (fanned out to all peers below this node).
 
+> The client must also be admin. BROADCAST is gated on `is_admin` **and**
+> `can_broadcast`, so granting this to a non-admin changes nothing — the CLI
+> prints a note saying so.
+
 ```bash
 hivemind-core allow-broadcast [NODE_ID]
 hivemind-core blacklist-broadcast [NODE_ID]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -187,6 +187,15 @@ hivemind-core allow-propagate [NODE_ID]
 hivemind-core blacklist-propagate [NODE_ID]
 ```
 
+### `allow-broadcast` / `blacklist-broadcast`
+
+Control whether a client may send `BROADCAST` messages (fanned out to all peers below this node).
+
+```bash
+hivemind-core allow-broadcast [NODE_ID]
+hivemind-core blacklist-broadcast [NODE_ID]
+```
+
 ---
 
 ## Skill & intent permissions

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,7 @@ The file is created with defaults on first run if absent.
 | `runtime_password_strength_check` | bool | `true` | Re-check password strength at handshake time. Set to `false`, or set `HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK=1`, to skip the backstop |
 | `last_seen_update_interval` | int | `60` | Seconds to debounce the `last_seen` write, which runs on every inbound message. `0` writes on every message |
 | `ping_flood_interval` | int | `30` | Minimum seconds between two mesh-wide `PING` floods emitted by this node. Inside the window the node answers only the peer that pinged it |
-| `utterance_transformers` | dict | `{}` | OVOS utterance transformer plugins to load, keyed by plugin name. See [transformers.md](transformers.md) |
+| `utterance_transformers` | dict | `{}` | OVOS utterance transformer plugins to load, keyed by plugin name. |
 | `metadata_transformers` | dict | `{}` | OVOS metadata transformer plugins to load, keyed by plugin name |
 | `dialog_transformers` | dict | `{}` | OVOS dialog transformer plugins to load, keyed by plugin name. They rewrite `QUERY`/`CASCADE` answer chunks before they go back to clients |
 | `presence` | dict | see above | Local-network advertisement through the optional `hivemind-presence` package. Keys: `enabled`, `name`, `zeroconf` (mDNS), `upnp` (SSDP) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,8 @@ The file is created with defaults on first run if absent.
   "min_password_bits": 40,
   "runtime_password_strength_check": true,
 
-  "last_seen_update_interval": 0,
+  "ping_flood_interval": 30,
+  "last_seen_update_interval": 60,
 
   "presence": {
     "enabled": true,
@@ -77,6 +78,10 @@ The file is created with defaults on first run if absent.
     }
   },
 
+  "utterance_transformers": {},
+  "metadata_transformers": {},
+  "dialog_transformers": {},
+
   "policy": {
     "chain": [
       {"module": "hivemind-ovos-agent-policy"}
@@ -97,7 +102,11 @@ The file is created with defaults on first run if absent.
 | `min_protocol_version` | int | `2` | Lowest HiveMind protocol version a client may negotiate. The server rejects a client that completes the handshake below this version. It advertises the higher of this value and the version its crypto settings need |
 | `min_password_bits` | float | `40` | Lowest password entropy `add-client` accepts, and the handshake backstop rejects |
 | `runtime_password_strength_check` | bool | `true` | Re-check password strength at handshake time. Set to `false`, or set `HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK=1`, to skip the backstop |
-| `last_seen_update_interval` | int | `0` | Seconds to debounce the `last_seen` write. `0` writes on every admitted message |
+| `last_seen_update_interval` | int | `60` | Seconds to debounce the `last_seen` write, which runs on every inbound message. `0` writes on every message |
+| `ping_flood_interval` | int | `30` | Minimum seconds between two mesh-wide `PING` floods emitted by this node. Inside the window the node answers only the peer that pinged it |
+| `utterance_transformers` | dict | `{}` | OVOS utterance transformer plugins to load, keyed by plugin name. See [transformers.md](transformers.md) |
+| `metadata_transformers` | dict | `{}` | OVOS metadata transformer plugins to load, keyed by plugin name |
+| `dialog_transformers` | dict | `{}` | OVOS dialog transformer plugins to load, keyed by plugin name. They rewrite `QUERY`/`CASCADE` answer chunks before they go back to clients |
 | `presence` | dict | see above | Local-network advertisement through the optional `hivemind-presence` package. Keys: `enabled`, `name`, `zeroconf` (mDNS), `upnp` (SSDP) |
 | `upstream` | dict | see above | Connection to a master above this node. Disabled by default |
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -120,8 +120,21 @@ def natural_language_query(self, utterance: str,
     ...
 ```
 
-This is the seam consumed by hivemind-core's QUERY and CASCADE message handlers.
 Yield `None` immediately if the agent has no answer (triggers upstream escalation).
+
+**Entry point hivemind-core calls:**
+
+```python
+def answer_query(self, utterance: str, lang: str,
+                 client: Optional[HiveMindClientConnection] = None
+                 ) -> Iterator[Optional[str]]:
+    ...
+```
+
+The QUERY and CASCADE handlers call `answer_query`, not `natural_language_query`. The
+base implementation ignores `client` and delegates to `natural_language_query`, so a
+plugin only implements the primitive. Override `answer_query` when the agent needs the
+caller's identity, for example to dispatch to one sub-agent per access key.
 
 **Registration:**
 

--- a/docs/hive_map.md
+++ b/docs/hive_map.md
@@ -62,9 +62,10 @@ class HiveMapper:
         """
 ```
 
-`nodes` and `edges` are not capped. They expire instead: call
-`prune_stale_nodes()` to drop what has gone quiet, so a live but silent peer is never
-evicted only because it is old.
+`nodes` and `edges` are not FIFO-capped. They expire on age instead: a node is
+dropped once `node_ttl` seconds (default 600) have passed with no PING from it, so a
+peer that is alive but silent does age out of the map. `on_ping` prunes automatically;
+`prune_stale_nodes()` can also be called directly.
 
 ### `start_ping(flood_id: str) -> None`
 

--- a/docs/hive_map.md
+++ b/docs/hive_map.md
@@ -4,9 +4,12 @@
 directed graph of the reachable network. It lives in `hivemind_bus_client.hive_map`
 and the server imports it in `hivemind_core/protocol.py`.
 
-Discovery is PING-only. Every node answers an inbound PING by relaying its own PING
-with the same `flood_id`, so all nodes in the network sync in one round. There is
-no separate PONG message. The `flood_id` stops infinite relay loops.
+Discovery is PING-only. A node answers an inbound PING with its own PING carrying the
+same `flood_id`. There is no separate PONG message, and the `flood_id` stops infinite
+relay loops. On the server the mesh-wide fan-out of that answer is rate-limited by
+`ping_flood_interval` (default 30 seconds); inside that window the node answers only the
+peer that pinged it. See [Protocol Internals](protocol.md) for the three flood-id caches
+involved.
 
 For a conceptual overview of the discovery protocol, see
 [HiveMind community docs: network discovery](https://github.com/JarbasHiveMind/HiveMind-community-docs/blob/master/docs/20_network_discovery.md).
@@ -41,17 +44,27 @@ HiveMapper.to_json()              ← export as a JSON string
 
 ```python
 class HiveMapper:
-    def __init__(self) -> None:
+    def __init__(self, max_seen_pings: int = 1000, node_ttl: float = 600.0) -> None:
         """
         Initialize an empty topology map.
+
+        Args:
+            max_seen_pings: FIFO bound on the per-flood deduplication index.
+            node_ttl: Seconds a node stays in the map after its last PING.
 
         Attributes:
             nodes (Dict[str, NodeInfo]): peer_id -> node metadata
             edges (Dict[str, Set[str]]): peer_id -> set of peer_ids it was seen routing to
-            _seen_pings (Dict[str, Set[str]]): flood_id -> set of peer_ids that already sent a PING
-            _seen_flood_ids (OrderedDict[str, float]): flood_id -> timestamp, for loop prevention
+            _seen_pings (OrderedDict[str, Set[str]]): flood_id -> set of peer_ids that already
+                sent a PING, FIFO-evicted at max_seen_pings
+            _seen_flood_ids (FloodIdCache): already-answered flood ids, for loop prevention.
+                It is replaceable, so the two protocol halves of one node can share one store
         """
 ```
+
+`nodes` and `edges` are not capped. They expire instead: call
+`prune_stale_nodes()` to drop what has gone quiet, so a live but silent peer is never
+evicted only because it is old.
 
 ### `start_ping(flood_id: str) -> None`
 
@@ -149,6 +162,15 @@ Check whether `flood_id` was already seen, and register it. The first call for a
 given `flood_id` returns `False` (not seen). Later calls return `True`. When the
 cache passes `max_size`, the oldest entries are evicted first (FIFO).
 
+### `prune_stale_nodes(now: Optional[float] = None) -> None`
+
+Drop every node, and its edges, not heard from within `node_ttl` seconds. Pass `now` to
+use a clock other than `time.time()`.
+
+```python
+mapper.prune_stale_nodes()
+```
+
 ### `clear() -> None`
 
 Reset the mapper to an empty state (nodes, edges, seen-ping and seen-flood-id
@@ -188,13 +210,18 @@ The server-side protocol creates a `HiveMapper` instance and feeds it PINGs:
 
 def handle_ping_message(self, message: HiveMessage, client: HiveMindClientConnection) -> None:
     """
-    Feed the PING into the local HiveMapper, emit hive.ping.received, then,
-    if this flood_id has not been seen before, relay this node's own
-    responsive PING (same flood_id) to all connected peers.
+    Feed the PING into the local HiveMapper. Emit hive.ping.received only for
+    a peer new to the map, then relay this node's own responsive PING (same
+    flood_id) — to every connected peer and upstream once per
+    ping_flood_interval, and to the asking peer alone inside that window.
     """
-    self.hive_mapper.on_ping(message, received_at=time.time())
-    self.agent_protocol.bus.emit(Message("hive.ping.received", {...}))
-    if flood_id_already_seen:
+    new_to_map = self.hive_mapper.on_ping(message, received_at=time.time())
+    if new_to_map:
+        self.agent_protocol.bus.emit(Message("hive.ping.received", {...}))
+    if self._answered_floods.check(flood_id):
+        return
+    if now - self._last_ping_flood < self.ping_flood_interval:
+        client.send(own_ping_outer)   # answer the asker only
         return
     for peer_id, conn in self.clients.items():
         conn.send(own_ping_outer)

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -110,13 +110,14 @@ pair emits `hive.ping.received` on the agent bus, so a peer that reaches this no
 several mesh paths is reported once, not once per path.
 
 The handler then builds its own responsive PING carrying the same `flood_id`, and decides
-who gets it. Three separate flood-id caches take part:
+who gets it. Two caches decide the answer; a third, `_forwarded_flood_ids`, gates the
+PROPAGATE fan-out around it:
 
 | Cache | Scope | Question it answers |
 |---|---|---|
 | `_answered_floods` | private to this protocol half | Has this half already answered this flood? |
 | `_seen_flood_ids` | shared with the upstream slave protocol through `bind_flood_cache` | Has the node, as a whole, already claimed this flood? It keeps the two halves counted as one node in remote maps |
-| `_forwarded_flood_ids` | private | Has this flood already been forwarded on this path? |
+| `_forwarded_flood_ids` | private | Has this **node** already forwarded this flood? Consulted by `handle_propagate_message` before the fan-out, not by the PING answer logic. Dedup is per node, never per peer |
 
 The mesh-wide fan-out is rate-limited by `ping_flood_interval` (default 30 seconds).
 Inside that window the node answers **only the peer that pinged it**, with one send, so

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -105,17 +105,32 @@ from hivemind_core.protocol import HiveMindListenerProtocol
 Called when a PROPAGATE message's inner payload is a PING.
 
 Discovery is PING-only. There is no PONG message. The handler feeds the PING into the
-local `HiveMapper`, emits `hive.ping.received` on the agent bus, then checks the
-`flood_id`. If the node has not seen that `flood_id` before, it builds its own PING with
-the same `flood_id` and sends it to every connected peer and upstream. If it has seen the
-`flood_id`, it stops. That check is what ends the flood.
+local `HiveMapper`, which answers whether this `(flood_id, peer)` pair is new. Only a new
+pair emits `hive.ping.received` on the agent bus, so a peer that reaches this node over
+several mesh paths is reported once, not once per path.
+
+The handler then builds its own responsive PING carrying the same `flood_id`, and decides
+who gets it. Three separate flood-id caches take part:
+
+| Cache | Scope | Question it answers |
+|---|---|---|
+| `_answered_floods` | private to this protocol half | Has this half already answered this flood? |
+| `_seen_flood_ids` | shared with the upstream slave protocol through `bind_flood_cache` | Has the node, as a whole, already claimed this flood? It keeps the two halves counted as one node in remote maps |
+| `_forwarded_flood_ids` | private | Has this flood already been forwarded on this path? |
+
+The mesh-wide fan-out is rate-limited by `ping_flood_interval` (default 30 seconds).
+Inside that window the node answers **only the peer that pinged it**, with one send, so
+that peer's map is still correct. Outside the window the responsive PING goes to every
+connected peer and upstream.
 
 ```
 Receive PROPAGATE(PING)
   ├─ hive_mapper.on_ping(message)
-  ├─ emit hive.ping.received on the agent bus
-  └─ if flood_id is new: send PROPAGATE(PING) with the same flood_id
-       to all peers and upstream
+  ├─ if new to the map: emit hive.ping.received on the agent bus
+  ├─ if _answered_floods already holds flood_id: stop
+  └─ send PROPAGATE(PING) with the same flood_id
+       ├─ inside ping_flood_interval: to the asking peer only
+       └─ otherwise: to all peers and upstream
 ```
 
 The node that started the flood collects the answering PINGs until its timeout expires,


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Part of an ecosystem-wide documentation accuracy pass. Five audit passes cross-checked every documented claim in ~150 files against freshly-synced `dev` source; this branch carries the corrections for this repo.

Every fix cites the source that disproves the old wording. Findings that turned out to be wrong were dropped rather than applied — the source wins over the audit.

See the commit message for the per-file detail.