### PR TITLE
fix: admit SHARED_BUS through the message-type allowlist

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -2796,8 +2796,27 @@ class HiveMindListenerProtocol:
             LOG.exception(f"failed to send hive.policy.denied to {client.peer}")
 
     def handle_client_shared_bus(self, message: Message, client: HiveMindClientConnection):
+        """Pass a client's own bus activity to the operator's monitor hook.
+
+        The content is chosen by the client, so it is admitted exactly like a
+        BUS message: the per-client message-type allowlist and the policy
+        chain both apply. Skipping them made ``shared_bus_callback`` a way
+        around the allowlist — a documented extension point that operators
+        wire to logging, aggregation or another system, reached with any
+        message type at all, including by a client whose allowlist is empty
+        and which is therefore denied everything else.
+        """
         # this message is going inside the client bus
         # take any metrics you need
         LOG.info("Monitoring bus from client: " + client.peer)
+        if not client.authorize(message):
+            LOG.warning(client.peer + " sent an unauthorized shared bus message")
+            return
+        verdict = self.policy_chain.review(message, client)
+        if verdict.denied:
+            LOG.info(f"policy denied shared bus '{message.msg_type}' from "
+                     f"{client.peer}: {verdict.code} ({verdict.reason})")
+            self._send_policy_denied(client, message, verdict)
+            return
         if self.shared_bus_callback:
             self.shared_bus_callback(message)

--- a/tests/test_shared_bus_acl.py
+++ b/tests/test_shared_bus_acl.py
@@ -1,0 +1,78 @@
+"""SHARED_BUS carries client-chosen content, so it is admitted like BUS.
+
+`shared_bus_callback` is a documented extension point — operators wire it to
+logging, aggregation, or another system. Reaching it without the per-client
+message-type allowlist made it a way around that allowlist, including for a
+client whose allowlist is empty and which is therefore denied everything else.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+
+from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
+
+
+def _protocol(allowed_types, **kwargs):
+    """The policy re-reads the allowlist from the DB so a grant or revocation
+    takes effect without a reconnect, so the DB row is what the test sets."""
+    db_user = MagicMock()
+    db_user.allowed_types = list(allowed_types)
+    db_user.intent_blacklist = []
+    db_user.skill_blacklist = []
+    db_user.message_blacklist = []
+    db_user.is_admin = False
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+    return HiveMindListenerProtocol(agent_protocol=MagicMock(), db=db, **kwargs)
+
+
+def _client(protocol, allowed_types):
+    client = HiveMindClientConnection(
+        key="access-key", send_msg=MagicMock(), disconnect=MagicMock(),
+        hm_protocol=protocol,
+    )
+    client.name = "sat"
+    client.allowed_types = allowed_types
+    client.intent_blacklist = []
+    client.skill_blacklist = []
+    client.message_blacklist = []
+    client.is_admin = False
+    return client
+
+
+def test_a_type_the_client_may_not_send_does_not_reach_the_monitor_hook():
+    protocol = _protocol(["recognizer_loop:utterance"])
+    seen = []
+    protocol.shared_bus_callback = seen.append
+    client = _client(protocol, allowed_types=["recognizer_loop:utterance"])
+
+    protocol.handle_client_shared_bus(
+        Message("mycroft.skills.shutdown", {}), client)
+
+    assert seen == [], "the allowlist must apply to SHARED_BUS too"
+
+
+def test_an_empty_allowlist_denies_shared_bus_as_well():
+    """An empty allowlist is deny-all; it must not leave one door open."""
+    protocol = _protocol([])
+    seen = []
+    protocol.shared_bus_callback = seen.append
+    client = _client(protocol, allowed_types=[])
+
+    protocol.handle_client_shared_bus(Message("anything.at.all", {}), client)
+
+    assert seen == []
+
+
+def test_an_allowed_type_still_reaches_the_monitor_hook():
+    """The control: gating must not disable passive bus sharing."""
+    protocol = _protocol(["recognizer_loop:utterance"])
+    seen = []
+    protocol.shared_bus_callback = seen.append
+    client = _client(protocol, allowed_types=["recognizer_loop:utterance"])
+
+    protocol.handle_client_shared_bus(
+        Message("recognizer_loop:utterance", {"utterances": ["hello"]}), client)
+
+    assert len(seen) == 1
+    assert seen[0].msg_type == "recognizer_loop:utterance"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

**Withdrawn — the premise was wrong.**

This proposed gating `SHARED_BUS` through `client.authorize()` and the policy chain, on the grounds that it was a way around the per-client message-type allowlist. Adversarial review refuted that on two counts, both reproduced by execution.

**`allowed_types` is an injection whitelist, and SHARED_BUS is not injection.** A satellite with `share_bus` mirrors its *whole* local bus: `bus.on("message", handle_outgoing_mycroft)` is a catch-all, and every outgoing message is wrapped as `SHARED_BUS`. Gating on the allowlist means a client granted the recommended single type loses its entire monitoring feed on upgrade — measured at 6 mirrored messages before, 1 after. `shared_bus_callback` also defaults to `None` and never injects into the agent bus, so what was being "bypassed" is hook visibility, not injection.

**The deny reply forms an unbounded loop.** `_send_policy_denied` sends a BUS frame, the client emits it on its internal bus, the catch-all re-shares it as `SHARED_BUS`, `hive.policy.denied` is not in `allowed_types`, and it is denied again. Reproduced: 20 denies / 21 shares before the limiter stopped it.

No replacement is proposed. Passive whole-bus mirroring to an operator-configured hook is the documented design of this message type.