### PR TITLE
fix: raise ovos-bus-client floor to 2.2.0a1 for receive-side migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pybase64",
     # 0.9.0a1 added AbstractDB.get_client_by_api_key, which ClientDatabase calls
     "hivemind-plugin-manager>=0.9.0a1,<1.0.0",
-    "ovos-bus-client>=2.0.0a3",
+    "ovos-bus-client>=2.2.0a1",
     "json-database>=0.10.2a1,<2.0.0",
     "hivemind-sqlite-database>=0.4.0a2",
     "hivemind-json-db-plugin>=0.0.3a2",
@@ -73,7 +73,7 @@ integration = [
     # ovos-bus-client 2.x support currently exists only in OVOS pre-releases;
     # pin pre-release floors so the resolver picks the 2.x-compatible alphas
     # instead of the latest stables (which still cap ovos-bus-client<2.0.0).
-    "ovos-bus-client>=2.0.0a3",
+    "ovos-bus-client>=2.2.0a1",
     "ovos-plugin-manager>=2.10.0a1",
     "ovos-workshop>=8.0.0a1",
     "ovos-utils>=0.11.1a1",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude (Opus 4.8 orchestrating, Sonnet 5 drafting this text) via Claude Code — NOT human-reviewed. Verify before acting.

This raises the `ovos-bus-client` floor from `>=2.0.0a3` to `>=2.2.0a1` in both the main `dependencies` list and the `integration` extra.

Receive-side migration-topic translation, which lets a client subscribed to a legacy topic (like `speak`) still receive it when a modern core emits the canonical topic (`ovos.utterance.speak`), only became default-on in ovos-bus-client 2.2.0a1 (translation itself was added opt-in in 2.1.2a2, and the spec-tools `NamespaceTranslator` landed in 2.3.0a1). Below 2.2.0a1, a deployment whose resolver lands anywhere in the 2.0.x-2.1.x window gets a client with no translation. On the hub relay path that means it silently drops `speak` and every other non-intent migrated topic whenever it talks to a canonical-emitting core, with no error or warning surfaced anywhere.

This is a floor-only change. HiveMind-core has no lockfile, so there is nothing to relock. The `hivemind-ovos-agent-plugin` dependency already pins `ovos-bus-client>=2.6.5a1`, well above this new floor, so it stays safe and unaffected by this bump.
