### PR TITLE
fix: answer PING floods when the agent bus is unreachable

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1956,12 +1956,23 @@ class HiveMindListenerProtocol:
         # dedup gate: a flood we already answered keeps carrying peers we have
         # never seen, and those are the discoveries.
         if new_to_map:
-            self.agent_protocol.bus.emit(Message("hive.ping.received", {
-                "flood_id": flood_id,
-                "peer": ping_payload.get("peer"),
-                "site_id": ping_payload.get("site_id"),
-                "timestamp": ping_payload.get("timestamp"),
-            }))
+            # Telemetry on the way past, not a step in answering. A flood is
+            # asked precisely when something is wrong, and an unreachable OVOS
+            # bus is one of the things being diagnosed — letting that failure
+            # out of here silenced the node's answer and made a hive that was
+            # merely missing its agent look unreachable. Same reasoning as
+            # _emit_lifecycle: log and carry on.
+            try:
+                self.agent_protocol.bus.emit(Message("hive.ping.received", {
+                    "flood_id": flood_id,
+                    "peer": ping_payload.get("peer"),
+                    "site_id": ping_payload.get("site_id"),
+                    "timestamp": ping_payload.get("timestamp"),
+                }))
+            except Exception as e:
+                LOG.error(f"can not publish 'hive.ping.received' for "
+                          f"{ping_payload.get('peer')}, the agent bus is "
+                          f"unreachable: {e}")
 
         # Flood-loop prevention (MSG-1 §4): answer a flood at most once.
         #

--- a/tests/test_ping_survives_agent_bus.py
+++ b/tests/test_ping_survives_agent_bus.py
@@ -1,0 +1,82 @@
+"""Topology discovery must not depend on the agent backend.
+
+A PING flood is how an operator asks which nodes are reachable. It is asked
+precisely when something is wrong, and "the OVOS bus on that node is down" is
+one of the things being diagnosed. Answering a flood needs nothing from the
+agent bus: the reply is built from the node's own identity.
+
+`hive.ping.received` is a telemetry emit on the way past, and the node already
+treats agent-bus notifications that way everywhere else — `_emit_lifecycle`
+logs and continues, because "the connection still has to be accepted, cleaned
+up or rejected, and the peer has nothing to act on".
+"""
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
+
+
+def _protocol(bus_error=None):
+    agent = MagicMock()
+    if bus_error is not None:
+        agent.bus.emit.side_effect = bus_error
+    return HiveMindListenerProtocol(agent_protocol=agent, db=MagicMock())
+
+
+def _client(protocol):
+    sent = []
+    client = HiveMindClientConnection(
+        key="access-key", send_msg=MagicMock(), disconnect=MagicMock(),
+        hm_protocol=protocol,
+    )
+    client.name = "sat"
+    client.send = lambda *args, **kwargs: sent.append(args)
+    # the answer fans out to connected peers, so the peer must be connected
+    protocol.clients[client.peer] = client
+    return client, sent
+
+
+def _ping(flood_id="f1"):
+    return HiveMessage(HiveMessageType.PING, {
+        "flood_id": flood_id, "peer": "sat::1", "site_id": "lab",
+        "timestamp": 1.0,
+    })
+
+
+def test_a_flood_is_answered_when_the_agent_bus_is_unreachable():
+    protocol = _protocol(bus_error=ConnectionError("agent bus is down"))
+    client, sent = _client(protocol)
+
+    protocol.handle_ping_message(_ping(), client)
+
+    assert sent, "an unreachable agent bus must not silence topology discovery"
+
+
+def test_a_broken_agent_bus_does_not_raise_out_of_the_handler():
+    """The handler runs on the connection's IO path; raising there takes the
+    rest of the message's handling with it."""
+    protocol = _protocol(bus_error=RuntimeError("bus exploded"))
+    client, _ = _client(protocol)
+
+    protocol.handle_ping_message(_ping(), client)  # must not raise
+
+
+def test_the_flood_is_still_answered_when_the_bus_works():
+    """The control: the telemetry emit is not what produces the answer."""
+    protocol = _protocol()
+    client, sent = _client(protocol)
+
+    protocol.handle_ping_message(_ping(), client)
+
+    assert sent
+
+
+def test_the_observation_is_still_published_when_the_bus_works():
+    protocol = _protocol()
+    client, _ = _client(protocol)
+
+    protocol.handle_ping_message(_ping(), client)
+
+    emitted = [c.args[0].msg_type for c in protocol.agent_protocol.bus.emit.call_args_list]
+    assert "hive.ping.received" in emitted


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

A PING flood is how an operator checks which nodes are reachable, and it gets asked precisely when something is wrong — "is the OVOS bus on that node down" is one of the things it's meant to diagnose. Answering a flood doesn't need anything from the agent bus, the reply is built entirely from the node's own identity. But the telemetry emit for a received ping was unguarded, so an unreachable agent bus raised an exception before the reply was even built. The node went silent to every flood while still serving its clients fine, and looked unreachable to the exact tool asking whether it was reachable.

I saw this in a three-layer reference hive: with the OVOS buses stopped, a flood from a leaf got zero answers back; with them running, the same flood got answered normally. The node already handles agent-bus notifications this way everywhere else in the code — log it and move on, because the connection still needs to be accepted or cleaned up regardless, and the peer has nothing useful to act on from a telemetry failure.

I added four tests. The two asserting the fix fail against unfixed dev, verified by reverting the patch. The other two are controls confirming that with a working bus, both the ping answer and the telemetry are still produced, so the guard isn't quietly swallowing anything it shouldn't. Unit suite on the rebased result: 332 passed, the 328 baseline plus exactly the four new tests.
