### PR TITLE
fix: disable rendezvous mailbox when hivemind-rendezvous is too old to deliver

### DIFF
--- a/hivemind_core/service.py
+++ b/hivemind_core/service.py
@@ -258,6 +258,29 @@ class HiveMindService:
         cfg = get_server_config().get("rendezvous", {})
         if not cfg.get("enabled", False):
             return
+
+        # hivemind-rendezvous 2.0.0a1 (PR #14) switched from keying mailboxes
+        # by the recipient's public key to keying them by the authenticated
+        # access key, which is what this protocol passes to mailbox.handle().
+        # An older package silently accepts deposits under the wrong key and
+        # never delivers them, so a too-old install must not be bound at all.
+        try:
+            from hivemind_rendezvous.version import (
+                VERSION_MAJOR, VERSION_MINOR, VERSION_BUILD
+            )
+            installed = (VERSION_MAJOR, VERSION_MINOR, VERSION_BUILD)
+        except (ImportError, AttributeError):
+            installed = (0, 0, 0)
+        if installed < (2, 0, 0):
+            LOG.error(
+                f"hivemind-rendezvous>=2.0.0a1 is required for mailbox "
+                f"delivery; installed {'.'.join(map(str, installed))} keys "
+                f"mailboxes by public key and is incompatible with this "
+                f"core's access-key addressing — rendezvous DISABLED, "
+                f"upgrade to restore it"
+            )
+            return
+
         hm_protocol.mailbox = RendezvousMailbox(
             max_pending_per_mailbox=cfg.get("max_pending_per_mailbox", 256)
         )

--- a/tests/test_rendezvous_version_guard.py
+++ b/tests/test_rendezvous_version_guard.py
@@ -1,0 +1,51 @@
+"""_start_rendezvous refuses to bind a too-old hivemind-rendezvous.
+
+hivemind-rendezvous 2.0.0a1 (PR #14, "fix!: address mailboxes by
+authenticated identity") switched mailbox addressing from the recipient's
+public key to the caller's authenticated access key — which is what this
+protocol passes to ``mailbox.handle()``. An older, unpinned install still
+imports cleanly and accepts deposits, it just never delivers them: silent
+mail loss. A version gate must refuse to bind it, leaving the node an
+honest non-rendezvous node instead.
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+
+from hivemind_core.service import HiveMindService
+
+
+class _StubMailbox:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _install_stub_rendezvous(monkeypatch, version):
+    pkg = types.ModuleType("hivemind_rendezvous")
+    pkg.RendezvousMailbox = _StubMailbox
+    version_mod = types.ModuleType("hivemind_rendezvous.version")
+    version_mod.VERSION_MAJOR, version_mod.VERSION_MINOR, version_mod.VERSION_BUILD = version
+    monkeypatch.setitem(sys.modules, "hivemind_rendezvous", pkg)
+    monkeypatch.setitem(sys.modules, "hivemind_rendezvous.version", version_mod)
+
+
+def _run(monkeypatch, version):
+    _install_stub_rendezvous(monkeypatch, version)
+    monkeypatch.setattr(
+        "hivemind_core.service.get_server_config",
+        lambda: {"rendezvous": {"enabled": True}},
+    )
+    hm_protocol = SimpleNamespace(mailbox=None)
+    HiveMindService._start_rendezvous(None, hm_protocol)
+    return hm_protocol
+
+
+def test_compatible_rendezvous_is_bound(monkeypatch):
+    hm_protocol = _run(monkeypatch, (2, 0, 0))
+    assert isinstance(hm_protocol.mailbox, _StubMailbox)
+
+
+def test_incompatible_rendezvous_is_refused(monkeypatch):
+    hm_protocol = _run(monkeypatch, (1, 0, 0))
+    assert hm_protocol.mailbox is None


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

hivemind-rendezvous 2.0.0a1 (PR #14, "fix!: address mailboxes by authenticated identity") changed how mailboxes are keyed: 1.x addressed a mailbox by the recipient's PEM public key, while 2.0.0a1+ addresses it by the caller's authenticated access key. hivemind-core's protocol already calls `self.mailbox.handle(message, client.key)`, passing the access key, so it only ever worked correctly against the 2.x addressing scheme.

Because hivemind-rendezvous is an optional, unpinned dependency, a 1.x install still imports cleanly and still gets bound as the mailbox. It accepts deposits and answers "ok", but stores them under a key the collector never asks for, so `collect` always returns zero messages — silent, permanent mail loss with no error anywhere in the path. This was confirmed live against the reference hive before writing the fix.

`_start_rendezvous` now checks the installed package's `(VERSION_MAJOR, VERSION_MINOR, VERSION_BUILD)` tuple before binding the mailbox and refuses anything below `(2, 0, 0)`, logging the installed version and the minimum required. When refused, the node keeps behaving exactly as it does today when hivemind-rendezvous is absent: it answers `RENDEZVOUS` with the honest `not_a_rendezvous_node` reply instead of silently swallowing mail.

Fail-before was verified by reverting only the `service.py` change and re-running the new regression test: `test_incompatible_rendezvous_is_refused` failed with a 1.0.0 stub getting bound as the mailbox (`assert <_StubMailbox ...> is None` failed). Re-applying the fix made it pass, and the companion `test_compatible_rendezvous_is_bound` (a 2.0.0 stub) passed in both states. The full suite passes: 438 passed, 3 skipped, 1 pre-existing unrelated xpass, no regressions.

No wire protocol change and no new bus message type — this only gates whether an already-optional feature activates.