### PR TITLE
fix: gate QUERY/CASCADE response routing behind the request-path ACL check

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -25,6 +25,9 @@ The server enforces access control through `ClientDatabase` and `HiveMindClientC
 - **Message whitelist**: `MessageTypeACLPolicy` checks each client's `allowed_types` whitelist during routing. See [Policy Admission Chain](policy.md).
 - **Skill/intent blacklisting**: restrict which AI skills a specific satellite can trigger with `hivemind-core blacklist-skill` and `blacklist-intent` (`hivemind_core.scripts`).
 - **Node-level isolation**: clients only receive messages meant for them, or broadcast to their permission level, as defined by `HiveMindNodeType` in `hivemind_core.protocol`.
+- **QUERY/CASCADE response routing**: `is_response` metadata on a QUERY or CASCADE message is checked against the same `can_escalate`/`can_propagate` permission as an original request, and checked before the response is routed. `_route_query_response` trusts `metadata.originator_peer` as a bare delivery address, with no proof the sender ever took part in that `query_id`; without the permission gate, a client with no escalate/propagate rights could forge `{"is_response": true, "originator_peer": <victim>}` around an arbitrary payload and have it delivered to the victim's connection.
+
+  This closes the unprivileged forgery path, not every forgery path: a client that does hold escalate/propagate permission can still address a response at a peer for a query it never participated in, because the server keeps no per-query record of who actually asked, and routing trusts the sender's own claimed `originator_peer`. A privileged sender is still bounded by whatever the message-type ACL and its own permission scope allow, but response addressing itself is not verified against the query.
 
 ---
 [← Installation](installation.md) · [Home](index.md) · [Protocol →](protocol.md)

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -2342,18 +2342,25 @@ class HiveMindListenerProtocol:
         """
         LOG.info(f"Received QUERY from: {client.peer}")
         metadata = message.metadata or {}
+        if not client.can_escalate:
+            # HIVEMIND-AGENT-1 §3.2: a client without escalate permission may
+            # not author a QUERY, and that includes forging a fake "response"
+            # to smuggle an arbitrary payload to an arbitrary peer by name
+            # (metadata.originator_peer) — the response branch below trusts
+            # that field with no other proof of participation, so it must be
+            # gated by the same permission as the request branch, not skipped
+            # ahead of it.
+            LOG.warning("Received QUERY from client without escalate permission")
+            if self.illegal_callback:
+                self.illegal_callback(self._unpack_message(message, client))
+            client.disconnect()
+            return
+
         if metadata.get("is_response", False):
             self._route_query_response(message, client)
             return
 
         payload = self._unpack_message(message, client)
-        if not client.can_escalate:
-            LOG.warning("Received QUERY from client without escalate permission")
-            if self.illegal_callback:
-                self.illegal_callback(payload)
-            client.disconnect()
-            return
-
         query_id = metadata.get("query_id", str(uuid.uuid4()))
         originator_peer = metadata.get("originator_peer", client.peer)
         try:
@@ -2406,16 +2413,24 @@ class HiveMindListenerProtocol:
         downstream toward the originator."""
         LOG.info(f"Received CASCADE from: {client.peer}")
         metadata = message.metadata or {}
+        if not client.can_propagate:
+            # See the matching comment in handle_query_message: the
+            # is_response branch below trusts an attacker-supplied
+            # originator_peer as a delivery address, so it must be gated by
+            # the same permission as the request branch, not skipped ahead
+            # of it (HIVEMIND-AGENT-1 §3.2).
+            LOG.warning("Received CASCADE from client without propagate "
+                        "permission")
+            if self.illegal_callback:
+                self.illegal_callback(self._unpack_message(message, client))
+            client.disconnect()
+            return
+
         if metadata.get("is_response", False):
             self._route_query_response(message, client)
             return
 
         payload = self._unpack_message(message, client)
-        if not client.can_propagate:
-            if self.illegal_callback:
-                self.illegal_callback(payload)
-            client.disconnect()
-            return
 
         # HIVEMIND-MSG-1 §5 gates re-forwarding of a looped message, not local
         # handling; suppress only the fan-out + master-forward at the end.

--- a/tests/test_response_forgery_acl.py
+++ b/tests/test_response_forgery_acl.py
@@ -1,0 +1,124 @@
+"""Regression tests: a client without escalate/propagate permission must not
+be able to forge a QUERY/CASCADE "response" to smuggle an arbitrary payload
+to an arbitrary peer.
+
+``handle_query_message``/``handle_cascade_message`` used to check
+``metadata.get("is_response")`` and dispatch straight to
+``_route_query_response`` *before* the ``can_escalate``/``can_propagate``
+gate that every request goes through. ``_route_query_response`` trusts
+``metadata["originator_peer"]`` as a bare delivery address with no proof the
+sender ever participated in that ``query_id`` — so an unprivileged client
+could forge ``{"is_response": True, "originator_peer": <victim>}`` around any
+payload and have it delivered verbatim to the victim's connection, bypassing
+the ACL entirely (HIVEMIND-AGENT-1 §3.2). The permission check now runs
+before the is_response branch, exactly like it already ran before the
+request branch.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_protocol():
+    proto = object.__new__(HiveMindListenerProtocol)
+    proto.peer = "master:0.0.0.0"
+    proto.identity = MagicMock(public_key="master-pubkey", site_id=None)
+    proto.clients = {}
+    proto.illegal_callback = MagicMock()
+    proto.cascade_select_callback = None
+    proto._pending_cascades = {}
+    return proto
+
+
+def _make_client(peer, **flags):
+    client = MagicMock()
+    client.peer = peer
+    client.is_admin = flags.get("is_admin", False)
+    client.can_propagate = flags.get("can_propagate", False)
+    client.can_escalate = flags.get("can_escalate", False)
+    return client
+
+
+def _forged_response(msg_type, originator_peer, query_id="not-a-real-query"):
+    inner = HiveMessage(HiveMessageType.BUS,
+                        payload={"type": "speak",
+                                 "data": {"utterance": "ATTACKER INJECTED THIS"},
+                                 "context": {}})
+    return HiveMessage(msg_type, payload=inner,
+                       metadata={"query_id": query_id,
+                                 "originator_peer": originator_peer,
+                                 "responder_peer": "attacker::1",
+                                 "is_response": True})
+
+
+def _wire(proto, peer):
+    conn = MagicMock()
+    conn.send = MagicMock()
+    proto.clients[peer] = conn
+    return conn
+
+
+# --- the defect: an unprivileged client must not be able to forge a response
+
+def test_forged_query_response_from_unprivileged_client_is_dropped():
+    proto = _make_protocol()
+    attacker = _make_client("attacker::1", can_escalate=False)
+    victim_conn = _wire(proto, "victim::1")
+
+    proto.handle_query_message(
+        _forged_response(HiveMessageType.QUERY, "victim::1"), attacker)
+
+    victim_conn.send.assert_not_called()
+    proto.illegal_callback.assert_called_once()
+    attacker.disconnect.assert_called_once_with()
+
+
+def test_forged_cascade_response_from_unprivileged_client_is_dropped():
+    proto = _make_protocol()
+    attacker = _make_client("attacker::1", can_propagate=False)
+    victim_conn = _wire(proto, "victim::1")
+
+    proto.handle_cascade_message(
+        _forged_response(HiveMessageType.CASCADE, "victim::1"), attacker)
+
+    victim_conn.send.assert_not_called()
+    proto.illegal_callback.assert_called_once()
+    attacker.disconnect.assert_called_once_with()
+
+
+# --- positive control: a legitimate in-flight response must still land -----
+
+def test_legitimate_query_response_still_reaches_its_originator():
+    proto = _make_protocol()
+    responder = _make_client("responder::1", can_escalate=True)
+    originator_conn = _wire(proto, "originator::1")
+
+    response = _forged_response(HiveMessageType.QUERY, "originator::1",
+                                query_id="real-query-42")
+    # simulate a genuinely privileged responder answering a real query
+    response.metadata["responder_peer"] = responder.peer
+
+    proto.handle_query_message(response, responder)
+
+    originator_conn.send.assert_called_once_with(response)
+    proto.illegal_callback.assert_not_called()
+    responder.disconnect.assert_not_called()
+
+
+def test_legitimate_cascade_response_still_reaches_its_originator():
+    proto = _make_protocol()
+    responder = _make_client("responder::1", can_propagate=True)
+    originator_conn = _wire(proto, "originator::1")
+
+    response = _forged_response(HiveMessageType.CASCADE, "originator::1",
+                                query_id="real-query-42")
+    response.metadata["responder_peer"] = responder.peer
+
+    proto.handle_cascade_message(response, responder)
+
+    originator_conn.send.assert_called_once_with(response)
+    proto.illegal_callback.assert_not_called()
+    responder.disconnect.assert_not_called()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

`handle_query_message` and `handle_cascade_message` both checked whether a message was flagged as a response and routed it before they ever reached the permission gate that every normal request has to pass through. The response router forwards based on an "originator peer" field the client itself supplies, with nothing proving the sender actually took part in that query. So a client could just forge a response message naming a victim as the originator, and have arbitrary content delivered straight to that victim's connection, completely bypassing its access controls.

I reproduced this live against a running protocol instance with a client that had both escalate and propagate permissions turned off, and got a forged message delivered to the victim carrying an injected utterance. A control run in the same session confirmed the permission gate does exist and work normally — a plain request from the same low-privilege client got disconnected as expected. Only the response branch was skipping it.

The fix moves the permission check ahead of the response branch in both handlers, so a forged response is now treated exactly like an illegal request: logged and the client disconnected. The cascade handler had no log line on this rejection path, unlike the query handler, so I added one — a silent disconnect here would have been impossible to diagnose.

This doesn't close everything. A privileged client can still address a response to a peer for a query it never actually took part in, because there's no bookkeeping today that could prove that either way. Fixing that properly needs recording which query went to which peer when it's relayed, then checking against that on the way back — that's follow-up work, deliberately not bolted on here. There's also one compatibility wrinkle worth knowing: cascade fan-out goes to every connected client regardless of propagate permission, so a downstream node configured without that permission could previously answer a cascade and now gets refused — arguably that was misconfiguration to begin with, and the new log line at least explains why instead of failing silently. Only hivemind-core produces these responses; the ordinary bus client has no such code path, so this can't affect a normal satellite.

I verified fail-before by reverting the patch, not stashing: the two forgery tests fail against the unfixed source with the payload actually reaching the victim, and the two legitimate-response controls pass both before and after, pinning the good path rather than the bug. Four new adversarial tests total. Gate was run on an idle 24-core host rather than the local box, which was under heavy load and producing spurious failures at the time: origin/dev showed 384 passed, this branch showed 388 passed — exactly the four new tests, with skip and xpass counts unchanged. I reproduced the forgery and reran the gate myself rather than trusting a report.
