### PR TITLE
fix: do not backfill a multi-transport block

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -159,12 +159,17 @@ def get_server_config() -> JsonStorageXDG:
     for k, v in defaults.items():
         if k not in db:
             db[k] = v
-        elif isinstance(v, dict) and isinstance(db[k], dict):
-            # ...and that a partially specified block keeps the rest of its
-            # defaults. Overriding one plugin setting is the common case:
-            #     {"network_protocol": {"hivemind-websocket-plugin": {...}}}
+        elif isinstance(v, dict) and isinstance(db[k], dict) and "module" in v:
+            # ...and that a partially specified single-plugin block keeps the
+            # rest of its defaults. Overriding one setting is the common case:
+            #     {"agent_protocol": {"hivemind-ovos-agent-plugin": {...}}}
             # Without this the block loses "module" and the service dies at
             # startup with a bare KeyError.
+            #
+            # Only blocks that name a "module" are filled. In a multi-transport
+            # block like `network_protocol` the sub-keys ARE the set of enabled
+            # transports, so backfilling them would start a transport the
+            # operator never asked for.
             for subk, subv in v.items():
                 if subk not in db[k]:
                     db[k][subk] = subv

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,15 +101,20 @@ class TestPartiallySpecifiedBlocksKeepTheirDefaults:
         })
         assert cfg["agent_protocol"]["module"] == "my-plugin"
 
-    def test_a_partial_network_block_keeps_the_other_transports(
+    def test_naming_one_transport_does_not_enable_the_others(
             self, tmp_path, monkeypatch):
-        """network_protocol is multi-transport and has no ``module``; naming
-        one transport must not silently drop the others' defaults."""
+        """`network_protocol` sub-keys are the set of *enabled* transports.
+
+        service.run() starts one transport per key, so backfilling this block
+        would start a listener the operator never asked for (and log a
+        traceback when its plugin is not installed).
+        """
         cfg = self._config(tmp_path, monkeypatch, {
             "network_protocol": {"hivemind-websocket-plugin": {"port": 9999}},
         })
         assert cfg["network_protocol"]["hivemind-websocket-plugin"]["port"] == 9999
-        assert "hivemind-http-plugin" in cfg["network_protocol"]
+        assert list(cfg["network_protocol"]) == ["hivemind-websocket-plugin"], \
+            "only the transports the operator configured may be present"
 
     def test_a_config_missing_a_whole_block_still_starts(self, tmp_path, monkeypatch):
         cfg = self._config(tmp_path, monkeypatch, {"min_protocol_version": 2})


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Fixes a regression I introduced in #238, caught on a live hub minutes after it merged.

## What went wrong

#238 backfilled every missing default sub-key into a block the user had partially specified. That is correct for a **single-plugin** block:

```json
{"agent_protocol": {"hivemind-ovos-agent-plugin": {"port": 8181}}}
```

It is wrong for `network_protocol`, because `service.run()` does:

```python
for plug_name, plug_conf in get_server_config()["network_protocol"].items():
    network_class = NetworkProtocolFactory.get_class(plug_name)
```

Every key **is** an enabled transport. So an operator who enabled only websocket got `hivemind-http-plugin` injected, and the service logged a traceback for a plugin they never installed. Non-fatal (the loop catches per-transport) but it starts listeners nobody asked for.

The test I wrote in #238 asserted the wrong behaviour, which is why CI was happy.

## The change

Only fill blocks whose default declares a `module`. `network_protocol` keeps exactly the transports the operator configured.

## Verified

- Test rewritten to assert the opposite, and mutation-checked: it **fails** against current dev (the merged #238 code) and passes with this fix.
- Suite: 308 passed, 1 skipped, 0 failed.
- Confirmed against the live hub log that produced the finding: `KeyError: "'hivemind-http-plugin' not found. Available plugins: ['hivemind-websocket-plugin']"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration handling so partially configured network settings no longer receive unintended transport entries.
  * Preserved explicitly configured transport settings without adding unconfigured defaults.

* **Tests**
  * Updated coverage to verify correct behavior for partial network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->