### PR TITLE
fix: CLI client commands accept an access key, not only a numeric id

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,7 +1,9 @@
 # CLI Reference
 
-All administration is done through the `hivemind-core` command. If you omit the numeric
-client ID from any command that requires one, you will be prompted to select interactively.
+All administration is done through the `hivemind-core` command. Any command that takes a
+client ID accepts either the client's numeric database id or its access key (the identifier
+a node prints in its own logs). If you omit the ID from a command that requires one, you
+will be prompted to select interactively.
 
 ```
 Usage: hivemind-core [OPTIONS] COMMAND [ARGS]...

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,7 +6,7 @@ All commands are available under the `hivemind-core` entry point.
 hivemind-core [COMMAND] [OPTIONS]
 ```
 
-If `node_id` is optional on a command and is not provided, you will be shown an interactive client selection table.
+`NODE_ID` accepts either the client's database id or its access key (the identifier a node prints in its own logs), on every command that takes one. If `node_id` is optional on a command and is not provided, you will be shown an interactive client selection table.
 
 ---
 

--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -277,7 +277,7 @@ def reset_noise_pin(node_id):
 
 
 @hmcore_cmds.command(help="Give administrator powers to a client in the database.", name="make-admin")
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def make_admin(node_id):
     with ClientDatabase() as db:
         client = resolve_client(db, node_id)
@@ -293,7 +293,7 @@ def make_admin(node_id):
 
 
 @hmcore_cmds.command(help="Revoke administrator powers from a client in the database.", name="revoke-admin")
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def revoke_admin(node_id):
     with ClientDatabase() as db:
         client = resolve_client(db, node_id)
@@ -309,12 +309,26 @@ def revoke_admin(node_id):
 
 
 @hmcore_cmds.command(help="Remove credentials for a client.", name="delete-client")
-@click.argument("node_id", required=False, type=int)
-def delete_client(node_id):
+@click.argument("node_id", required=False, type=str)
+@click.option("--yes", is_flag=True, default=False,
+              help="Skip the confirmation prompt (for scripting).")
+def delete_client(node_id, yes):
+    """Delete a client, permanently revoking its credentials.
+
+    Destructive, so it always confirms before deleting — including when
+    ``node_id`` is omitted and there is exactly one client: without this,
+    a bare ``delete-client`` would silently auto-select and remove the
+    only client on the server. ``--yes`` skips the prompt for scripting.
+    """
     with ClientDatabase() as db:
         client = resolve_client(db, node_id)
         if client is None:
             print("Invalid Node ID!")
+            return
+        if not yes and not click.confirm(
+                f"Delete client '{client.name}' (id {client.client_id})? "
+                "This permanently revokes its credentials."):
+            print("Aborted.")
             return
         db.delete_client(client.api_key)
         print("Revoked credentials!\n")
@@ -371,7 +385,7 @@ def export_clients(path):
 
 @hmcore_cmds.command(help="Allow a message type to be sent from a client.", name="allow-msg")
 @click.argument("msg_type", required=True, type=str)
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def allow_msg(msg_type, node_id):
     with ClientDatabase() as db:
         client = resolve_client(db, node_id)
@@ -388,7 +402,7 @@ def allow_msg(msg_type, node_id):
 
 @hmcore_cmds.command(help="Blacklist a message type from a client.", name="blacklist-msg")
 @click.argument("msg_type", required=True, type=str)
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def blacklist_msg(msg_type, node_id):
     with ClientDatabase() as db:
         client = resolve_client(db, node_id)
@@ -435,7 +449,7 @@ def toggle_capability(label: str, node_id, allow: bool) -> None:
 
 
 @hmcore_cmds.command(help="allow 'BROADCAST' messages to be sent from a client", name="allow-broadcast")
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def allow_broadcast(node_id):
     """Grant a client permission to send 'BROADCAST' messages.
 
@@ -443,60 +457,56 @@ def allow_broadcast(node_id):
     this grant only narrows it.
     """
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if client.can_broadcast:
-                    print(f"Client {client.name} already allowed to send 'BROADCAST' messages")
-                    exit()
-                client.can_broadcast = True
-                db.update_item(client)
-                print(f"Allowed 'BROADCAST' messages for {client.name}")
-                if not client.is_admin:
-                    print(f"NOTE: {client.name} is not an admin, so it still can not broadcast")
-                break
-        else:
+        client = resolve_client(db, node_id)
+        if client is None:
             print("Invalid Node ID!")
+            return
+        if client.can_broadcast:
+            print(f"Client {client.name} already allowed to send 'BROADCAST' messages")
+            exit()
+        client.can_broadcast = True
+        db.update_item(client)
+        print(f"Allowed 'BROADCAST' messages for {client.name}")
+        if not client.is_admin:
+            print(f"NOTE: {client.name} is not an admin, so it still can not broadcast")
 
 
 @hmcore_cmds.command(help="blacklist 'BROADCAST' messages from being sent by a client", name="blacklist-broadcast")
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def blacklist_broadcast(node_id):
     with ClientDatabase() as db:
-        node_id = node_id or prompt_node_id(db)
-        for client in db:
-            if client.client_id == int(node_id):
-                if client.can_broadcast:
-                    client.can_broadcast = False
-                    db.update_item(client)
-                    print(f"Blacklisted 'BROADCAST' messages for {client.name}")
-                    return
-                print(f"Client '{client.name}' 'BROADCAST' messages already blacklisted")
-                break
-        else:
+        client = resolve_client(db, node_id)
+        if client is None:
             print("Invalid Node ID!")
+            return
+        if client.can_broadcast:
+            client.can_broadcast = False
+            db.update_item(client)
+            print(f"Blacklisted 'BROADCAST' messages for {client.name}")
+            return
+        print(f"Client '{client.name}' 'BROADCAST' messages already blacklisted")
 
 
 @hmcore_cmds.command(help="Allow 'ESCALATE' messages to be sent from a client.", name="allow-escalate")
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def allow_escalate(node_id):
     toggle_capability("ESCALATE", node_id, allow=True)
 
 
 @hmcore_cmds.command(help="blacklist 'ESCALATE' messages from being sent by a client", name="blacklist-escalate")
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def blacklist_escalate(node_id):
     toggle_capability("ESCALATE", node_id, allow=False)
 
 
 @hmcore_cmds.command(help="allow 'PROPAGATE' messages to be sent from a client", name="allow-propagate")
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def allow_propagate(node_id):
     toggle_capability("PROPAGATE", node_id, allow=True)
 
 
 @hmcore_cmds.command(help="blacklist 'PROPAGATE' messages from being sent by a client", name="blacklist-propagate")
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def blacklist_propagate(node_id):
     toggle_capability("PROPAGATE", node_id, allow=False)
 
@@ -542,7 +552,7 @@ def _toggle_metadata_blacklist(metadata_key: str, value: str,
                           "OVOSAgentPolicy in the server's policy.chain.",
                      name="blacklist-skill")
 @click.argument("skill_id", required=True, type=str)
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def blacklist_skill(skill_id, node_id):
     _toggle_metadata_blacklist("skill_blacklist", skill_id, node_id, add=True)
 
@@ -551,7 +561,7 @@ def blacklist_skill(skill_id, node_id):
                           "requires OVOSAgentPolicy in the server's policy.chain.",
                      name="allow-skill")
 @click.argument("skill_id", required=True, type=str)
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def unblacklist_skill(skill_id, node_id):
     _toggle_metadata_blacklist("skill_blacklist", skill_id, node_id, add=False)
 
@@ -560,7 +570,7 @@ def unblacklist_skill(skill_id, node_id):
                           "OVOSAgentPolicy in the server's policy.chain.",
                      name="blacklist-intent")
 @click.argument("intent_id", required=True, type=str)
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def blacklist_intent(intent_id, node_id):
     _toggle_metadata_blacklist("intent_blacklist", intent_id, node_id, add=True)
 
@@ -569,7 +579,7 @@ def blacklist_intent(intent_id, node_id):
                           "requires OVOSAgentPolicy in the server's policy.chain.",
                      name="allow-intent")
 @click.argument("intent_id", required=True, type=str)
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 def unblacklist_intent(intent_id, node_id):
     _toggle_metadata_blacklist("intent_blacklist", intent_id, node_id, add=False)
 
@@ -580,7 +590,7 @@ def unblacklist_intent(intent_id, node_id):
          "other policies may read their own keys. Merge a JSON object with --metadata "
          "and/or set one entry with --key/--value; --unset removes a key.",
     name="set-metadata")
-@click.argument("node_id", required=False, type=int)
+@click.argument("node_id", required=False, type=str)
 @click.option("--metadata", required=False, type=str,
               help="JSON object merged into the client's metadata.")
 @click.option("--key", required=False, type=str,

--- a/tests/test_cli_accepts_access_key.py
+++ b/tests/test_cli_accepts_access_key.py
@@ -1,0 +1,200 @@
+"""Most client-targeting commands declared ``node_id`` as ``type=int``, which
+rejects the access key the tool itself tells operators to use (the node
+names clients by access key in its logs — see ``rename-client``'s and
+``reset-noise-pin``'s docstrings, and ``resolve_client``, which already
+accepts either form). This covers every command that was still declaring
+``type=int`` before this fix, plus ``allow-broadcast``/``blacklist-broadcast``
+which hand-rolled their own ``int(node_id)`` lookup instead of going through
+``resolve_client``.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from hivemind_core.scripts import (
+    allow_broadcast,
+    allow_escalate,
+    allow_msg,
+    allow_propagate,
+    blacklist_broadcast,
+    blacklist_escalate,
+    blacklist_intent,
+    blacklist_msg,
+    blacklist_propagate,
+    blacklist_skill,
+    delete_client,
+    make_admin,
+    revoke_admin,
+    set_metadata,
+    unblacklist_intent as allow_intent,
+    unblacklist_skill as allow_skill,
+)
+
+ACCESS_KEY = "c0d14821bbece410349e2541"
+
+
+class _DB:
+    def __init__(self, client):
+        self.client = client
+        self.updated = []
+        self.deleted = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+    def __iter__(self):
+        return iter([self.client] if self.client else [])
+
+    def update_item(self, client):
+        self.updated.append(client)
+
+    def delete_client(self, api_key):
+        self.deleted.append(api_key)
+
+
+def _client(**kw):
+    base = dict(
+        name="kitchen",
+        client_id=1,
+        api_key=ACCESS_KEY,
+        allowed_types=[],
+        is_admin=False,
+        can_escalate=False,
+        can_propagate=False,
+        can_broadcast=False,
+        metadata={},
+        password="pw",
+        crypto_key="ck",
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# Commands that take only a node_id argument (no other required args).
+SIMPLE_COMMANDS = [
+    make_admin,
+    revoke_admin,
+    allow_escalate,
+    blacklist_escalate,
+    allow_propagate,
+    blacklist_propagate,
+]
+
+
+@pytest.mark.parametrize("cmd", SIMPLE_COMMANDS)
+def test_access_key_is_accepted(cmd):
+    client = _client()
+    db = _DB(client)
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client) as resolve:
+        result = CliRunner().invoke(cmd, [ACCESS_KEY])
+    assert "not a valid integer" not in result.output
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with(db, ACCESS_KEY)
+
+
+@pytest.mark.parametrize("cmd", SIMPLE_COMMANDS)
+def test_numeric_id_still_works(cmd):
+    client = _client()
+    db = _DB(client)
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client) as resolve:
+        result = CliRunner().invoke(cmd, ["1"])
+    assert "not a valid integer" not in result.output
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with(db, "1")
+
+
+@pytest.mark.parametrize("cmd,extra_arg", [
+    (allow_msg, "recognizer_loop:utterance"),
+    (blacklist_msg, "recognizer_loop:utterance"),
+])
+def test_msg_type_commands_accept_access_key(cmd, extra_arg):
+    client = _client(allowed_types=[extra_arg] if cmd is blacklist_msg else [])
+    db = _DB(client)
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client) as resolve:
+        result = CliRunner().invoke(cmd, [extra_arg, ACCESS_KEY])
+    assert "not a valid integer" not in result.output
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with(db, ACCESS_KEY)
+
+
+@pytest.mark.parametrize("cmd,extra_arg", [
+    (blacklist_skill, "skill.id"),
+    (allow_skill, "skill.id"),
+    (blacklist_intent, "intent.id"),
+    (allow_intent, "intent.id"),
+])
+def test_skill_intent_commands_accept_access_key(cmd, extra_arg):
+    client = _client(metadata={"skill_blacklist": ["skill.id"], "intent_blacklist": ["intent.id"]})
+    db = _DB(client)
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client) as resolve:
+        result = CliRunner().invoke(cmd, [extra_arg, ACCESS_KEY])
+    assert "not a valid integer" not in result.output
+    resolve.assert_called_once_with(db, ACCESS_KEY)
+
+
+def test_set_metadata_accepts_access_key():
+    client = _client(metadata={})
+    db = _DB(client)
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client) as resolve:
+        result = CliRunner().invoke(
+            set_metadata, [ACCESS_KEY, "--key", "foo", "--value", "bar"])
+    assert "not a valid integer" not in result.output
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with(db, ACCESS_KEY)
+
+
+@pytest.mark.parametrize("cmd", [allow_broadcast, blacklist_broadcast])
+def test_broadcast_commands_now_route_through_resolve_client(cmd):
+    """These used to hand-roll ``int(node_id)`` lookups instead of using
+    ``resolve_client``, so an access key could never work for them either."""
+    client = _client(can_broadcast=(cmd is blacklist_broadcast), is_admin=True)
+    db = _DB(client)
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client) as resolve:
+        result = CliRunner().invoke(cmd, [ACCESS_KEY])
+    assert "not a valid integer" not in result.output
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with(db, ACCESS_KEY)
+
+
+def test_delete_client_accepts_access_key_with_yes():
+    client = _client()
+    db = _DB(client)
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client) as resolve:
+        result = CliRunner().invoke(delete_client, [ACCESS_KEY, "--yes"])
+    assert "not a valid integer" not in result.output
+    assert result.exit_code == 0, result.output
+    resolve.assert_called_once_with(db, ACCESS_KEY)
+    assert db.deleted == [ACCESS_KEY]
+
+
+def test_delete_client_bare_with_one_client_does_not_delete_without_confirmation():
+    client = _client()
+    db = _DB(client)
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client):
+        # No --yes, and stdin gives no input -> click.confirm reads EOF, which
+        # click treats as "no" (abort), never as an implicit "yes".
+        result = CliRunner().invoke(delete_client, [ACCESS_KEY], input="n\n")
+    assert db.deleted == [], "must not delete without an explicit confirmation"
+
+
+def test_delete_client_yes_flag_bypasses_confirmation():
+    client = _client()
+    db = _DB(client)
+    with patch("hivemind_core.scripts.ClientDatabase", return_value=db), \
+            patch("hivemind_core.scripts.resolve_client", return_value=client):
+        result = CliRunner().invoke(delete_client, [ACCESS_KEY, "--yes"])
+    assert result.exit_code == 0, result.output
+    assert db.deleted == [ACCESS_KEY]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Draft — held for the ser9 gate before ready.

`resolve_client` already accepts either a numeric client id or an access-key string, which is why `rename-client` and `reset-noise-pin` declare their id argument as a plain string. But 16 other client-targeting commands still declared it as an integer, so pasting the access key a node prints in its own logs would die on click's "not a valid integer" error before `resolve_client` ever got a chance to run. This came out of the UX audit linked from admin-panel issue #44; the access-key part of that finding belongs here in core.

The fix switches that argument to a string on all 16 commands — make-admin, revoke-admin, delete-client, and the various allow/blacklist commands for messages, escalation, propagation, skills, and intents, plus set-metadata. `resolve_client` already coerces an all-digits string back to an integer id, so nothing downstream needed to change. `allow-broadcast` and `blacklist-broadcast` had their own hand-rolled integer parsing instead of going through `resolve_client` at all; both now go through the same resolver as everything else. I also added a confirmation prompt before `delete-client` actually deletes, with a `--yes` flag to skip it for scripts — previously it deleted with no prompt at all.

Fail-before verified by reverting the patch: 23 of 24 new tests fail against the unfixed code, covering both the integer-parse rejections and the missing confirmation flag. Gate: 437 passed, 2 skipped, 1 xpassed, which is the 413 baseline plus the 24 new tests. Updated the CLI docs to describe the id-or-access-key form.
