### PR TITLE
fix: bind QUERY/CASCADE answer routing to a request the node saw (MSG-1 §5.2)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -134,6 +134,15 @@ class HiveMindNodeType(str, Enum):
 # protocol content, not loose metadata.
 QUERY_STREAM_END = "hive.query.complete"
 
+# Retention window (seconds) for participation-binding state (MSG-1 §5.2): how
+# long a node remembers a request it saw so it can route the matching answer.
+# Kept comfortably above a query's expected round-trip; a later answer is a
+# genuinely stale one and is dropped. Time source is time.monotonic().
+OUTSTANDING_QUERY_TTL = 300.0
+# Hard cap on distinct outstanding queries, mirroring the _pending_cascades
+# bound, so a flood of unique query_ids cannot grow the store without limit.
+OUTSTANDING_QUERY_MAX = 256
+
 
 def _non_negative_float(value, default: float) -> float:
     try:
@@ -507,6 +516,16 @@ class HiveMindListenerProtocol:
     # plain __post_init__ assignment left every object.__new__ fixture
     # raising AttributeError the first time a cascade or query was routed.
     _cascades_lock: Optional[threading.Lock] = field(default=None, init=False, repr=False)
+    # Participation-binding state (MSG-1 §5.2): (originator_peer, query_id) ->
+    # monotonic insert time for every request this node admitted or forwarded.
+    # An is_response QUERY/CASCADE is only routed when a matching entry exists,
+    # which is what proves this node saw the request and holds a return path.
+    # Backing fields with None defaults (class attributes) so a fixture built
+    # with ``object.__new__`` finds them, and the properties build the real
+    # store/lock lazily — the same treatment as the flood caches and the
+    # cascade lock above.
+    _outstanding_queries_store: Optional[dict] = field(default=None, init=False, repr=False)
+    _outstanding_query_lock: Optional[threading.Lock] = field(default=None, init=False, repr=False)
     # Backing field for the ``_forwarded_flood_ids`` property below. Same
     # treatment as the other flood caches: a mutable FloodIdCache cannot be a
     # class-level default without every node sharing one, so the default is
@@ -693,6 +712,58 @@ class HiveMindListenerProtocol:
         if self._cascades_lock is None:
             self._cascades_lock = threading.Lock()
         return self._cascades_lock
+
+    @property
+    def _outstanding_queries(self) -> dict:
+        """Participation-binding store (MSG-1 §5.2): query_id -> (return_peer,
+        monotonic insert time). ``return_peer`` is the SERVER-OBSERVED peer of
+        the connection the request arrived on — the only address authorized to
+        receive the answer, never the client-claimed ``originator_peer``.
+        Lazily built so a fixture constructed with ``object.__new__`` finds it
+        instead of raising AttributeError."""
+        if self._outstanding_queries_store is None:
+            self._outstanding_queries_store = {}
+        return self._outstanding_queries_store
+
+    @property
+    def _outstanding_queries_lock(self) -> threading.Lock:
+        """Guards the outstanding-query store. ``_route_query_response`` runs on
+        both the tornado thread and the upstream slave thread, so record/check/
+        evict must be atomic (same reasoning as ``_pending_cascades_lock``)."""
+        if self._outstanding_query_lock is None:
+            self._outstanding_query_lock = threading.Lock()
+        return self._outstanding_query_lock
+
+    def _record_outstanding_query(self, query_id: str,
+                                  return_peer: str) -> None:
+        """Bind ``query_id`` to the connection it arrived on so the matching
+        answer can only be routed back that way (MSG-1 §5.2). FIRST-WRITER-WINS:
+        a query_id already bound is never rebound, so an attacker cannot steal a
+        live query's return path by replaying its id. Bounded by a hard cap
+        alongside the TTL eviction in ``_outstanding_return_path``."""
+        now = time.monotonic()
+        with self._outstanding_queries_lock:
+            store = self._outstanding_queries
+            if query_id in store:
+                return
+            while len(store) >= OUTSTANDING_QUERY_MAX:
+                store.pop(next(iter(store)))
+            store[query_id] = (return_peer, now)
+
+    def _outstanding_return_path(self, query_id: str) -> Optional[str]:
+        """The server-observed return peer this node recorded for ``query_id``,
+        or None if it saw no request (forged, or evicted past
+        ``OUTSTANDING_QUERY_TTL``). An answer is only ever delivered to this
+        exact peer — a client-supplied originator_peer or route may select a
+        candidate, but this authorizes the send."""
+        now = time.monotonic()
+        with self._outstanding_queries_lock:
+            store = self._outstanding_queries
+            for qid in [q for q, (_, ts) in store.items()
+                        if now - ts > OUTSTANDING_QUERY_TTL]:
+                store.pop(qid, None)
+            entry = store.get(query_id)
+            return entry[0] if entry else None
 
     @property
     def _seen_flood_ids(self) -> FloodIdCache:
@@ -988,6 +1059,13 @@ class HiveMindListenerProtocol:
             for query_id in [qid for qid, c in self._pending_cascades.items()
                               if c.originator_peer == client.peer]:
                 self._pending_cascades.pop(query_id, None)
+        # participation-binding state whose return path is this connection is
+        # dead once it has disconnected — no future answer can reach it — so
+        # purge it now instead of waiting for TTL/cap reclaim (MSG-1 §5.2).
+        with self._outstanding_queries_lock:
+            for qid in [q for q, (peer, _) in self._outstanding_queries.items()
+                        if peer == client.peer]:
+                self._outstanding_queries.pop(qid, None)
         client.disconnect()
         context = {"source": client.peer}
         # never hand the reserved session of a non-admin to the OVOS bus: it
@@ -2216,6 +2294,11 @@ class HiveMindListenerProtocol:
         if (message.metadata or {}).get("is_response"):
             self._route_query_response(message, None)
             return
+        # A master-originated request has no downstream return path recorded on
+        # this node (the request came FROM upstream, not from a downstream peer
+        # this node admitted), so no participation state is bound here; the
+        # matching response has nowhere authorized to go and drops at
+        # _route_query_response, unchanged from before this binding existed.
         self._relay_downstream(message)
 
     def query_to_master(self, message: HiveMessage) -> None:
@@ -2334,16 +2417,39 @@ class HiveMindListenerProtocol:
         sender = client.peer if client else None
         metadata = message.metadata or {}
         originator_peer = metadata.get("originator_peer", "")
+        query_id = metadata.get("query_id", "")
+        # Participation binding (MSG-1 §5.2): route an answer only to the
+        # SERVER-OBSERVED connection the matching request arrived on. Both the
+        # client-supplied ``originator_peer`` and the client-supplied route may
+        # only SELECT a candidate connection below — the recorded return path
+        # AUTHORIZES the actual send. This closes two forgery vectors an
+        # existence-only check missed: (1) self-record — an attacker sends a
+        # request claiming a victim's originator_peer, then an answer for the
+        # same id; and (2) crafted-route — an attacker plants a victim hop in
+        # the route. In both the chosen candidate's peer is the attacker's, not
+        # the recorded arriving connection, so the send is refused.
+        return_peer = self._outstanding_return_path(query_id)
+        if return_peer is None:
+            LOG.warning(
+                "dropping unbacked %s response (participation binding, "
+                "MSG-1 §5.2): no request seen for query_id=%s "
+                "originator_peer=%s" % (message.msg_type, query_id,
+                                        originator_peer))
+            return
         # One lookup serves both the CASCADE gate below and the default route
         # at the end. An "in" check followed by an index would KeyError if the
         # originator disconnected between the two, and that KeyError travels up
         # to the websocket handler and drops the *responder's* connection.
         originator_conn = self.clients.get(originator_peer)
         # CASCADE disambiguation: collect responses for a select callback at
-        # the originating node, letting it pick a winner progressively.
+        # the originating node, letting it pick a winner progressively. Only
+        # when THIS node is the genuine originator — the direct originator
+        # connection is the recorded return path — so a forged originator_peer
+        # can not trigger the collector (and a relay does not mis-collect).
         if (message.msg_type == HiveMessageType.CASCADE
                 and self.cascade_select_callback is not None
-                and originator_conn is not None):
+                and originator_conn is not None
+                and originator_conn.peer == return_peer):
             query_id = metadata.get("query_id", "")
             # _route_query_response runs both on the tornado thread (direct
             # clients) and on the upstream slave thread (relayed cascades), so
@@ -2380,25 +2486,32 @@ class HiveMindListenerProtocol:
             except Exception:
                 LOG.exception(f"cascade_select_callback error for query_id={query_id}")
             return
-        # Default routing: forward toward the originator.
+        # Default routing: forward toward the originator, but only if the
+        # candidate connection IS the recorded return path. A client-claimed
+        # originator_peer that resolves to some other live connection is a
+        # forged target and must not receive the answer.
         conn = originator_conn
-        if conn is not None:
+        if conn is not None and conn.peer == return_peer:
             conn.send(message)
             return
-        # route-aware return: send to the downstream hop on the path back to
-        # the originator (from the request's recorded route) instead of flooding
+        # route-aware return: the downstream hop on the path back to the
+        # originator (from the request's recorded route). Same authorization —
+        # a client-planted victim hop never equals the recorded return path.
         for hop in reversed(message.route or []):
             src = hop.get("source")
-            conn = self.clients.get(src) if src and src != sender else None
+            if not src or src == sender or src != return_peer:
+                continue
+            conn = self.clients.get(src)
             if conn is not None:
                 conn.send(message)
                 return
-        # no return path: the originator is not ours and the route names no
-        # peer we can reach. Fanning the response downstream would hand one
-        # peer's answer to its siblings (NODE-1 §5.2, AGENT-1 §3.2), so drop it.
-        LOG.warning(f"dropping {message.msg_type} response with no return path: "
-                    f"query_id={metadata.get('query_id', '')} "
-                    f"originator_peer={originator_peer}")
+        # no authorized return path: the recorded arriving connection is gone,
+        # or the claimed target/route names some other peer. Delivering anywhere
+        # else hands one peer's answer to another (NODE-1 §5.2, AGENT-1 §3.2),
+        # so drop it.
+        LOG.warning(f"dropping {message.msg_type} response with no authorized "
+                    f"return path: query_id={metadata.get('query_id', '')} "
+                    f"originator_peer={originator_peer} return_peer={return_peer}")
 
     def handle_query_message(self, message: HiveMessage,
                              client: HiveMindClientConnection):
@@ -2429,6 +2542,11 @@ class HiveMindListenerProtocol:
         payload = self._unpack_message(message, client)
         query_id = metadata.get("query_id", str(uuid.uuid4()))
         originator_peer = metadata.get("originator_peer", client.peer)
+        # participation binding (MSG-1 §5.2): bind this query to the connection
+        # it arrived on (client.peer, the server-observed return path — NOT the
+        # client-claimed originator_peer), before any answer routes. The answer
+        # is only ever delivered back to this exact connection.
+        self._record_outstanding_query(query_id, client.peer)
         try:
             bus = self.get_bus(client)
         except ConnectionError as e:
@@ -2463,6 +2581,9 @@ class HiveMindListenerProtocol:
         if (message.metadata or {}).get("is_response"):
             self._route_query_response(message, None)
             return
+        # As with query_from_master: a master-originated cascade binds no
+        # downstream return path here, so its response drops at
+        # _route_query_response (behavior unchanged by participation binding).
         self._relay_downstream(message)
 
     def cascade_to_master(self, message: HiveMessage) -> None:
@@ -2507,6 +2628,11 @@ class HiveMindListenerProtocol:
 
         query_id = metadata.get("query_id", str(uuid.uuid4()))
         originator_peer = metadata.get("originator_peer", client.peer)
+        # participation binding (MSG-1 §5.2): bind this cascade to the arriving
+        # connection (client.peer) before _answer_query_locally below, whose
+        # CASCADE answer routes THROUGH _route_query_response — the return path
+        # must already exist or the node would drop its own answer.
+        self._record_outstanding_query(query_id, client.peer)
         try:
             bus = self.get_bus(client)
         except ConnectionError as e:

--- a/tests/test_mesh_routing_conformance.py
+++ b/tests/test_mesh_routing_conformance.py
@@ -57,6 +57,7 @@ def _wire_peers(node, *peers):
     sent = {p: [] for p in peers}
     for p in peers:
         conn = MagicMock()
+        conn.peer = p
         conn.send = lambda m, *a, box=sent[p]: box.append(m)
         node.clients[p] = conn
     return sent
@@ -124,6 +125,8 @@ def test_query_response_from_master_reaches_only_the_originator():
     node = _make_node()
     sent = _wire_peers(node, "asker::1", "sibling::2")
 
+    # participation binding (MSG-1 §5.2): this node forwarded the request
+    node._record_outstanding_query("q1", "asker::1")
     node.query_from_master(_response(HiveMessageType.QUERY, "asker::1"))
 
     assert len(sent["asker::1"]) == 1
@@ -137,6 +140,8 @@ def test_cascade_response_from_master_reaches_only_the_originator():
     node._pending_cascades = {}
     sent = _wire_peers(node, "asker::1", "sibling::2")
 
+    # participation binding (MSG-1 §5.2): this node forwarded the request
+    node._record_outstanding_query("q1", "asker::1")
     node.cascade_from_master(_response(HiveMessageType.CASCADE, "asker::1"))
 
     assert len(sent["asker::1"]) == 1

--- a/tests/test_query_participation_binding.py
+++ b/tests/test_query_participation_binding.py
@@ -1,0 +1,328 @@
+"""Participation binding for QUERY/CASCADE answer routing (HIVEMIND-MSG-1 §5.2).
+
+A node MUST route a QUERY/CASCADE answer ONLY back to the SERVER-OBSERVED
+connection the matching request arrived on — the return path it recorded when
+it admitted the request. Client-supplied fields (``originator_peer``, the
+message ``route``) may only SELECT a candidate connection; the recorded return
+path AUTHORIZES the actual send. An answer for a request this node never
+admitted (forged, or arrived after the retention TTL) is dropped.
+
+This closes two forgery vectors an existence-only check would miss:
+
+* self-record — an attacker sends a QUERY/CASCADE *request* claiming a victim's
+  ``originator_peer`` (which would record that victim), then an ``is_response``
+  for the same ``query_id``; and
+* crafted-route — an attacker plants a victim hop in the response ``route`` so
+  the route-walk delivers to the victim.
+
+In both, the recorded return path is the attacker's own arriving connection,
+never the victim, so the send is refused.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                     HiveMindListenerProtocol)
+
+
+def _make_node(node_key: str = "master-pubkey") -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = "master:0.0.0.0"
+    node.identity = MagicMock(public_key=node_key, site_id=None)
+    node.clients = {}
+    node.cascade_select_callback = None
+    node.illegal_callback = None
+    node._pending_cascades = {}
+    node._upstream_hm = None
+    # stubs shared by the request-admission path in these unit tests
+    node._unpack_message = MagicMock(
+        return_value=Message("recognizer_loop:utterance", {"utterances": ["hi"]}))
+    node.get_bus = MagicMock(return_value=MagicMock())
+    node._answer_query_locally = MagicMock(return_value=False)
+    return node
+
+
+def _make_client(peer, **flags):
+    client = MagicMock()
+    client.peer = peer
+    client.can_escalate = flags.get("can_escalate", False)
+    client.can_propagate = flags.get("can_propagate", False)
+    return client
+
+
+def _wire(node, peer):
+    conn = MagicMock()
+    conn.peer = peer
+    conn.send = MagicMock()
+    node.clients[peer] = conn
+    return conn
+
+
+def _response(msg_type, originator_peer, query_id, route=None):
+    inner = HiveMessage(HiveMessageType.BUS,
+                        payload=Message("speak", {"utterance": "the answer"}))
+    msg = HiveMessage(msg_type, payload=inner,
+                      metadata={"query_id": query_id,
+                                "originator_peer": originator_peer,
+                                "responder_peer": "responder::9",
+                                "is_response": True})
+    if route:
+        msg.replace_route(route)
+    return msg
+
+
+def _request(msg_type, originator_peer, query_id):
+    inner = HiveMessage(HiveMessageType.BUS,
+                        payload=Message("recognizer_loop:utterance",
+                                        {"utterances": ["what time is it"]}))
+    return HiveMessage(msg_type, payload=inner,
+                       metadata={"query_id": query_id,
+                                 "originator_peer": originator_peer})
+
+
+# --- forgery: self-record --------------------------------------------------
+
+def test_self_record_forgery_is_dropped():
+    """An attacker sends a QUERY *request* claiming the victim as originator,
+    then an is_response for the same query_id. The node bound the query to the
+    attacker's arriving connection, not the claimed victim, so the answer is
+    refused delivery to the victim."""
+    node = _make_node()
+    attacker = _make_client("attacker::1", can_escalate=True)
+    victim_conn = _wire(node, "victim::1")
+
+    # request claims the victim as originator (this is the self-record attempt)
+    node.handle_query_message(
+        _request(HiveMessageType.QUERY, "victim::1", "forge-q"), attacker)
+    # forged answer for the same query_id, addressed to the victim
+    node.handle_query_message(
+        _response(HiveMessageType.QUERY, "victim::1", "forge-q"), attacker)
+
+    victim_conn.send.assert_not_called()
+
+
+def test_self_record_cascade_forgery_is_dropped():
+    node = _make_node()
+    attacker = _make_client("attacker::1", can_propagate=True)
+    victim_conn = _wire(node, "victim::1")
+    node._is_routing_loop = MagicMock(return_value=False)
+    node._append_self_hop = MagicMock()
+    node._rewrap = MagicMock(
+        return_value=_request(HiveMessageType.CASCADE, "victim::1", "forge-c"))
+    node.cascade_to_master = MagicMock()
+
+    node.handle_cascade_message(
+        _request(HiveMessageType.CASCADE, "victim::1", "forge-c"), attacker)
+    # note: the CASCADE *request* legitimately fans out to the victim as a
+    # downstream peer; the forgery is the ANSWER, which must never be delivered.
+    forged_answer = _response(HiveMessageType.CASCADE, "victim::1", "forge-c")
+    node.handle_cascade_message(forged_answer, attacker)
+
+    delivered = [c.args[0] for c in victim_conn.send.call_args_list]
+    assert forged_answer not in delivered
+    assert not any((m.metadata or {}).get("is_response") for m in delivered)
+
+
+# --- forgery: crafted route ------------------------------------------------
+
+def test_crafted_route_forgery_is_dropped():
+    """An attacker self-records a query_id, then sends an is_response whose
+    route names the victim as a hop and whose originator_peer is not directly
+    connected. The route-walk must refuse the victim: it is not the recorded
+    return path."""
+    node = _make_node()
+    attacker = _make_client("attacker::1", can_escalate=True)
+    victim_conn = _wire(node, "victim::1")
+
+    # request records query_id -> attacker's arriving connection
+    node.handle_query_message(
+        _request(HiveMessageType.QUERY, "ghost::0", "route-q"), attacker)
+    # forged answer: originator not connected, route plants the victim as a hop
+    node.handle_query_message(
+        _response(HiveMessageType.QUERY, "ghost::0", "route-q",
+                  route=[{"source": "victim::1", "targets": ["master:0.0.0.0"]}]),
+        attacker)
+
+    victim_conn.send.assert_not_called()
+
+
+# --- legit single-node round trip ------------------------------------------
+
+def test_legit_query_answer_routes_to_the_recorded_return_path():
+    node = _make_node()
+    asker = _make_client("asker::1", can_escalate=True)
+    originator_conn = _wire(node, "asker::1")
+
+    node.handle_query_message(
+        _request(HiveMessageType.QUERY, "asker::1", "q-rt"), asker)
+    assert node._outstanding_return_path("q-rt") == "asker::1"
+
+    responder = _make_client("responder::9", can_escalate=True)
+    answer = _response(HiveMessageType.QUERY, "asker::1", "q-rt")
+    node.handle_query_message(answer, responder)
+
+    originator_conn.send.assert_called_once_with(answer)
+
+
+# --- legit multi-hop relay: request from a downstream peer -----------------
+
+def test_legit_multihop_answer_routes_back_to_the_downstream_hop():
+    """The originator sits behind a downstream relay N. The request arrives
+    from N (records N as the return path); the answer, addressed to the
+    originator behind N, walks the route back to N."""
+    node = _make_node()
+    relay = _make_client("relay::1", can_escalate=True)
+    relay_conn = _wire(node, "relay::1")
+
+    node.handle_query_message(
+        _request(HiveMessageType.QUERY, "behind-relay::7", "q-hop"), relay)
+    assert node._outstanding_return_path("q-hop") == "relay::1"
+
+    responder = _make_client("responder::9", can_escalate=True)
+    answer = _response(HiveMessageType.QUERY, "behind-relay::7", "q-hop",
+                       route=[{"source": "relay::1",
+                               "targets": ["master:0.0.0.0"]}])
+    node.handle_query_message(answer, responder)
+
+    relay_conn.send.assert_called_once_with(answer)
+
+
+# --- master-originated response still drops (behavior unchanged) -----------
+
+def test_master_originated_query_response_still_drops():
+    node = _make_node()
+    node._relay_downstream = MagicMock()
+    victim_conn = _wire(node, "leaf::1")
+
+    # a request relayed FROM the master binds no downstream return path here
+    node.query_from_master(_request(HiveMessageType.QUERY, "leaf::1", "q-m"))
+    node._relay_downstream.assert_called_once()
+    assert node._outstanding_return_path("q-m") is None
+
+    node.query_from_master(_response(HiveMessageType.QUERY, "leaf::1", "q-m"))
+    victim_conn.send.assert_not_called()
+
+
+def test_master_originated_cascade_response_still_drops():
+    node = _make_node()
+    node._relay_downstream = MagicMock()
+    victim_conn = _wire(node, "leaf::1")
+
+    node.cascade_from_master(_request(HiveMessageType.CASCADE, "leaf::1", "c-m"))
+    assert node._outstanding_return_path("c-m") is None
+
+    node.cascade_from_master(_response(HiveMessageType.CASCADE, "leaf::1", "c-m"))
+    victim_conn.send.assert_not_called()
+
+
+# --- CASCADE local answer still delivered ----------------------------------
+
+def test_cascade_local_answer_is_delivered_not_self_dropped():
+    """The CASCADE local answer routes THROUGH _route_query_response; the
+    request binds the return path first, so the node's own answer reaches the
+    genuine originator."""
+    node = _make_node()
+    asker = _make_client("asker::1", can_propagate=True)
+    originator_conn = _wire(node, "asker::1")
+    node._is_routing_loop = MagicMock(return_value=False)
+    node._append_self_hop = MagicMock()
+    node._rewrap = MagicMock(
+        return_value=_request(HiveMessageType.CASCADE, "asker::1", "cq"))
+    node.cascade_to_master = MagicMock()
+
+    def _local_answer(message, client, query_id, originator_peer, msg_type,
+                      route, send_fn):
+        send_fn(_response(msg_type, originator_peer, query_id))
+        return True
+
+    node._answer_query_locally = _local_answer
+
+    node.handle_cascade_message(
+        _request(HiveMessageType.CASCADE, "asker::1", "cq"), asker)
+
+    originator_conn.send.assert_called_once()
+
+
+# --- CASCADE collector runs only at the true origin ------------------------
+
+def test_cascade_collector_runs_only_when_this_node_is_the_origin():
+    """The select callback collects here only when the direct originator
+    connection is the recorded return path (this node is the true origin)."""
+    node = _make_node()
+    asker = _make_client("asker::1", can_propagate=True)
+    originator_conn = _wire(node, "asker::1")
+    collected = []
+    node.cascade_select_callback = lambda qid, responses: collected.append(qid)
+    node.get_bus = MagicMock(return_value=MagicMock())
+
+    # the origin admitted the request from asker -> return path is asker
+    node._record_outstanding_query("cq2", "asker::1")
+    node._route_query_response(
+        _response(HiveMessageType.CASCADE, "asker::1", "cq2"), None)
+
+    assert collected == ["cq2"]
+    assert "cq2" in node._pending_cascades
+
+
+def test_cascade_collector_not_triggered_for_forged_originator():
+    """A forged originator_peer pointing at a connected victim must not trigger
+    the collector for that victim (the return path is not the victim)."""
+    node = _make_node()
+    victim_conn = _wire(node, "victim::1")
+    collected = []
+    node.cascade_select_callback = lambda qid, responses: collected.append(qid)
+    node.get_bus = MagicMock(return_value=MagicMock())
+
+    # the request actually arrived on the attacker's connection
+    node._record_outstanding_query("cq3", "attacker::1")
+    node._route_query_response(
+        _response(HiveMessageType.CASCADE, "victim::1", "cq3"), None)
+
+    assert collected == []
+    victim_conn.send.assert_not_called()
+
+
+# --- originator disconnect purges its entries ------------------------------
+
+def test_disconnect_purges_entries_bound_to_that_connection():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.return_value = MagicMock()
+    agent.callbacks = MagicMock()
+
+    db_user = MagicMock()
+    db_user.allowed_types = ["recognizer_loop:utterance"]
+    db_user.is_admin = False
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    node = HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+    client = HiveMindClientConnection(
+        key="test-key", send_msg=MagicMock(), disconnect=MagicMock(),
+        hm_protocol=node, sess=Session("a-session"))
+    client.name = "leaf"
+    peer = client.peer
+
+    node._record_outstanding_query("q1", peer)
+    node._record_outstanding_query("q2", peer)
+    node._record_outstanding_query("q3", "other::2")
+
+    node.handle_client_disconnected(client)
+
+    assert node._outstanding_return_path("q1") is None
+    assert node._outstanding_return_path("q2") is None
+    assert node._outstanding_return_path("q3") == "other::2"
+
+
+# --- first-writer-wins: a live query_id can not be rebound ------------------
+
+def test_first_writer_wins_prevents_return_path_rebinding():
+    node = _make_node()
+    node._record_outstanding_query("dup", "asker::1")
+    node._record_outstanding_query("dup", "attacker::1")
+    assert node._outstanding_return_path("dup") == "asker::1"

--- a/tests/test_query_response_isolation.py
+++ b/tests/test_query_response_isolation.py
@@ -33,6 +33,7 @@ def _wire_peers(node, *peers):
     sent = {p: [] for p in peers}
     for p in peers:
         conn = MagicMock()
+        conn.peer = p
         conn.send = lambda m, *a, box=sent[p]: box.append(m)
         node.clients[p] = conn
     return sent
@@ -95,6 +96,8 @@ def test_direct_originator_still_receives_the_response():
     node = _make_node()
     sent = _wire_peers(node, "asker::1", "sibling::2")
 
+    # participation binding (MSG-1 §5.2): the node saw this request
+    node._record_outstanding_query("q1", "asker::1")
     node._route_query_response(_response("asker::1"), None)
 
     assert len(sent["asker::1"]) == 1
@@ -107,6 +110,8 @@ def test_route_walk_still_delivers_to_the_downstream_hop():
     node = _make_node()
     sent = _wire_peers(node, "relay::1", "sibling::2")
 
+    # participation binding (MSG-1 §5.2): the node saw this request
+    node._record_outstanding_query("q1", "relay::1")
     node._route_query_response(
         _response("behind-relay::7",
                   route=[{"source": "relay::1", "targets": ["master:0.0.0.0"]}]),
@@ -121,6 +126,8 @@ def test_route_walk_does_not_send_the_response_back_to_its_sender():
     sent = _wire_peers(node, "relay::1", "responder::2")
     client = MagicMock(peer="responder::2")
 
+    # participation binding (MSG-1 §5.2): the node saw this request
+    node._record_outstanding_query("q1", "relay::1")
     node._route_query_response(
         _response("behind-relay::7",
                   route=[{"source": "responder::2", "targets": ["master:0.0.0.0"]},

--- a/tests/test_response_forgery_acl.py
+++ b/tests/test_response_forgery_acl.py
@@ -56,6 +56,7 @@ def _forged_response(msg_type, originator_peer, query_id="not-a-real-query"):
 
 def _wire(proto, peer):
     conn = MagicMock()
+    conn.peer = peer
     conn.send = MagicMock()
     proto.clients[peer] = conn
     return conn
@@ -98,8 +99,10 @@ def test_legitimate_query_response_still_reaches_its_originator():
 
     response = _forged_response(HiveMessageType.QUERY, "originator::1",
                                 query_id="real-query-42")
-    # simulate a genuinely privileged responder answering a real query
+    # simulate a genuinely privileged responder answering a real query the
+    # node actually saw (participation binding, MSG-1 §5.2)
     response.metadata["responder_peer"] = responder.peer
+    proto._record_outstanding_query("real-query-42", "originator::1")
 
     proto.handle_query_message(response, responder)
 
@@ -116,6 +119,8 @@ def test_legitimate_cascade_response_still_reaches_its_originator():
     response = _forged_response(HiveMessageType.CASCADE, "originator::1",
                                 query_id="real-query-42")
     response.metadata["responder_peer"] = responder.peer
+    # the node actually saw this request (participation binding, MSG-1 §5.2)
+    proto._record_outstanding_query("real-query-42", "originator::1")
 
     proto.handle_cascade_message(response, responder)
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

A node used to route a QUERY/CASCADE answer on the strength of the `originator_peer` field (and the message `route`) the sender supplied. `_route_query_response` treated those as delivery addresses with no proof the node had ever admitted the matching request, so any client holding `can_escalate`/`can_propagate` could name a victim and have an arbitrary Layer-1 payload — for example a spoofed `speak` — delivered straight to that victim, past the ACL.

HIVEMIND-MSG-1 §5.2 (participation binding) requires routing an answer only back to the server-observed connection the request arrived on. Each query is bound, at the two downstream request-admission sites, to `client.peer` — the arriving connection, never the client-claimed `originator_peer` — in a per-node store keyed `query_id -> (return_peer, monotonic time)` under its own lock. Binding is first-writer-wins so a live `query_id` cannot be rebound, bounded by a 300s TTL (no query timeout exists in config) and a 256-entry cap mirroring `_pending_cascades`. In `_route_query_response` the client-supplied `originator_peer` and route may only select a candidate connection; the recorded return path authorizes the send — a candidate whose peer is not the recorded return path is dropped, and the CASCADE collector runs only when the direct originator connection is the return path. Originator disconnect purges the entries bound to that connection.

This revision closes two bypasses an earlier existence-only check missed. Self-record: an attacker sends a request claiming a victim's `originator_peer`, then an answer for the same `query_id`. Crafted-route: an attacker plants a victim hop in the response route so the route-walk delivers to the victim. In both the recorded return path is the attacker's own connection, so the send is refused. Master-originated requests (the `query_from_master`/`cascade_from_master` relays) bind no downstream return path here, so their responses drop at `_route_query_response` exactly as before — covered by a test.

The change is per-node and self-contained: no wire format, metadata key, or bus message changes. A leaf satellite originates and consumes its own queries; a relay records the downstream connection each request arrived on, so legitimate multi-hop answers still route back along it. The only new drop is a genuinely unbacked answer.

Fail-before was verified by reverting only `protocol.py` and keeping the tests: the self-record, self-record-cascade and crafted-route forgery tests all deliver the answer to the victim (`send` "Called 1 times"); with the fix restored each is dropped. Existing positive-control tests that routed an answer for a request the node never recorded were updated to record the request the way the handler now does (`query_id` bound to the arriving connection). Full non-e2e suite: 393 passed, 1 skipped, 34 subtests.