### PR TITLE
fix: rename-client must not blank the name it was not given

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -92,8 +92,12 @@ hivemind-core list-clients
 
 ## `rename-client`
 
+`--name` is required. `NODE_ID` accepts the client's database id or its
+access key.
+
 ```bash
 hivemind-core rename-client 1 --name "new name"
+hivemind-core rename-client 42caf3d2405075fb9e7a4e1ff44e4c4f --name "new name"
 ```
 
 ---

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -100,11 +100,14 @@ hivemind-core export-clients [--path PATH]
 
 ### `rename-client`
 
-Rename a registered client.
+Rename a registered client. `--name` is required — the command edits a
+name, it does not clear one.
 
 ```bash
-hivemind-core rename-client [NODE_ID] [--name NAME]
+hivemind-core rename-client NODE_ID --name NAME
 ```
+
+`NODE_ID` accepts either the client's database id or its access key.
 
 ---
 

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -212,9 +212,21 @@ def add_client(name, access_key, password, crypto_key, admin, metadata, allow_we
 
 
 @hmcore_cmds.command(help="Rename a client in the database.", name="rename-client")
-@click.argument("node_id", required=False, type=int)
-@click.option("--name", required=False, type=str, help="The new friendly name for the client")
+@click.argument("node_id", required=False, type=str)
+@click.option("--name", required=True, type=str, help="The new friendly name for the client")
 def rename_client(node_id, name):
+    """Rename a client.
+
+    ``--name`` is required. It used to be optional and was assigned
+    unconditionally, so omitting it blanked the client's name and printed
+    "Renamed 'kitchen' to None" — a destructive edit reported as a success,
+    with no way to recover the old name.
+
+    ``node_id`` is a string for the same reason as in ``reset-noise-pin``:
+    the node names clients by access key in its logs, and coercing to int
+    rejected the value an operator would copy from there before
+    ``resolve_client`` ever saw it.
+    """
     with ClientDatabase() as db:
         client = resolve_client(db, node_id)
         if client is None:
@@ -223,7 +235,7 @@ def rename_client(node_id, name):
         old_name = client.name
         client.name = name
         db.update_item(client)
-        print(f"Renamed '{old_name}' to {name}")
+        print(f"Renamed '{old_name}' to '{name}'")
 
 
 @hmcore_cmds.command(

--- a/tests/test_rename_client.py
+++ b/tests/test_rename_client.py
@@ -1,0 +1,83 @@
+"""`rename-client` must not destroy a name it was never given.
+
+`--name` was optional and assigned unconditionally, so `rename-client 1` with
+no name blanked the client's friendly name and printed "Renamed 'kitchen' to
+None" — a destructive edit reported as a success, with the old value
+unrecoverable.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from hivemind_core.scripts import rename_client
+
+
+class _DB:
+    def __init__(self, client):
+        self.client = client
+        self.updated = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    def update_item(self, client):
+        self.updated.append(client)
+
+
+def _client(**kw):
+    return SimpleNamespace(name="kitchen", client_id=1,
+                           api_key="c0d14821bbece410349e2541", **kw)
+
+
+def _run(db, client, *args):
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client):
+        return CliRunner().invoke(rename_client, list(args))
+
+
+def test_a_missing_name_is_refused_and_changes_nothing():
+    client = _client()
+    db = _DB(client)
+
+    result = _run(db, client, "1")
+
+    assert result.exit_code != 0, result.output
+    assert client.name == "kitchen", "the old name must survive"
+    assert db.updated == [], "nothing may be written"
+
+
+def test_a_name_is_applied():
+    client = _client()
+    db = _DB(client)
+
+    result = _run(db, client, "1", "--name", "living-room")
+
+    assert result.exit_code == 0, result.output
+    assert client.name == "living-room"
+    assert db.updated == [client]
+
+
+def test_the_access_key_the_logs_print_is_accepted():
+    """The node names clients by access key; coercing to int rejected that
+    value before resolve_client ever saw it."""
+    client = _client()
+    db = _DB(client)
+
+    result = _run(db, client, "c0d14821bbece410349e2541", "--name", "hall")
+
+    assert result.exit_code == 0, result.output
+    assert "not a valid integer" not in result.output
+    assert client.name == "hall"
+
+
+def test_an_unknown_node_is_reported_and_writes_nothing():
+    db = _DB(None)
+
+    result = _run(db, None, "99", "--name", "whatever")
+
+    assert "Invalid Node ID" in result.output
+    assert db.updated == []


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

`--name` on `rename-client` was optional but got assigned unconditionally, so running the command without it renamed the client to the literal string "None" and reported that as a success, with the old name gone for good. `--name` is now required, so that can't happen.

While in there, I also changed `node_id` to accept a string instead of requiring an integer, for the same reason `reset-noise-pin` already does: the node logs clients by access key, and click was rejecting that value as "not a valid integer" before the code that resolves either form ever got to see it.

I added four tests. The two asserting the fixes fail against unfixed dev, verified by reverting the patch. The others are controls confirming a real rename still works and an unknown node id writes nothing. Unit suite on the rebased result: 332 passed, the 328 baseline plus exactly the four new tests.
