### PR TITLE
fix: evict flooding peer's own outstanding queries first

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -740,14 +740,19 @@ class HiveMindListenerProtocol:
         answer can only be routed back that way (MSG-1 §5.2). FIRST-WRITER-WINS:
         a query_id already bound is never rebound, so an attacker cannot steal a
         live query's return path by replaying its id. Bounded by a hard cap
-        alongside the TTL eviction in ``_outstanding_return_path``."""
+        alongside the TTL eviction in ``_outstanding_return_path``; at the cap,
+        the inserting peer's own oldest entry is evicted first, so a peer
+        flooding distinct query_ids can only ever displace its own prior
+        entries and can never starve other peers' outstanding queries."""
         now = time.monotonic()
         with self._outstanding_queries_lock:
             store = self._outstanding_queries
             if query_id in store:
                 return
             while len(store) >= OUTSTANDING_QUERY_MAX:
-                store.pop(next(iter(store)))
+                own = next((q for q, (p, _) in store.items()
+                            if p == return_peer), None)
+                store.pop(own if own is not None else next(iter(store)))
             store[query_id] = (return_peer, now)
 
     def _outstanding_return_path(self, query_id: str) -> Optional[str]:

--- a/tests/test_outstanding_query_fairness.py
+++ b/tests/test_outstanding_query_fairness.py
@@ -1,0 +1,81 @@
+"""Fairness of the outstanding-query eviction (HIVEMIND-MSG-1 §5.2).
+
+``_record_outstanding_query`` binds a client-supplied ``query_id`` to the
+server-observed peer that sent the request, and bounds that store with a hard
+cap (``OUTSTANDING_QUERY_MAX``). Because ``query_id`` is chosen by the client,
+any single permitted peer (``can_escalate``/``can_propagate`` default true)
+can mint an unbounded number of distinct ids. If eviction picked the globally
+oldest entry regardless of who owns it, one peer flooding the store could
+evict every other peer's legitimately-outstanding return path, causing their
+genuine answers to be dropped by ``_route_query_response`` as "no request
+seen" — a cross-peer answer-loss denial of service.
+
+Eviction must instead prefer the INSERTING peer's own oldest entry, so a
+flood can only ever cost the flooder its own bindings.
+"""
+from hivemind_core.protocol import (HiveMindListenerProtocol,
+                                     OUTSTANDING_QUERY_MAX)
+
+
+def _make_node() -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node._outstanding_queries_store = None
+    node._outstanding_query_lock = None
+    return node
+
+
+def test_flood_does_not_evict_other_peers_entry():
+    """A flood of distinct query_ids from one peer must never evict a
+    different peer's outstanding query."""
+    node = _make_node()
+
+    node._record_outstanding_query("victim-qid", "victim-peer:1")
+    for i in range(OUTSTANDING_QUERY_MAX):
+        node._record_outstanding_query(f"atk-{i}", "attacker-peer:2")
+
+    assert node._outstanding_return_path("victim-qid") == "victim-peer:1"
+
+
+def test_flooding_peer_self_caps():
+    """The flooder's own entries are what gets evicted to make room, so it
+    never holds more than MAX - 1 of its own bindings once another peer's
+    entry is present."""
+    node = _make_node()
+
+    node._record_outstanding_query("victim-qid", "victim-peer:1")
+    for i in range(OUTSTANDING_QUERY_MAX):
+        node._record_outstanding_query(f"atk-{i}", "attacker-peer:2")
+
+    store = node._outstanding_queries
+    attacker_entries = sum(1 for (peer, _) in store.values()
+                            if peer == "attacker-peer:2")
+    assert attacker_entries <= OUTSTANDING_QUERY_MAX - 1
+    assert len(store) == OUTSTANDING_QUERY_MAX
+
+
+def test_newcomers_still_admitted_after_flood():
+    """Once an attacker has filled the store, fresh peers recording a single
+    query each must still be admitted (displacing the global-oldest attacker
+    entries), and the store never exceeds the cap."""
+    node = _make_node()
+
+    for i in range(OUTSTANDING_QUERY_MAX):
+        node._record_outstanding_query(f"atk-{i}", "attacker-peer:2")
+
+    fresh_qids = [f"fresh-qid-{i}" for i in range(5)]
+    for i, qid in enumerate(fresh_qids):
+        node._record_outstanding_query(qid, f"fresh-peer:{i}")
+
+    for qid in fresh_qids:
+        assert node._outstanding_return_path(qid) is not None
+    assert len(node._outstanding_queries) == OUTSTANDING_QUERY_MAX
+
+
+def test_first_writer_wins():
+    """A query_id already bound is never rebound to a different peer."""
+    node = _make_node()
+
+    node._record_outstanding_query("qid-1", "peer-a:1")
+    node._record_outstanding_query("qid-1", "peer-b:2")
+
+    assert node._outstanding_return_path("qid-1") == "peer-a:1"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

## Summary

`_record_outstanding_query` bounds the participation-binding store (`OUTSTANDING_QUERY_MAX = 256`) with a global FIFO: at the cap it always popped the globally-oldest entry, regardless of which peer owns it. Since `query_id` is client-supplied, any single permitted peer (`can_escalate`/`can_propagate` default true) can mint 256 distinct query_ids and evict every other peer's legitimately-outstanding return path well within the 300s TTL. The victim's genuine answer then hits the "no request seen" drop in `_route_query_response` and is silently discarded — a cross-peer answer-loss denial of service on the seam the participation-binding fix (#273) introduced.

The fix: when the store is at the cap, evict the INSERTING peer's own oldest entry first, falling back to the globally-oldest entry only when the inserting peer holds none. The hard cap, the TTL eviction, and the first-writer-wins guard are all unchanged; a flood now only ever costs the flooder its own bindings.

## Test plan

- [x] New `tests/test_outstanding_query_fairness.py` covering: cross-peer preservation under flood, the flooder self-capping at MAX-1, fresh peers still being admitted after a flood fills the store, and first-writer-wins.
- [x] Fail-before via patch-revert (source reverted, tests kept): `test_flood_does_not_evict_other_peers_entry` and `test_flooding_peer_self_caps` FAILED on unfixed `dev`, PASSED after re-applying the fix.
- [x] Full suite: 454 passed, 3 skipped, 1 xpassed (pre-existing xfail flip unrelated to this change), no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query tracking fairness when one peer sends many requests.
  * Prevented query entries belonging to other peers from being evicted unnecessarily.
  * Ensured existing query IDs remain associated with their original peer.
  * Preserved capacity for new peers while maintaining the query store limit.

* **Tests**
  * Added coverage for fair eviction, flooding scenarios, capacity limits, and query ownership consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->