### PR TITLE
fix: give a client that lost its Noise key a way back in

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1381,7 +1381,11 @@ class HiveMindListenerProtocol:
         pinned = self._get_pinned_client_noise_key(client)
         if pinned and transport.remote_static_key != pinned:
             self._abort_noise_handshake(
-                client, "client Noise static key contradicts pinned key")
+                client,
+                "client Noise static key contradicts the pinned key. If this "
+                "client was reinstalled or moved to new hardware, clear the "
+                f"pin with 'hivemind-core reset-noise-pin {client.key}' and "
+                "let it pair again; otherwise another node is answering for it")
             return
         if not pinned and transport.remote_static_key:
             self._pin_client_noise_key(client, transport.remote_static_key)

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -214,6 +214,41 @@ def rename_client(node_id, name):
         print(f"Renamed '{old_name}' to {name}")
 
 
+@hmcore_cmds.command(
+    help="Forget a client's pinned Noise static key so it can pair again.",
+    name="reset-noise-pin")
+@click.argument("node_id", required=False, type=int)
+def reset_noise_pin(node_id):
+    """Clear the TOFU-pinned Noise static key for one client.
+
+    The pin is what stops an unknown key answering for a known client
+    (CRYPTO-1 §3.4.5), so the node refuses any protocol v3 handshake whose
+    static key contradicts it. A client that legitimately lost its key —
+    reinstalled, reflashed, moved to new hardware, or rebuilt its identity
+    file — therefore cannot reconnect at all, and before this command the
+    only way out was editing the database by hand.
+
+    Clearing the pin re-arms trust-on-first-use: the next handshake pins
+    whatever key that client presents. Only run it when the client really did
+    change, since it is exactly the check that would otherwise catch an
+    impostor.
+    """
+    with ClientDatabase() as db:
+        client = resolve_client(db, node_id)
+        if client is None:
+            print("Invalid Node ID!")
+            return
+        metadata = client.metadata or {}
+        if not metadata.get("noise_pubkey"):
+            print(f"{client.name} has no pinned Noise key — nothing to reset")
+            return
+        metadata.pop("noise_pubkey")
+        client.metadata = metadata
+        db.update_item(client)
+        print(f"Forgot the pinned Noise key for {client.name}. "
+              "Its next connection will pin the key it presents.")
+
+
 @hmcore_cmds.command(help="Give administrator powers to a client in the database.", name="make-admin")
 @click.argument("node_id", required=False, type=int)
 def make_admin(node_id):

--- a/tests/test_reset_noise_pin.py
+++ b/tests/test_reset_noise_pin.py
@@ -1,0 +1,89 @@
+"""reset-noise-pin — the recovery path for a client that lost its Noise key.
+
+CRYPTO-1 §3.4.5 pins a client's static key on first use and the node then
+refuses any v3 handshake presenting a different one. That is the right default
+and it is also a total lockout for a satellite that was reinstalled, reflashed
+or moved to new hardware: the key legitimately changed, and until this command
+existed the only way back was editing the client database by hand.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from hivemind_core.scripts import reset_noise_pin
+
+
+class _DB:
+    """Stands in for ClientDatabase as a context manager."""
+
+    def __init__(self, client):
+        self.client = client
+        self.updated = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    def update_item(self, client):
+        self.updated.append(client)
+
+
+def _client(**kw):
+    return SimpleNamespace(name="sat0", client_id=1, api_key="key-0", **kw)
+
+
+def _run(db, client, node_id="1"):
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client):
+        return CliRunner().invoke(reset_noise_pin, [node_id])
+
+
+def test_a_pinned_key_is_forgotten():
+    client = _client(metadata={"noise_pubkey": "abc123", "other": "kept"})
+    db = _DB(client)
+
+    result = _run(db, client)
+
+    assert result.exit_code == 0
+    assert "noise_pubkey" not in client.metadata
+    assert db.updated == [client], "the cleared pin must be persisted"
+
+
+def test_unrelated_metadata_survives():
+    client = _client(metadata={"noise_pubkey": "abc123", "site": "kitchen"})
+
+    _run(_DB(client), client)
+
+    assert client.metadata["site"] == "kitchen"
+
+
+def test_a_client_with_no_pin_is_left_alone():
+    client = _client(metadata={"site": "kitchen"})
+    db = _DB(client)
+
+    result = _run(db, client)
+
+    assert "nothing to reset" in result.output
+    assert db.updated == [], "an unpinned client must not be written back"
+
+
+def test_metadata_may_be_absent_entirely():
+    client = _client(metadata=None)
+    db = _DB(client)
+
+    result = _run(db, client)
+
+    assert result.exit_code == 0
+    assert db.updated == []
+
+
+def test_an_unknown_node_id_is_reported():
+    db = _DB(None)
+
+    result = _run(db, None, node_id="99")
+
+    assert "Invalid Node ID" in result.output
+    assert db.updated == []


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting. Found by hitting it on the live `hivemind.openvoiceos.pt` hub, then fixed and used there to recover.

Server-side half of the lockout fixed client-side in JarbasHiveMind/hivemind-websocket-client#187.

## The problem

CRYPTO-1 §3.4.5 pins a client's Noise static key on first use, and `handle_noise_handshake_message` then refuses any handshake presenting a different one:

```python
if pinned and transport.remote_static_key != pinned:
    self._abort_noise_handshake(client, "client Noise static key contradicts pinned key")
```

Right against an impostor. Also a **permanent lockout** for a satellite that was reinstalled, reflashed, or moved to new hardware — its key legitimately changed, so every reconnect is refused, forever.

There was no way out. The pin lives in the client DB row's `metadata["noise_pubkey"]`, there is no CLI for it, and the abort reason does not tell an operator what to do.

I hit this for real: after recreating a client identity, it could not reconnect to the live hub at all.

## The fix

`hivemind-core reset-noise-pin <node_id>` clears that one key and re-arms TOFU, and the abort reason now names the command:

```
client Noise static key contradicts the pinned key. If this client was
reinstalled or moved to new hardware, clear the pin with
'hivemind-core reset-noise-pin <key>' and let it pair again; otherwise
another node is answering for it
```

The security property is unchanged — the default is still refuse-and-log. What changes is that the refusal is now recoverable by an operator instead of by a database edit, and it says which of the two situations it might be.

## Verification

Five tests, mutation-verified — dropping the `db.update_item(client)` fails `test_a_pinned_key_is_forgotten`:

- the pin is cleared and persisted
- unrelated metadata survives
- a client with no pin is left alone and **not** written back
- `metadata=None` does not crash
- an unknown node id is reported

**Used in production**: ran it against ser9 to clear two stale pins, after which the blocked clients paired again and a full RENDEZVOUS deposit → collect → ack round trip completed over `wss://hivemind.openvoiceos.pt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `reset-noise-pin` command to clear a client’s stored security pin and allow re-pairing.
  * Added clear status messages for invalid clients, missing pins, and successful resets.

* **Bug Fixes**
  * Expanded security handshake errors with guidance for clients that were reinstalled or relocated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->