### PR TITLE
feat: route RENDEZVOUS to an optional store-and-forward mailbox

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -47,6 +47,13 @@ _DEFAULT = {
         "zeroconf": True,   # mDNS (optional zeroconf)
         "upnp": False,      # UPnP/SSDP (optional upnpclient)
     },
+    # store-and-forward dead drop for peers that are never online at the same
+    # time (optional hivemind-rendezvous package). Off by default: holding
+    # other nodes' mail is a role an operator opts into, not a default.
+    "rendezvous": {
+        "enabled": False,
+        "max_pending_per_mailbox": 256,
+    },
     # optional connection to a master above this node — HIVEMIND-NODE-1
     # §3.3/§4. Disabled by default: the node is a top-level master. Enable it
     # and the node also holds one connection upstream.

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -527,6 +527,14 @@ class HiveMindListenerProtocol:
     metadata_transformers: Optional[MetadataTransformersService] = None
     dialog_transformers: Optional[DialogTransformersService] = None
 
+    # Store-and-forward mailbox, bound at startup when the optional
+    # hivemind-rendezvous package is installed and rendezvous is enabled
+    # (see HiveMindService._start_rendezvous). None on every ordinary node,
+    # which is what makes RENDEZVOUS answer "not_a_rendezvous_node".
+    # A dataclass field, so an instance built with ``object.__new__`` in a
+    # test fixture still finds the default instead of raising AttributeError.
+    mailbox: Optional[object] = field(default=None, repr=False)
+
     # Interval (seconds) between persisted last-seen updates for the same
     # client, read from config in __post_init__ (which always wins over this
     # default). Declared as a field — not just a __post_init__ assignment —
@@ -1086,6 +1094,8 @@ class HiveMindListenerProtocol:
             self.handle_intercom_message(message, client)
         elif message.msg_type == HiveMessageType.BINARY:
             self.handle_binary_message(message, client)
+        elif message.msg_type == HiveMessageType.RENDEZVOUS:
+            self.handle_rendezvous_message(message, client)
         else:
             self.handle_unknown_message(message, client)
 
@@ -1157,6 +1167,30 @@ class HiveMindListenerProtocol:
         return True
 
     # HiveMind protocol messages -  from slave -> master
+    def handle_rendezvous_message(
+            self, message: HiveMessage, client: HiveMindClientConnection
+    ):
+        """Serve a RENDEZVOUS request, when this node holds mail.
+
+        A rendezvous node is an ordinary node with the optional
+        hivemind-rendezvous package installed and ``rendezvous.enabled`` set;
+        ``mailbox`` is then bound at startup. Every other node has no mailbox
+        and says so, rather than dropping the frame silently — a peer that
+        cannot tell "no mail" from "not a rendezvous node" cannot fail over to
+        one that is.
+
+        The caller never names a mailbox. It gets the one belonging to the
+        public key this connection was TOFU-pinned to at handshake time, so
+        collecting another node's mail is not something the wire can express.
+        """
+        if self.mailbox is None:
+            client.send(HiveMessage(
+                HiveMessageType.RENDEZVOUS,
+                payload={"status": "error", "reason": "not_a_rendezvous_node"}))
+            return
+        owner = self.trusted_pubkeys.get(client.key) or client.pub_key
+        client.send(self.mailbox.handle(message, owner))
+
     def handle_unknown_message(
             self, message: HiveMessage, client: HiveMindClientConnection
     ):

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -199,6 +199,30 @@ class HiveMindService:
         create_daemon(self._presence.start)
         LOG.info("LocalPresence started")
 
+    def _start_rendezvous(self, hm_protocol: HiveMindListenerProtocol) -> None:
+        """Optionally make this node a rendezvous point, holding mail for peers
+        that are never online at the same time, via the optional
+        hivemind-rendezvous package. No-op when that package is not installed
+        or rendezvous is disabled — the node then answers RENDEZVOUS with
+        "not_a_rendezvous_node", which is the honest reply.
+
+        Same shape as _start_presence: an optional import, a config switch,
+        and nothing else in the process to run or expose. The mailbox is
+        served over the listener that is already accepting clients, so being
+        a rendezvous node costs no extra port, credential or service.
+        """
+        try:
+            from hivemind_rendezvous import RendezvousMailbox
+        except ImportError:
+            return
+        cfg = get_server_config().get("rendezvous", {})
+        if not cfg.get("enabled", False):
+            return
+        hm_protocol.mailbox = RendezvousMailbox(
+            max_pending_per_mailbox=cfg.get("max_pending_per_mailbox", 256)
+        )
+        LOG.info("rendezvous mailbox enabled")
+
     def _connect_upstream(self, hm_protocol: HiveMindListenerProtocol
                           ) -> Optional[HiveMindSlaveProtocol]:
         """Optionally connect this node to a master above it
@@ -351,6 +375,9 @@ class HiveMindService:
                                        callbacks=self.callbacks,
                                        binary_data_protocol=bin_protocol,
                                        agent_protocol=agent_protocol)
+
+        # optionally hold mail for peers that are never online together
+        self._start_rendezvous(hm_protocol)
 
         # optionally connect this node to a master above it
         self._connect_upstream(hm_protocol)

--- a/tests/test_rendezvous_routing.py
+++ b/tests/test_rendezvous_routing.py
@@ -1,0 +1,130 @@
+"""RENDEZVOUS routing — the mailbox hook and the mailbox-less default.
+
+RENDEZVOUS was reserved in the enum in 2021 and fell through to the empty
+handle_unknown_message stub ever since. These tests pin the two things that
+routing has to get right: an ordinary node says so out loud, and a rendezvous
+node serves the caller's own mailbox and no other.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _protocol(**kwargs):
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.callbacks = MagicMock()
+    agent.get_bus.return_value = agent.bus
+    return HiveMindListenerProtocol(
+        agent_protocol=agent,
+        db=MagicMock(),
+        require_crypto=False,
+        handshake_enabled=True,
+        policy_chain=MagicMock(),
+        **kwargs,
+    )
+
+
+def _client(key="access-key", pub_key="CLIENT-PEM"):
+    sent = []
+    return SimpleNamespace(
+        key=key,
+        pub_key=pub_key,
+        peer="peer::sess",
+        send=sent.append,
+        sent=sent,
+    )
+
+
+class _RecordingMailbox:
+    """Stands in for hivemind_rendezvous.RendezvousMailbox."""
+
+    def __init__(self):
+        self.calls = []
+
+    def handle(self, message, owner_pubkey):
+        self.calls.append((message, owner_pubkey))
+        return HiveMessage(HiveMessageType.RENDEZVOUS,
+                           payload={"status": "ok", "messages": []})
+
+
+def test_node_without_a_mailbox_says_so():
+    # silence would be indistinguishable from "no mail waiting", and a peer
+    # that cannot tell those apart cannot fail over to a real rendezvous node
+    proto = _protocol()
+    client = _client()
+    proto.handle_rendezvous_message(
+        HiveMessage(HiveMessageType.RENDEZVOUS, payload={"cmd": "collect"}),
+        client)
+    assert len(client.sent) == 1
+    reply = client.sent[0]
+    assert reply.msg_type == HiveMessageType.RENDEZVOUS
+    assert reply.payload["status"] == "error"
+    assert reply.payload["reason"] == "not_a_rendezvous_node"
+
+
+def test_mailbox_is_served_the_pinned_pubkey_not_a_requested_one():
+    # the caller does not get to name a mailbox: whatever it puts in the
+    # payload, the owner passed to the mailbox is the pinned key of *this*
+    # connection
+    proto = _protocol()
+    proto.mailbox = _RecordingMailbox()
+    proto.trusted_pubkeys["access-key"] = "PINNED-PEM"
+    client = _client()
+
+    proto.handle_rendezvous_message(
+        HiveMessage(HiveMessageType.RENDEZVOUS,
+                    payload={"cmd": "collect", "pubkey": "VICTIM-PEM"}),
+        client)
+
+    _msg, owner = proto.mailbox.calls[0]
+    assert owner == "PINNED-PEM"
+
+
+def test_falls_back_to_the_connection_pubkey_when_unpinned():
+    proto = _protocol()
+    proto.mailbox = _RecordingMailbox()
+    client = _client(pub_key="CONN-PEM")
+
+    proto.handle_rendezvous_message(
+        HiveMessage(HiveMessageType.RENDEZVOUS, payload={"cmd": "collect"}),
+        client)
+
+    _msg, owner = proto.mailbox.calls[0]
+    assert owner == "CONN-PEM"
+
+
+def test_the_mailbox_reply_reaches_the_client():
+    proto = _protocol()
+    proto.mailbox = _RecordingMailbox()
+    client = _client()
+
+    proto.handle_rendezvous_message(
+        HiveMessage(HiveMessageType.RENDEZVOUS, payload={"cmd": "collect"}),
+        client)
+
+    assert client.sent[0].payload["status"] == "ok"
+
+
+def test_handle_message_dispatches_rendezvous_to_the_handler():
+    """The actual defect: RENDEZVOUS fell through to handle_unknown_message.
+
+    This has to go through ``handle_message`` rather than calling the handler
+    directly, or it passes with the dispatch branch deleted and proves nothing.
+    """
+    proto = _protocol()
+    proto.mailbox = _RecordingMailbox()
+    proto.handle_unknown_message = MagicMock()
+    proto.update_last_seen = MagicMock()
+    client = _client()
+
+    proto.handle_message(
+        HiveMessage(HiveMessageType.RENDEZVOUS, payload={"cmd": "collect"}),
+        client)
+
+    proto.handle_unknown_message.assert_not_called()
+    assert proto.mailbox.calls, "RENDEZVOUS never reached the mailbox"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Counterpart: **JarbasHiveMind/hivemind-rendezvous#12**. Neither half does anything alone.

## What

`RENDEZVOUS` has been in `HiveMessageType` since the first commit of hivemind-bus-client (2021-04-22, v0.0.1), commented `# reserved for rendezvous-nodes`, and has fallen through to the empty `handle_unknown_message` stub ever since. It also holds binary framing code `10`, so the slot was reserved, not free.

This routes it to an optional mailbox, so a node can hold mail for peers that are never online at the same time.

## Shape

Three small pieces, modelled on `_start_presence`:

1. `handle_message` dispatches `RENDEZVOUS` to `handle_rendezvous_message`.
2. `HiveMindListenerProtocol.mailbox` — `None` on every ordinary node.
3. `HiveMindService._start_rendezvous` — optional import of `hivemind_rendezvous`, gated on a new `rendezvous.enabled` config block (**off by default**: holding other nodes' mail is a role an operator opts into).

Nodes without the package answer `{"status": "error", "reason": "not_a_rendezvous_node"}` rather than dropping the frame silently. That reply is deliberately distinct from a successful collect that returns no messages, so a client can tell "no mail" from "wrong node" and fail over.

## The design decision worth reviewing

**The caller never names a mailbox.** The owner passed to the mailbox is `trusted_pubkeys.get(client.key) or client.pub_key` — the key this connection was TOFU-pinned to during the handshake, with mismatch already rejected in `handle_handshake_message`.

That single line is what lets the rendezvous package delete its entire authentication layer: a signed-timestamp ownership proof, its ±60s replay window, and its own rate limiter. With a session, none of those problems exist. Without it, they all do — and the HTTP version had a real hole where an observer could replay a captured proof to collect (and thereby delete) another node's mail.

If a connection has no pinned key, the mailbox refuses every command; there is nothing to address.

## Verification

`tests/test_rendezvous_routing.py`, 5 tests. **Mutation-verified**: deleting only the dispatch branch makes `test_handle_message_dispatches_rendezvous_to_the_handler` fail, and restoring it makes it pass.

Worth noting, since it nearly slipped through: my first version of that test called `handle_rendezvous_message` directly and passed with the dispatch branch removed — it proved nothing. It now goes through `handle_message`.

Full suite (excluding e2e): **319 passed, 34 subtests, 0 failures.**

## Notes

- `mailbox` is a dataclass field rather than a `__post_init__` assignment, matching the convention already documented in that class for fixtures built with `object.__new__`.
- Typed `Optional[object]` to avoid importing the optional package for a type hint.
