### PR TITLE
fix: raise ovos-bus-client floor to 2.8.3a1 for send-side wire twins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pybase64",
     # 0.9.0a1 added AbstractDB.get_client_by_api_key, which ClientDatabase calls
     "hivemind-plugin-manager>=0.9.0a1,<1.0.0",
-    "ovos-bus-client>=2.2.0a1",
+    "ovos-bus-client>=2.8.3a1",
     "json-database>=0.10.2a1,<2.0.0",
     "hivemind-sqlite-database>=0.4.0a2",
     "hivemind-json-db-plugin>=0.0.3a2",
@@ -73,7 +73,7 @@ integration = [
     # ovos-bus-client 2.x support currently exists only in OVOS pre-releases;
     # pin pre-release floors so the resolver picks the 2.x-compatible alphas
     # instead of the latest stables (which still cap ovos-bus-client<2.0.0).
-    "ovos-bus-client>=2.2.0a1",
+    "ovos-bus-client>=2.8.3a1",
     "ovos-plugin-manager>=2.10.0a1",
     "ovos-workshop>=8.0.0a1",
     "ovos-utils>=0.11.1a1",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude (Opus 4.8 orchestrating, Sonnet 5 drafting this text) via Claude Code — NOT human-reviewed. Verify before acting.

This raises the ovos-bus-client floor from >=2.2.0a1 to >=2.8.3a1 in both the base and integration dependency groups.

ovos-bus-client 2.8.3a1 adds default-on send-side wire-twin generation for canonical MIGRATION_MAP topics. That means a pre-spec-tools listener still running a stable release like 1.5.0 keeps receiving legacy-spelled topics (for example, 'speak') even when the message came from a modern emitter on this relay path. The owner ruling is that the twin stays default-on because back-compat is owed to those stable releases. Bumping the floor here gives HiveMind-core send-side protection plus marker dedup on that path.

This is a floor-only version bump. There is no lockfile in this repo, so no relock is needed. The diff touches only the two ovos-bus-client lines in pyproject.toml.

Left as a draft pending review.
