### PR TITLE
fix: dedup PING floods per announcement, so nodes below a relay see the hive

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1757,6 +1757,19 @@ class HiveMindListenerProtocol:
         payload.replace_route(list(payload.route) + [hop])
 
     @staticmethod
+    def _flood_peer(message: HiveMessage) -> str:
+        """The ``peer`` a flood message announces, or ``""`` when it names none.
+
+        A flood is not one message. Every node that answers builds its own PING
+        carrying the same ``flood_id`` and its own ``peer``, so one flood id
+        covers as many distinct announcements as there are answering nodes.
+        """
+        inner = message.payload
+        if isinstance(inner, HiveMessage):
+            inner = inner.payload
+        return inner.get("peer", "") if isinstance(inner, dict) else ""
+
+    @staticmethod
     def _flood_id(message: HiveMessage) -> str:
         """The ``flood_id`` a routing message carries, or ``""`` when it carries
         none.
@@ -1799,6 +1812,26 @@ class HiveMindListenerProtocol:
         flood_id = self._flood_id(message)
         if not flood_id:
             return False
+        # Keyed on (flood_id, peer), not flood_id alone.
+        #
+        # One flood carries one announcement per answering node. Collapsing
+        # them by flood_id makes a node forward whichever arrives first and
+        # silently drop the rest, so a satellite below a relay never learns
+        # the nodes above it — and not only for someone else's flood: when it
+        # floods itself, every answer comes back wrapped with ITS flood id, so
+        # the relay forwards one of them and the originator's own map comes
+        # back incomplete. A topology probe that quietly reports a wrong
+        # topology is worse than an expensive one.
+        #
+        # The duplication this gate exists for is still removed: the same
+        # node's announcement crossing this node twice is what cost
+        # n(n-1)^2, and that is still dropped. Mesh-wide answer volume is
+        # bounded by ping_flood_interval, which is the knob for cost.
+        #
+        # The mapper already keys its own novelty check the same way, so this
+        # brings the gate in line with how the rest of the node models a
+        # flood.
+        flood_id = f"{flood_id}\x00{self._flood_peer(message)}"
         # FloodIdCache.check() records the id and reports whether it was
         # already there, so the test and the insert cannot race. Sized from
         # the client count like the answer caches: every connected peer can

--- a/tests/test_flood_forward_dedup.py
+++ b/tests/test_flood_forward_dedup.py
@@ -56,6 +56,14 @@ def _make_client(peer: str) -> MagicMock:
     return client
 
 
+def _flood_peer_of(message):
+    """The peer named by a PROPAGATE-wrapped PING."""
+    inner = message.payload
+    if hasattr(inner, "payload"):
+        inner = inner.payload
+    return inner.get("peer", "") if isinstance(inner, dict) else ""
+
+
 def _flood_id_of(message: HiveMessage) -> str:
     """Read a ``flood_id`` off the wire without going through the code we test."""
     inner = message.payload
@@ -119,35 +127,71 @@ class StarMesh:
         return self.sends
 
 
-def test_ping_round_cost_stops_growing_quadratically():
-    """The n(n-1)^2 term is gone: cost per round is linear in n per flood.
+def test_round_cost_is_bounded_by_announcements_not_by_repeats():
+    """What the forward gate can and cannot buy.
 
-    Measured on this harness with the forward gate removed: 1000 sends at n=10
-    and 8000 at n=20, i.e. n(2n-1 + (n-1)^2). With the gate: 190 and 780.
+    Full topology knowledge is inherently quadratic: n nodes each learning
+    n-1 peers means the master relays every peer's announcement to every other
+    peer. The gate cannot remove that and stay correct — an earlier version
+    keyed on the flood id alone, which did make a round cheap, by dropping
+    every announcement after the first and leaving satellites unaware of their
+    siblings.
+
+    What the gate removes is *repeats*: the same announcement crossing this
+    node again over another path. This asserts that, and pins the shape of the
+    remaining cost so a future change that reintroduces repeat fan-out is
+    visible.
+
+    In a deployment the multiplier on top is bounded by ping_flood_interval
+    (default 30s): a node answers mesh-wide at most once per interval and
+    replies only to the asker inside it, so the n simultaneous unthrottled
+    floods this harness drives are a worst case, not a steady state.
     """
-    counts = {n: StarMesh(n).run_round() for n in (10, 20)}
+    n = 10
+    mesh = StarMesh(n)
+    cost = mesh.run_round()
 
-    # n floods per round, each costing the master (n-1) forwards + n answers
-    assert counts[10] == 10 * (2 * 10 - 1)   # 190, was 1000
-    assert counts[20] == 20 * (2 * 20 - 1)   # 780, was 8000
+    # n floods, each costing the master n(n-1) forwards of its peers'
+    # announcements plus n deliveries of its own answer: n * (n(n-1) + n),
+    # which is exactly n^3.
+    assert cost == n ** 3
 
-    # doubling n used to multiply the round cost by 8; it may now only quadruple
-    assert counts[20] < 5 * counts[10]
+    # and no announcement is delivered to the same peer twice
+    for peer, messages in mesh.delivered.items():
+        seen = [(_flood_id_of(m), _flood_peer_of(m)) for m in messages]
+        assert len(seen) == len(set(seen)), f"{peer} received a repeat"
 
 
-def test_master_forwards_a_flood_once_no_matter_how_many_copies_arrive():
+def test_the_same_announcement_is_not_re_fanned():
+    """The duplication the gate exists for: one node's announcement arriving
+    twice, over two mesh paths. The second copy adds nothing and must not cost
+    another fan-out."""
     mesh = StarMesh(5)
     master = mesh.master
-    origin = _make_client("sat::0")
 
-    master.handle_propagate_message(_ping("f1", "sat::0"), origin)
+    master.handle_propagate_message(_ping("f1", "sat::0"), _make_client("sat::0"))
     first_round = mesh.sends
+    assert first_round > 0
 
-    # the same flood arriving again from a different peer is not re-fanned
+    # same flood, same peer, arriving again from somewhere else
+    mesh.sends = 0
+    master.handle_propagate_message(_ping("f1", "sat::0"), _make_client("sat::1"))
+    assert mesh.sends == 0, "a repeat of the same announcement must not re-fan"
+
+
+def test_a_different_peer_in_the_same_flood_is_still_forwarded():
+    """Each answering node contributes its own announcement under the shared
+    flood id. Collapsing them by flood id alone is what left a node below a
+    relay knowing only whichever peer answered first — including for its own
+    flood, whose answers all come back carrying its id."""
+    mesh = StarMesh(5)
+    master = mesh.master
+
+    master.handle_propagate_message(_ping("f1", "sat::0"), _make_client("sat::0"))
     mesh.sends = 0
     master.handle_propagate_message(_ping("f1", "sat::1"), _make_client("sat::1"))
-    assert mesh.sends == 0, "an already forwarded flood must not be re-fanned"
-    assert first_round > 0
+    assert mesh.sends > 0, (
+        "a second node's announcement is new information and must cross")
 
 
 def test_a_new_flood_still_reaches_every_node():


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting. Bisected, measured, and validated against the live hub; the numbers below are observed.

Fixes #245 — the contradiction between this repo and the conformance harness. Paired with JarbasHiveMind/hivemind-test-harness#46, which removes the ten xfails.

## The decision

#245 was a genuine fork: core said a flood crosses each node **once**, the harness said each **announcement** must cross. Both were enforced by passing tests. I went with per-announcement, and the deciding argument is not the harness's expectation:

**flood_id-only dedup breaks a node's own flood.** When S0 floods, every node answers with a fresh PROPAGATE carrying **S0's** flood id. The relay above S0 forwards the first and drops the rest, so S0's own map comes back incomplete. A topology probe that quietly reports a wrong topology is worse than an expensive one.

Keyed on `(flood_id, peer)`. The mapper already keys its novelty check exactly this way — `handle_ping_message` feeds it *before* the gate precisely so it sees what the gate drops — so this brings the gate in line with how the rest of the node already models a flood.

## On the cost #212 was protecting

Worth being blunt: **the `n(n-1)^2` term #212 removed was not waste, it was sibling discovery.** In a star, every satellite's announcement reaching every other satellite is inherently quadratic per flood, and no gate removes it while staying correct. Measured on core's own `StarMesh`, per-announcement keying costs exactly `n^3` per unthrottled round (1000 at n=10, 8000 at n=20) — the same as no gate at all, because in a star there are no duplicate `(flood_id, peer)` pairs to drop.

What the gate still buys is **repeats**: the same announcement crossing this node again over another path, which is what a real mesh (not a star) produces.

What bounds the rest in a deployment is `ping_flood_interval`, default 30s: a node answers mesh-wide at most once per interval and replies only to the asker inside it. The n simultaneous unthrottled floods the harness drives are a worst case, not a steady state.

If that trade is wrong for a large site, the lever is the interval, not information loss.

## Tests

The two dedup tests asserted the old model, so they are rewritten to assert what is actually true:

- `test_the_same_announcement_is_not_re_fanned` — same flood id **and** same peer, arriving twice → one fan-out
- `test_a_different_peer_in_the_same_flood_is_still_forwarded` — the property that was broken
- `test_round_cost_is_bounded_by_announcements_not_by_repeats` — pins `n^3` and asserts no peer receives the same announcement twice, so a future change reintroducing repeat fan-out is visible

## Verification

- core suite green
- **the ten harness PING tests that were xfail against #245 now pass**: `33 passed, 10 xpassed, 0 failed` across `test_ping_exactly_once.py` and `test_ping_pong.py`
- deployed to ser9 and exercised on the live hub before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flood message handling to prevent duplicate announcements from being forwarded repeatedly.
  * Distinct peer announcements sharing the same flood identifier are now forwarded correctly.
  * Reduced unnecessary network traffic caused by repeated announcement messages.

* **Tests**
  * Added coverage for duplicate suppression, distinct-peer forwarding, and bounded forwarding costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->