### PR TITLE
fix: keep defaults for a partially specified config block

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -159,6 +159,15 @@ def get_server_config() -> JsonStorageXDG:
     for k, v in defaults.items():
         if k not in db:
             db[k] = v
+        elif isinstance(v, dict) and isinstance(db[k], dict):
+            # ...and that a partially specified block keeps the rest of its
+            # defaults. Overriding one plugin setting is the common case:
+            #     {"network_protocol": {"hivemind-websocket-plugin": {...}}}
+            # Without this the block loses "module" and the service dies at
+            # startup with a bare KeyError.
+            for subk, subv in v.items():
+                if subk not in db[k]:
+                    db[k][subk] = subv
     # back-compat for the policy block: legacy installs may have
     # `policy.fail_open` (removed — chain is unconditionally fail-closed)
     # or be missing `policy.chain` (we default to OVOSAgentPolicy).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import pytest
 """Shared pytest hooks for the hivemind-core test suite."""
 
 
@@ -20,3 +21,15 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     )
     for rep in xpassed:
         terminalreporter.write_line(f"  XPASS  {rep.nodeid}")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_xdg_config(tmp_path_factory, monkeypatch):
+    """Keep the developer's real config out of the tests.
+
+    ``get_server_config`` reads ``$XDG_CONFIG_HOME/hivemind-core/server.json``.
+    On a machine that actually runs a hub that file exists, so tests asserting
+    on "the default config" silently read local settings and fail only for the
+    person who has a deployment. CI never saw it.
+    """
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path_factory.mktemp("xdg")))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,3 +65,61 @@ class TestPolicyConfigBackCompat(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPartiallySpecifiedBlocksKeepTheirDefaults:
+    """A server.json that overrides one plugin setting must still start.
+
+    Overriding a single value is the documented way to change the bind
+    address::
+
+        {"network_protocol": {"hivemind-websocket-plugin": {"port": 5678}}}
+
+    That block has no ``module``, and ``get_network_protocol`` reads
+    ``config["module"]`` directly, so before this fix the service died at
+    startup with a bare KeyError instead of using the default plugin.
+    """
+
+    def _config(self, tmp_path, monkeypatch, written):
+        import json
+        from hivemind_core import config as cfg_mod
+        cfgdir = tmp_path / "hivemind-core"
+        cfgdir.mkdir(parents=True)
+        (cfgdir / "server.json").write_text(json.dumps(written))
+        monkeypatch.setattr(cfg_mod, "xdg_config_home", lambda: str(tmp_path))
+        return cfg_mod.get_server_config()
+
+    def test_a_partial_agent_block_keeps_its_module(self, tmp_path, monkeypatch):
+        cfg = self._config(tmp_path, monkeypatch, {
+            "agent_protocol": {"hivemind-ovos-agent-plugin": {"port": 8181}},
+        })
+        assert cfg["agent_protocol"]["module"] == "hivemind-ovos-agent-plugin"
+
+    def test_the_users_own_values_still_win(self, tmp_path, monkeypatch):
+        cfg = self._config(tmp_path, monkeypatch, {
+            "agent_protocol": {"module": "my-plugin"},
+        })
+        assert cfg["agent_protocol"]["module"] == "my-plugin"
+
+    def test_a_partial_network_block_keeps_the_other_transports(
+            self, tmp_path, monkeypatch):
+        """network_protocol is multi-transport and has no ``module``; naming
+        one transport must not silently drop the others' defaults."""
+        cfg = self._config(tmp_path, monkeypatch, {
+            "network_protocol": {"hivemind-websocket-plugin": {"port": 9999}},
+        })
+        assert cfg["network_protocol"]["hivemind-websocket-plugin"]["port"] == 9999
+        assert "hivemind-http-plugin" in cfg["network_protocol"]
+
+    def test_a_config_missing_a_whole_block_still_starts(self, tmp_path, monkeypatch):
+        cfg = self._config(tmp_path, monkeypatch, {"min_protocol_version": 2})
+        assert cfg["agent_protocol"]["module"]
+        assert "binary_protocol" in cfg
+        assert cfg["min_protocol_version"] == 2
+
+    def test_binary_protocol_module_none_is_preserved_not_overwritten(
+            self, tmp_path, monkeypatch):
+        """None is a meaningful value here (binary protocol is optional)."""
+        cfg = self._config(tmp_path, monkeypatch,
+                           {"binary_protocol": {"module": None}})
+        assert cfg["binary_protocol"]["module"] is None


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Found by deploying a hub on a real host and writing a normal-looking `server.json`. The service crash-looped.

## Bug 1 — a partial config block loses its defaults

Overriding one plugin setting is the ordinary way to configure the server:

```json
{"agent_protocol": {"hivemind-ovos-agent-plugin": {"port": 8181}}}
```

`get_server_config` already backfills missing **top-level** keys, but a block the user *did* specify was taken whole. So that config loses `module`, and `get_agent_protocol` reads `config["module"]` directly — the service dies at startup with a bare `KeyError: 'module'`. The same shape silently drops `hivemind-http-plugin` from `network_protocol`.

Nothing warns. The only symptom is a crash loop.

Fix: backfill one level deep too. The user's own values still win, and `binary_protocol.module = null` is preserved (None is meaningful — the binary protocol is optional).

## Bug 2 — the test suite reads the developer's real config

`test_default_config_throttles_last_seen_writes` failed for me every run and passed on CI. Cause: `get_server_config` reads `$XDG_CONFIG_HOME/hivemind-core/server.json`, and on a machine that actually runs a hub, that file exists. The test asserting on "the default config" was reading my deployment's settings. CI never had the file, so it never saw it.

An autouse fixture now points `XDG_CONFIG_HOME` at a tmpdir. This is a bug that only bites people who run what they develop.

## Verified

4 new tests in `tests/test_config.py` for bug 1, mutation-checked: 2 fail against unpatched code, all pass with the fix.

Suite: **308 passed, 1 skipped, 0 failed**, both with and without `pytest-randomly` ordering, on a machine that has a real `server.json`. Before this PR the same machine got 1 failure.

_(An earlier version of this description said dev was red on that debounce test. That was wrong — it was local config pollution, which bug 2 above now fixes.)_