### PR TITLE
fix: derive the rendezvous mailbox from proven identity, not a declared pubkey

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1174,22 +1174,45 @@ class HiveMindListenerProtocol:
 
         A rendezvous node is an ordinary node with the optional
         hivemind-rendezvous package installed and ``rendezvous.enabled`` set;
-        ``mailbox`` is then bound at startup. Every other node has no mailbox
-        and says so, rather than dropping the frame silently — a peer that
-        cannot tell "no mail" from "not a rendezvous node" cannot fail over to
-        one that is.
+        ``mailbox`` is then bound at startup. Every other node answers
+        "not_a_rendezvous_node" rather than dropping the frame, so a peer can
+        tell "no mail" from "wrong node" and fail over.
 
-        The caller never names a mailbox. It gets the one belonging to the
-        public key this connection was TOFU-pinned to at handshake time, so
-        collecting another node's mail is not something the wire can express.
+        The mailbox is addressed by ``client.key`` — the access key this
+        connection authenticated with — and never by anything in the request.
+
+        It deliberately is NOT addressed by ``client.pub_key`` or by
+        ``trusted_pubkeys``. Both are populated from the HELLO payload with no
+        proof of possession (see ``handle_hello_message``), and
+        ``trusted_pubkeys`` is keyed by the *caller's own* access key, so any
+        admitted client could name a victim's public key — which is public by
+        design, it is the INTERCOM addressing key — and be handed that
+        victim's mailbox. The access key is proven by the handshake itself,
+        which is what makes it safe to own a mailbox.
         """
         if self.mailbox is None:
             client.send(HiveMessage(
                 HiveMessageType.RENDEZVOUS,
                 payload={"status": "error", "reason": "not_a_rendezvous_node"}))
             return
-        owner = self.trusted_pubkeys.get(client.key) or client.pub_key
-        client.send(self.mailbox.handle(message, owner))
+        if not client.key:
+            # No authenticated identity means no mailbox to serve. Falling
+            # through would hand every such connection one shared mailbox.
+            client.send(HiveMessage(
+                HiveMessageType.RENDEZVOUS,
+                payload={"status": "error", "reason": "no_client_identity"}))
+            return
+        try:
+            reply = self.mailbox.handle(message, client.key)
+        except Exception:
+            # The mailbox is an optional third-party component. An exception
+            # here used to escape handle_message and take the connection down
+            # with it, skipping update_last_seen on the way out.
+            LOG.exception(f"rendezvous mailbox failed for {client.peer}")
+            reply = HiveMessage(HiveMessageType.RENDEZVOUS,
+                                payload={"status": "error",
+                                         "reason": "mailbox_error"})
+        client.send(reply)
 
     def handle_unknown_message(
             self, message: HiveMessage, client: HiveMindClientConnection

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -75,9 +75,21 @@ def resolve_client(db: ClientDatabase, node_id) -> Optional[Client]:
     Returns None when no client carries that id — every caller reports
     that to the operator itself.
     """
-    node_id = node_id or prompt_node_id(db)
+    if node_id is None:
+        node_id = prompt_node_id(db)
+    # An access key is accepted as well as a numeric id: error messages the
+    # node logs identify a client by its access key, and an operator following
+    # such a message verbatim would otherwise get "not a valid integer".
+    wanted = str(node_id)
     for client in db:
-        if client.client_id == int(node_id):
+        if client.api_key == wanted:
+            return client
+    try:
+        numeric = int(wanted)
+    except (TypeError, ValueError):
+        return None
+    for client in db:
+        if client.client_id == numeric:
             return client
     return None
 

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -229,7 +229,10 @@ def rename_client(node_id, name):
 @hmcore_cmds.command(
     help="Forget a client's pinned Noise static key so it can pair again.",
     name="reset-noise-pin")
-@click.argument("node_id", required=False, type=int)
+# str, not int: the node logs this command with the client's ACCESS KEY, and
+# click would reject that with "is not a valid integer" before resolve_client
+# ever saw it — leaving the operator exactly as stuck as before.
+@click.argument("node_id", required=False, type=str)
 def reset_noise_pin(node_id):
     """Clear the TOFU-pinned Noise static key for one client.
 

--- a/tests/test_rendezvous_routing.py
+++ b/tests/test_rendezvous_routing.py
@@ -67,35 +67,72 @@ def test_node_without_a_mailbox_says_so():
     assert reply.payload["reason"] == "not_a_rendezvous_node"
 
 
-def test_mailbox_is_served_the_pinned_pubkey_not_a_requested_one():
+def test_mailbox_is_served_the_authenticated_access_key():
     # the caller does not get to name a mailbox: whatever it puts in the
-    # payload, the owner passed to the mailbox is the pinned key of *this*
-    # connection
+    # payload, the owner is the access key THIS connection authenticated with
     proto = _protocol()
     proto.mailbox = _RecordingMailbox()
-    proto.trusted_pubkeys["access-key"] = "PINNED-PEM"
-    client = _client()
+    client = _client(key="my-key")
 
     proto.handle_rendezvous_message(
         HiveMessage(HiveMessageType.RENDEZVOUS,
-                    payload={"cmd": "collect", "pubkey": "VICTIM-PEM"}),
+                    payload={"cmd": "collect", "pubkey": "VICTIM-PEM",
+                             "key": "victim-key"}),
         client)
 
     _msg, owner = proto.mailbox.calls[0]
-    assert owner == "PINNED-PEM"
+    assert owner == "my-key"
 
 
-def test_falls_back_to_the_connection_pubkey_when_unpinned():
+def test_a_declared_pubkey_cannot_claim_a_mailbox():
+    """The HELLO-declared pubkey carries no proof of possession.
+
+    trusted_pubkeys is filled from the HELLO payload and keyed by the caller's
+    OWN access key, so if ownership were derived from it, any admitted client
+    could name a victim's public key — which is public by design, it is the
+    INTERCOM addressing key — and be handed the victim's mailbox.
+    """
     proto = _protocol()
     proto.mailbox = _RecordingMailbox()
-    client = _client(pub_key="CONN-PEM")
+    proto.trusted_pubkeys["attacker-key"] = "VICTIM-PEM"
+    client = _client(key="attacker-key", pub_key="VICTIM-PEM")
 
     proto.handle_rendezvous_message(
         HiveMessage(HiveMessageType.RENDEZVOUS, payload={"cmd": "collect"}),
         client)
 
     _msg, owner = proto.mailbox.calls[0]
-    assert owner == "CONN-PEM"
+    assert owner == "attacker-key", "ownership must not come from a declared pubkey"
+
+
+def test_a_connection_with_no_identity_gets_no_mailbox():
+    # otherwise every such connection shares one mailbox
+    proto = _protocol()
+    proto.mailbox = _RecordingMailbox()
+    client = _client(key="")
+
+    proto.handle_rendezvous_message(
+        HiveMessage(HiveMessageType.RENDEZVOUS, payload={"cmd": "collect"}),
+        client)
+
+    assert proto.mailbox.calls == []
+    assert client.sent[0].payload["reason"] == "no_client_identity"
+
+
+def test_a_raising_mailbox_does_not_kill_the_connection():
+    class _Boom:
+        def handle(self, message, owner):
+            raise RuntimeError("backend down")
+
+    proto = _protocol()
+    proto.mailbox = _Boom()
+    client = _client()
+
+    proto.handle_rendezvous_message(
+        HiveMessage(HiveMessageType.RENDEZVOUS, payload={"cmd": "collect"}),
+        client)
+
+    assert client.sent[0].payload["reason"] == "mailbox_error"
 
 
 def test_the_mailbox_reply_reaches_the_client():

--- a/tests/test_reset_noise_pin.py
+++ b/tests/test_reset_noise_pin.py
@@ -87,3 +87,22 @@ def test_an_unknown_node_id_is_reported():
 
     assert "Invalid Node ID" in result.output
     assert db.updated == []
+
+
+def test_the_command_accepts_the_access_key_the_logs_print():
+    """The node's abort message names the client by ACCESS KEY.
+
+    With click coercing the argument to int, following that message verbatim
+    failed with "is not a valid integer" — the operator was left exactly as
+    stuck as before the command existed.
+    """
+    client = _client(metadata={"noise_pubkey": "abc123"})
+    db = _DB(client)
+
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client):
+        result = CliRunner().invoke(reset_noise_pin, ["c0d14821bbece410349e2541"])
+
+    assert result.exit_code == 0, result.output
+    assert "not a valid integer" not in result.output
+    assert db.updated == [client]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting. Found by an adversarial review that was told to refute my own merged PR #243, and it did.

**Security fix.** Pairs with JarbasHiveMind/hivemind-rendezvous#14. Rendezvous is disabled on ser9 until both land.

## The vulnerability

#243 claimed: *"a caller cannot name a mailbox — it only ever gets the one belonging to the public key its connection was TOFU-pinned to"*. That claim is **false**.

```python
owner = self.trusted_pubkeys.get(client.key) or client.pub_key
```

Both sides of that come from the HELLO payload with **no proof of possession** — `handle_hello_message` simply records what the client sent. And `trusted_pubkeys` is keyed by the **caller's own** access key, so an attacker never races the victim for the entry.

**Attack:** any client holding *any* valid access key and password for the hive (one low-privilege satellite is enough) sends `HELLO {"pubkey": "<victim's public RSA PEM>"}`. Victim public keys are public by design — they are the INTERCOM addressing keys. The node stores that PEM under the attacker's own access key, and every subsequent RENDEZVOUS resolves `owner` to the victim's mailbox. The attacker reads and deletes the victim's mail. No victim credentials needed.

## The fix

The owner is `client.key` — the access key the connection authenticated with, which the handshake actually proves. Nothing in the request can influence it.

A connection with no key is refused (`no_client_identity`) rather than served: `None` fell through as a valid owner, so every identity-less caller shared one mailbox.

The mailbox call is also now guarded. It is an optional third-party component, and an exception escaped `handle_message`, dropped the connection and skipped `update_last_seen` on the way out.

## Why the tests missed it

`tests/test_rendezvous_routing.py` set `proto.trusted_pubkeys["access-key"]` **by hand**. Nothing drove the pin through `handle_hello_message`, which is exactly where the trust boundary is. The new `test_a_declared_pubkey_cannot_claim_a_mailbox` sets up the attacker's view — pin keyed by the attacker's own access key, `pub_key` set to the victim's — and asserts ownership does not follow it.

## Verification

- 7 tests in `test_rendezvous_routing.py`, **mutation-verified**: restoring `trusted_pubkeys.get(client.key) or client.pub_key` fails `test_a_declared_pubkey_cannot_claim_a_mailbox` and `test_mailbox_is_served_the_authenticated_access_key`.
- Full core suite green.
- Deployed to ser9 and exercised live before merge.

## Not fixed here

RENDEZVOUS does not pass through the policy chain, so a client with a deny-everything ACL can still poll a mailbox at any rate. Storage is bounded; request rate is not. Filed separately rather than widened into this PR.