### PR TITLE
fix: generate a node public key when the server has none

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,6 +191,14 @@ negotiate a session cipher during HANDSHAKE. Supported ciphers (order of prefere
 in config): `CHACHA20-POLY1305`, `AES-GCM`. Supported encodings: `JSON-B64`,
 `JSON-URLSAFE-B64`, `JSON-B91`, `JSON-Z85B`, `JSON-Z85P`, `JSON-B32`, `JSON-HEX`.
 
+If `_identity.json` has no public key yet, one is generated and persisted
+the first time the service starts. This never stops the node from booting:
+a read-only or unwritable config directory is logged and the node continues
+unkeyed, since a node that served clients yesterday must not refuse to boot
+today over a key it can live without. An unkeyed node cannot be addressed by
+INTERCOM, is invisible on the hive map (its PINGs report no `peer`), and does
+not suppress loops in its own PROPAGATE floods.
+
 `INTERCOM` messages add a second layer: signed and end-to-end encrypted between the
 originating and target peers, opaque to intermediate relay nodes.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,10 +193,12 @@ Run `hivemind-core add-client` **on the master** to get the `key` and
 error and stays a top-level master, rather than refusing to start and taking
 its own clients offline with it.
 
-The upstream connection keeps its credentials in its own identity file,
-`~/.config/hivemind/_identity_upstream.json`. The node's own
-`_identity.json` — the identity it presents to its downstream clients — is
-never written to by the upstream link.
+The upstream connection uses the node's own identity
+(`~/.config/hivemind/_identity.json`) for both directions — the key it
+answers its own clients with is the key it announces to its master.
+`upstream.key` / `upstream.password` are connection settings for the
+upstream client, not part of the node's identity, and they are never
+written back into `_identity.json`.
 
 The connection opens on a background thread and the client keeps retrying, so
 an unreachable master delays nothing at startup: the node comes up and serves

--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -2,13 +2,13 @@
 # Copyright (C) 2026 Casimiro Ferreira
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
+from os.path import isfile
 import ipaddress
 import socket
 import threading
 import time
 from typing import Callable, Mapping, Optional, Type
 
-from json_database import JsonConfigXDG
 
 from ovos_utils import create_daemon, wait_for_exit_signal
 from ovos_utils.log import LOG
@@ -17,6 +17,7 @@ from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
 from hivemind_bus_client.client import HiveMessageBusClient
 from hivemind_bus_client.fakebus import FakeBus
 from hivemind_bus_client.identity import NodeIdentity
+from poorman_handshake.asymmetric.utils import load_RSA_key
 from hivemind_bus_client.protocol import HiveMindSlaveProtocol
 from hivemind_core.config import get_server_config, upstream_config
 from hivemind_core.database import ClientDatabase
@@ -90,29 +91,66 @@ def own_listener_for(host: str, port: int, network_protocol: Mapping) -> Optiona
     return None
 
 
-def upstream_identity() -> NodeIdentity:
-    """Identity for the client this node uses to reach its upstream master,
-    kept in ``hivemind/_identity_upstream.json``.
+def _ensure_node_identity(identity: NodeIdentity) -> None:
+    """Give an identity a public key if it does not have one yet.
 
-    It MUST NOT be the node's own ``_identity.json``. ``HiveMessageBusClient``
-    copies the credentials it is given onto the identity it holds, and the
-    first successful Noise handshake calls ``pin_noise_key``, which saves that
-    whole identity to disk. Handed the node's own identity, the client would
-    overwrite the node's ``password`` and ``access_key`` — the very values the
-    node presents to its own downstream clients — and every satellite would
-    then fail its handshake with "invalid api key".
+    ``NodeIdentity`` reads its JSON file and returns ``None`` for a key that
+    was never generated. Nothing on the server path generates one:
+    ``hivemind-client set-identity`` does, but that is the client CLI, and an
+    operator who only ever runs ``hivemind-core`` never calls it. The node then
+    runs with ``_node_id is None`` for its whole life, and the public key is
+    not decoration:
+
+    * It is the ``peer`` of every responsive PING the node sends, so an unkeyed
+      node answers a flood anonymously and no client can put it on the hive
+      map. Observed live: ``hivemind-client ping`` printing
+      "[No responses received]" against a node that was answering.
+    * It is the hop identity for MSG-1 §5 loop suppression. ``_append_self_hop``
+      stamps ``{"source": _node_id}`` and ``HiveMessage.route`` drops any hop
+      with a falsy ``source``, so an unkeyed node never appears in a route and
+      never recognises its own — a flood is not suppressed at all.
+    * It is how the mesh addresses this node end-to-end (INTERCOM
+      ``target_pubkey``), so mail to it cannot be addressed.
+
+    A node has one identity and uses it in both directions: the key it answers
+    its own clients with is the key it announces to its master. A relay without
+    one is mapped as an anonymous client, and its two halves cannot be
+    recognised as one node.
+
+    Generating is idempotent: it happens only when the field is empty, and the
+    key is persisted so it stays stable across restarts, which is the property
+    everything above depends on. Failure is not fatal. A read-only or
+    root-owned config directory is a normal container shape, and a node that
+    served clients yesterday must not refuse to boot today over a key it can
+    live without.
     """
-    identity_file = JsonConfigXDG("_identity_upstream", subfolder="hivemind")
-    if not identity_file:
-        # NodeIdentity does `identity_file or JsonConfigXDG("_identity", ...)`,
-        # and a JsonConfigXDG for a file that does not exist yet is an empty
-        # dict — which is falsy, so it would silently fall back to the node's
-        # own identity. Write one key so the file exists and is TRUTHY; the
-        # value is never read. HiveMessageBusClient overwrites `name` with the
-        # name the master knows this node by, so do not read anything into it.
-        identity_file["name"] = "hivemind-core-upstream"
-        identity_file.store()
-    return NodeIdentity(identity_file=identity_file)
+    if identity.public_key:
+        return
+    # A configured private key is the node's identity even when the JSON
+    # carries no public_key field: create_keys() writes a fresh keypair to a
+    # fixed filename and rewrites secret_key, so generating here would orphan
+    # the operator's key and rotate the identity everything else pinned.
+    # Publish the public half of the key that is already in use instead.
+    configured = identity.IDENTITY_FILE.get("secret_key")
+    if configured and isfile(configured):
+        try:
+            identity.public_key = load_RSA_key(configured).publickey(
+                ).export_key().decode("utf-8")
+            identity.save()
+            LOG.info(f"published the public half of {configured}")
+            return
+        except Exception:
+            LOG.exception(f"could not read the configured private key "
+                          f"{configured}, generating a new keypair")
+    try:
+        LOG.info("no node public key found, generating one")
+        identity.create_keys()
+        identity.save()
+        LOG.info(f"node identity saved to {identity.IDENTITY_FILE.path}")
+    except Exception:
+        LOG.exception("could not generate a node public key, continuing "
+                      "without one — this node will be unmappable and cannot "
+                      "be addressed by INTERCOM")
 
 
 def on_ready():
@@ -172,6 +210,8 @@ class HiveMindService:
                                                          on_stopping=self.stopping_hook,
                                                      ))
         self._status.set_alive()
+        # after the status hooks exist: a failure in here must be reportable
+        _ensure_node_identity(self.identity)
 
     def _start_presence(self) -> None:
         """Optionally advertise this hivemind-core server on the local network
@@ -269,7 +309,7 @@ class HiveMindService:
                                         host=scheme + config["host"],
                                         port=config["port"],
                                         self_signed=config["self_signed"],
-                                        identity=upstream_identity())
+                                        identity=self.identity)
         slave = HiveMindSlaveProtocol(hm=upstream)
         hm_protocol.bind_upstream(slave)
         LOG.info(f"Upstream master: {config['host']}:{config['port']}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,13 @@ dependencies = [
     # node derive each Noise PSK once per (password, node_id) instead of once
     # per connection (argon2id, ~217ms and 64 MiB each time). The server still
     # degrades gracefully to the legacy handshake against older clients on the
-    # wire.
-    "hivemind_bus_client>=1.0.3a1,<2.0.0",
+    # wire. 1.0.12a1 raises the floor further: this node now generates and
+    # uses one identity in both directions, and the client at that release
+    # stops copying a master's credentials onto that identity and rotating its
+    # Noise static key. An older client paired with this change rotates the
+    # node's server-side key on first upstream connect and breaks every pinned
+    # downstream peer, so the floor must move with it.
+    "hivemind_bus_client>=1.0.12a1,<2.0.0",
     "ovos_utils>=0.0.33,<1.0.0",
     "pybase64",
     # 0.9.0a1 added AbstractDB.get_client_by_api_key, which ClientDatabase calls

--- a/tests/test_node_identity.py
+++ b/tests/test_node_identity.py
@@ -1,0 +1,171 @@
+"""A node without a public key cannot be named, mapped or routed around.
+
+`NodeIdentity` returns None for a key that was never generated, and nothing on
+the server path generates one: `hivemind-client set-identity` does, but that is
+the client CLI. A node started by an operator who only runs `hivemind-core`
+therefore has `_node_id is None` for its whole life.
+
+Observed live on hivemind.openvoiceos.pt before this fix: the node answered a
+PING flood with `peer: null, public_key: null`, and `hivemind-client ping`
+reported "[No responses received]" against a node that was replying.
+"""
+from unittest.mock import MagicMock, patch
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+from hivemind_core.service import HiveMindService
+
+
+def _service(identity):
+    """Build the service without touching the database or the bus."""
+    with patch("hivemind_core.service.ClientDatabase", MagicMock()):
+        return HiveMindService(identity=identity, db=MagicMock())
+
+
+def _identity(public_key=None):
+    ident = MagicMock()
+    ident.public_key = public_key
+    ident.IDENTITY_FILE.path = "/tmp/_identity.json"
+
+    def create_keys():
+        ident.public_key = "-----BEGIN PUBLIC KEY-----\nGENERATED\n-----END PUBLIC KEY-----"
+
+    ident.create_keys.side_effect = create_keys
+    return ident
+
+
+def test_a_node_with_no_key_generates_one_at_startup():
+    ident = _identity(public_key=None)
+
+    _service(ident)
+
+    ident.create_keys.assert_called_once()
+    ident.save.assert_called_once(), "a key that is not persisted changes on every restart"
+    assert ident.public_key, "the node must be able to name itself"
+
+
+def test_an_existing_key_is_never_regenerated():
+    """Regenerating would change the node's identity on restart, and every
+    peer that pinned it, addressed INTERCOM to it, or mapped it would be
+    talking to a stranger."""
+    ident = _identity(public_key="-----BEGIN PUBLIC KEY-----\nORIGINAL\n-----END PUBLIC KEY-----")
+
+    _service(ident)
+
+    ident.create_keys.assert_not_called()
+    ident.save.assert_not_called()
+    assert "ORIGINAL" in ident.public_key
+
+
+def test_the_generated_key_is_what_the_protocol_announces():
+    """The whole point of the key: it becomes _node_id, which is the `peer` of
+    every responsive PING and the hop identity for loop detection."""
+    ident = _identity(public_key=None)
+
+    _service(ident)
+    protocol = HiveMindListenerProtocol(identity=ident, agent_protocol=MagicMock(), db=MagicMock())
+
+    assert protocol._node_id == ident.public_key
+    assert protocol._node_id, "an anonymous node cannot be put on a hive map"
+
+
+def test_a_config_dir_we_cannot_write_does_not_stop_the_node():
+    """A read-only or root-owned config dir is a normal container shape. The
+    node served clients yesterday without a key; it must not refuse to boot
+    today over one it can live without."""
+    ident = _identity(public_key=None)
+    ident.create_keys.side_effect = PermissionError("read-only config dir")
+
+    service = _service(ident)
+
+    assert service is not None, "an unwritable config dir must not kill the boot"
+    assert not ident.public_key
+
+
+def test_the_status_hooks_exist_before_the_key_is_generated():
+    """Ordering is load-bearing: a failure raised before ProcessStatus is built
+    reaches no error hook, so the supervisor sees the process die silently."""
+    ident = _identity(public_key=None)
+    order = []
+    ident.create_keys.side_effect = lambda: order.append("create_keys")
+
+    with patch("hivemind_core.service.ProcessStatus") as status:
+        status.side_effect = lambda *a, **k: order.append("status") or MagicMock()
+        with patch("hivemind_core.service.ClientDatabase", MagicMock()):
+            HiveMindService(identity=ident, db=MagicMock())
+
+    assert order.index("status") < order.index("create_keys"), order
+
+
+def test_a_relay_reaches_its_master_with_the_same_identity_it_serves_with():
+    """One node, one keypair, both directions. A separate upstream identity
+    made a relay two nodes to the mesh: anonymous as a client of its master,
+    keyed as a server to its own clients, with no way to see they were one."""
+    from hivemind_core import service
+
+    ident = _identity(public_key=None)
+    built = {}
+
+    class _Client:
+        def __init__(self, **kwargs):
+            built.update(kwargs)
+            self.identity = kwargs.get("identity")
+
+        def connect(self, *a, **kw):
+            pass
+
+        def close(self):
+            pass
+
+    svc = _service(ident)
+    with patch.object(service, "HiveMessageBusClient", _Client), \
+            patch.object(service, "HiveMindSlaveProtocol", MagicMock()), \
+            patch.object(service, "create_daemon", lambda *a, **k: None), \
+            patch.object(service, "upstream_config", lambda _cfg: {
+                "enabled": True, "host": "10.0.0.1", "port": 5678,
+                "key": "k", "password": "p", "ssl": False, "self_signed": True}), \
+            patch.object(service, "own_listener_for", lambda *a, **k: None), \
+            patch.object(service, "get_server_config", lambda: {"network_protocol": {}}):
+        svc._connect_upstream(MagicMock())
+
+    assert built.get("identity") is ident, \
+        "the upstream link must use the node's own identity, not a second one"
+
+
+def test_the_service_has_no_second_identity_file():
+    from hivemind_core import service
+
+    assert not hasattr(service, "upstream_identity"), \
+        "a node has one identity"
+
+
+def test_a_configured_private_key_is_kept(tmp_path):
+    """A private key in the config is the node's identity even when the JSON
+    carries no public_key. Generating a new pair would orphan the operator's
+    key and rotate the identity that peers pinned and address INTERCOM to."""
+    from json_database import JsonStorageXDG
+    from poorman_handshake.asymmetric.utils import create_RSA_key, export_RSA_key
+
+    from hivemind_bus_client.identity import NodeIdentity
+    from hivemind_core.service import _ensure_node_identity
+
+    _pub, secret = create_RSA_key()
+    key_path = str(tmp_path / "operator.pem")
+    export_RSA_key(secret, key_path)
+
+    store = JsonStorageXDG("_identity", subfolder="hivemind")
+    store.clear()  # it loaded the real user identity before the path override
+    store["name"] = "operator-node"  # an EMPTY store is falsy and falls back
+    store.path = str(tmp_path / "_identity.json")
+    identity = NodeIdentity(identity_file=store)
+    identity.private_key = key_path
+
+    _ensure_node_identity(identity)
+
+    assert identity.private_key == key_path, "the configured key must survive"
+
+    # the property: what is published is the public half of the key ON DISK,
+    # compared as key material rather than as an encoding
+    from Cryptodome.PublicKey import RSA
+    on_disk = RSA.import_key(open(key_path).read())
+    assert RSA.import_key(identity.public_key).n == on_disk.n, \
+        "the published key must be the public half of the key in use"

--- a/tests/test_presence.py
+++ b/tests/test_presence.py
@@ -15,9 +15,10 @@ from hivemind_core.service import HiveMindService
 
 
 def _service():
-    # avoid touching a real ClientDatabase at construction
+    # avoid touching a real ClientDatabase at construction, and never let the
+    # startup key generation write into the developer's real ~/.config/hivemind
     with mock.patch("hivemind_core.service.ClientDatabase"):
-        return HiveMindService()
+        return HiveMindService(identity=mock.MagicMock())
 
 
 def test_presence_block_in_default_config():

--- a/tests/test_service_availability.py
+++ b/tests/test_service_availability.py
@@ -16,7 +16,9 @@ from hivemind_core.service import HiveMindService
 
 
 def _service(**kwargs):
-    # avoid touching a real ClientDatabase at construction
+    # avoid touching a real ClientDatabase at construction, and never let the
+    # startup key generation write into the developer's real ~/.config/hivemind
+    kwargs.setdefault("identity", mock.MagicMock())
     with mock.patch("hivemind_core.service.ClientDatabase"):
         return HiveMindService(**kwargs)
 

--- a/tests/test_upstream_connection.py
+++ b/tests/test_upstream_connection.py
@@ -52,7 +52,7 @@ def scratch_config_home():
     would come too late. Redirect the folder explicitly instead.
     """
     with tempfile.TemporaryDirectory() as tmp:
-        with patch("hivemind_core.service.JsonConfigXDG",
+        with patch("hivemind_bus_client.identity.JsonConfigXDG",
                    lambda name, subfolder: JsonConfigXDG(
                        name, xdg_folder=tmp, subfolder=subfolder)):
             yield tmp
@@ -129,14 +129,16 @@ class TestUpstreamConfigured(unittest.TestCase):
         # upstream can not hold the node down
         daemon.assert_called_once()
 
-    def test_the_upstream_client_gets_its_own_identity_file(self):
-        """Regression, found by live testing against two real nodes.
+    def test_the_upstream_client_uses_the_nodes_own_identity(self):
+        """A node has one identity and uses it in both directions: the key it
+        answers its own clients with is the key it announces to its master.
 
-        ``HiveMessageBusClient`` copies the credentials it is given onto the
-        identity it holds, and the first Noise handshake saves that identity
-        to disk. Handed the node's own identity, it overwrote the node's
-        ``password`` and ``access_key``, and every downstream satellite then
-        failed its handshake with "invalid api key".
+        A second identity file made a relay two nodes to the mesh — anonymous
+        as a client of its master, keyed as a server to its own clients, with
+        nothing to show they were one. It existed because the client copied
+        the credentials it was given onto the identity it held and the first
+        Noise handshake persisted them; that is fixed in the client, so the
+        node keeps one identity.
         """
         service = _make_service()
 
@@ -147,9 +149,7 @@ class TestUpstreamConfigured(unittest.TestCase):
                 patch("hivemind_core.service.create_daemon"):
             service._connect_upstream(MagicMock())
 
-        identity = client.call_args.kwargs["identity"]
-        self.assertTrue(identity.IDENTITY_FILE.path.endswith(
-            "_identity_upstream.json"), identity.IDENTITY_FILE.path)
+        self.assertIs(client.call_args.kwargs["identity"], service.identity)
 
     def test_ssl_selects_the_wss_scheme(self):
         service = _make_service()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

A node reads its identity from `_identity.json`, and a key that was never generated just reads as None. Nothing on the server path generates one — `hivemind-client set-identity` does that, but that's the client CLI, and an operator running only `hivemind-core` never calls it. So the node runs with no node id for its whole life.

That key matters more than it looks. It's the peer id every PING answer carries, so an unkeyed node answers floods anonymously and can't be placed on a hive map. Loop-suppression hops are keyed on it, so the node never recognizes its own hop in a route. INTERCOM addresses a node by its public key. And cross-implementation handshakes salt the Noise PSK with a hash of the node id — with no node id, different implementations fill in different defaults, so two Python peers agree with each other but nobody else agrees with them.

The deeper fix is that a node should have one identity, not two. There was a separate upstream identity file and a helper that built it, left over from the client copying credentials onto the identity and persisting them on first handshake — that's fixed at the source in the websocket client PR #190, which this PR depends on. The separate file and helper are removed here, and the upstream link now just uses the node's own identity. Because of that dependency, #190 needs to ship first and the client version pin here needs to move to the release that contains it — with the currently released client, using the node's own identity upstream is actively harmful, since it would rewrite the name that the server-side Noise key is derived from and rotate every downstream peer's pinned key out from under them.

Key generation runs after the process status object is built and never raises — a read-only or root-owned config directory is a normal container shape, and a node that can live without a key shouldn't refuse to boot over one. If an operator already configured a secret key, that key's public half gets published instead of generating a fresh pair, since generating fresh would orphan their key and rotate an identity peers already pinned.

I added 8 tests covering node identity, including the configured-key path and the error paths, plus replaced a test that had pinned the old two-file workaround with one that asserts the single-identity property instead. Unit suite: 336 passed. One upgrade note for anyone running this: a peer holding a PSK derived against a null node id will need to re-derive it, since the node now salts with its real id.
