### PR TITLE
fix: translate session_id to a per-connection Layer-1 id at the bridge

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -228,6 +228,11 @@ class HiveMindClientConnection:
     # ``name::session_id`` string. See ``handle_hello_message``.
     _peer_suffix: str = field(default="", init=False, repr=False)
 
+    # Per-connection nonce, minted lazily once and stable for the
+    # connection's life. Namespaces the client-declared session_id — see
+    # ``layer1_session_id`` below (HIVEMIND-BRIDGE-1 §4).
+    _conn_nonce: str = field(default="", init=False, repr=False)
+
     # Serialises ``send``. The IOLoop thread, the ovos messagebus thread and
     # the upstream slave thread all send on the same connection, and a v3
     # Noise frame is only decryptable in the order its nonce was assigned, so
@@ -239,6 +244,26 @@ class HiveMindClientConnection:
     # outer frame was handed over, so it cannot invert the nonce sequence.
     _send_lock: threading.RLock = field(default_factory=threading.RLock,
                                         init=False, repr=False)
+
+    @property
+    def conn_nonce(self) -> str:
+        """Per-connection nonce, minted lazily on first use and stable for
+        the connection's life."""
+        if not self._conn_nonce:
+            self._conn_nonce = uuid.uuid4().hex
+        return self._conn_nonce
+
+    @property
+    def layer1_session_id(self) -> str:
+        """The orchestrator-side (Layer-1) session id for this connection's
+        CURRENT declared session — the connection nonce namespaces the
+        client-declared session_id, so two connections that chose the same
+        name get distinct Layer-1 sessions (HIVEMIND-BRIDGE-1 §4) while one
+        connection's distinct declared sessions (a re-HELLO, or a bridge like
+        baresip that mints a fresh session_id per call on one connection)
+        stay distinct too — session travels per message, the client
+        declares it."""
+        return f"{self.conn_nonce}:{self.sess.session_id}"
 
     def resolve_user(self, db, ttl: float = 5.0,
                      force: bool = False) -> Optional[Client]:
@@ -2874,6 +2899,13 @@ class HiveMindListenerProtocol:
             session.pop("pipeline", None)
         # SESSION-1 §2: strip null-valued fields — null is malformed, treat as absent.
         session = {k: v for k, v in session.items() if v is not None}
+        # HIVEMIND-BRIDGE-1 §4: session_id is a Layer-1 (orchestrator) identity
+        # that OVOS SessionManager keys conversational state on. The client
+        # picks it arbitrarily, so two peers choosing the same value (e.g. both
+        # "default") would otherwise collide onto one OVOS session. Translate
+        # it at this inbound boundary to a per-connection id; every other
+        # session field is passed through unchanged.
+        session["session_id"] = client.layer1_session_id
         message.context["session"] = session
         return message
 

--- a/tests/e2e/test_bridge1_conformance.py
+++ b/tests/e2e/test_bridge1_conformance.py
@@ -200,9 +200,14 @@ def test_destination_routed():
 # ─────────────────────────────────────────────────────────────────────────────
 
 def test_session_inbound_preserved():
-    """Satellite's session fields are preserved into bus context.session.
+    """Satellite's session fields are preserved into bus context.session,
+    except ``session_id`` itself, which the bridge translates to a
+    per-connection Layer-1 id (HIVEMIND-BRIDGE-1 §4): the client-chosen
+    session_id is an orchestrator-side identity OVOS SessionManager keys
+    conversational state on, and two peers picking the same value must not
+    collide onto one OVOS session.
 
-    Spec: BRIDGE-1 §4.1 (inbound)
+    Spec: BRIDGE-1 §4.1 (inbound), §4 (session_id translation)
     Helper: assert_session_inbound_preserved
     """
     b = _topology_with_utterance()
@@ -222,8 +227,17 @@ def test_session_inbound_preserved():
 
         assert_session_inbound_preserved(
             m, s,
-            expected_session={"session_id": sid, "lang": sess.serialize().get("lang")},
+            expected_session={"lang": sess.serialize().get("lang")},
         )
+
+        peer = s.peer
+        record = [
+            r for r in m.recorder.snapshot()
+            if r.direction == "bus_inject" and r.peer == peer
+        ][-1]
+        actual_sid = (getattr(record.payload, "context", {}) or {}).get(
+            "session", {}).get("session_id")
+        assert actual_sid != sid
     finally:
         b.stop_all()
 

--- a/tests/e2e/test_bus_routing.py
+++ b/tests/e2e/test_bus_routing.py
@@ -41,7 +41,12 @@ def test_satellite_bus_message_reaches_master_bus():
 
 
 def test_satellite_session_id_attached_to_inbound_bus_messages():
-    """Master-side bus message context carries the satellite's session_id."""
+    """Master-side bus message context carries a session_id — but it is the
+    bridge's own per-connection Layer-1 id, not the satellite's chosen one
+    (HIVEMIND-BRIDGE-1 §4): session_id is an orchestrator-side identity that
+    OVOS SessionManager keys conversational state on, so the client-chosen
+    value is translated at the inbound boundary.
+    """
     b = admin_satellite(allowed_types=["recognizer_loop:utterance"])
     try:
         b.start_all()
@@ -59,8 +64,10 @@ def test_satellite_session_id_attached_to_inbound_bus_messages():
 
         assert _wait_for(lambda: len(seen) >= 1)
         ctx = seen[0].context.get("session", {})
-        assert ctx.get("session_id") == s0.shim.session_id, (
-            f"session_id missing or wrong: {ctx}"
+        assert ctx.get("session_id"), f"session_id missing: {ctx}"
+        assert ctx.get("session_id") != s0.shim.session_id, (
+            f"session_id should be translated to a Layer-1 id, not the "
+            f"satellite's own: {ctx}"
         )
     finally:
         b.stop_all()

--- a/tests/test_policy_chain.py
+++ b/tests/test_policy_chain.py
@@ -818,6 +818,7 @@ class TestProtocolWiring(unittest.TestCase):
         client.sess.session_id = "session-1"
         client.sess.serialize.return_value = {"session_id": "session-1"}
         client.sess.pipeline = None
+        client.layer1_session_id = "layer1-session-1"
         client.authorize.return_value = True
         client.key = "test-key"
         client._resolved_user = None

--- a/tests/test_session_nat.py
+++ b/tests/test_session_nat.py
@@ -1,0 +1,144 @@
+"""Inbound session_id NAT at the bridge (HIVEMIND-BRIDGE-1 §4).
+
+``session_id`` is a Layer-1 (orchestrator) identity that OVOS
+``SessionManager`` keys per-conversation state on. The client picks it
+arbitrarily, so two connections that happen to choose the same value (two
+satellites both using "default", or any shared name) must not resolve to the
+same OVOS session — that would merge their converse/active-skill/dialog
+state. ``_install_client_session`` must translate the client-chosen
+``session_id`` to a per-connection Layer-1 id before the message reaches the
+OVOS bus, while leaving every other session field untouched.
+
+The Layer-1 id is derived as ``f"{conn_nonce}:{sess.session_id}"``, NOT
+cached once per connection: session travels per message and the client
+declares it (a peer may re-HELLO with a new session_id, and a bridge like
+the baresip SIP gateway mints a fresh session_id per call on a single,
+long-lived connection). Namespacing by the connection's own nonce keeps two
+different connections that pick the same declared name apart, while letting
+one connection's distinct declared sessions (a fresh call, a re-HELLO) stay
+distinct from each other too.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+
+def _make_protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.return_value = agent.bus
+
+    db = MagicMock()
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+
+
+def _make_client(sess, key="test-key", name="test-client"):
+    client = HiveMindClientConnection(
+        key=key,
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=_make_protocol(),
+        sess=sess,
+    )
+    client.name = name
+    return client
+
+
+def _install(client, message):
+    node = object.__new__(HiveMindListenerProtocol)
+    return node._install_client_session(message, client)
+
+
+def test_two_connections_same_session_id_get_distinct_layer1_sessions():
+    first = _make_client(Session(session_id="shared"), key="key-1", name="sat-1")
+    second = _make_client(Session(session_id="shared"), key="key-2", name="sat-2")
+
+    msg1 = _install(first, Message("recognizer_loop:utterance",
+                                    {"utterances": ["hi"]}))
+    msg2 = _install(second, Message("recognizer_loop:utterance",
+                                     {"utterances": ["hi"]}))
+
+    sid1 = msg1.context["session"]["session_id"]
+    sid2 = msg2.context["session"]["session_id"]
+
+    assert sid1 != sid2
+    assert sid1 == first.layer1_session_id
+    assert sid2 == second.layer1_session_id
+
+
+def test_layer1_session_id_is_stable_per_connection():
+    client = _make_client(Session(session_id="shared"))
+
+    msg1 = _install(client, Message("recognizer_loop:utterance",
+                                     {"utterances": ["one"]}))
+    msg2 = _install(client, Message("recognizer_loop:utterance",
+                                     {"utterances": ["two"]}))
+
+    sid1 = msg1.context["session"]["session_id"]
+    sid2 = msg2.context["session"]["session_id"]
+
+    assert sid1 == sid2 == client.layer1_session_id
+
+
+def test_redeclared_session_gets_a_distinct_layer1_session():
+    # A single connection may declare a new session_id mid-life — a re-HELLO,
+    # or a bridge like baresip's SIP gateway that mints a fresh session_id
+    # per call on one long-lived connection. Each declared session must get
+    # its own Layer-1 id; caching the Layer-1 id once per connection would
+    # wrongly collapse them into a single OVOS session.
+    client = _make_client(Session(session_id="call-1"))
+
+    msg1 = _install(client, Message("recognizer_loop:utterance",
+                                     {"utterances": ["first call"]}))
+    sid1 = msg1.context["session"]["session_id"]
+
+    client.sess = Session(session_id="call-2")
+
+    msg2 = _install(client, Message("recognizer_loop:utterance",
+                                     {"utterances": ["second call"]}))
+    sid2 = msg2.context["session"]["session_id"]
+
+    assert sid1 != sid2
+    nonce1, _, declared1 = sid1.partition(":")
+    nonce2, _, declared2 = sid2.partition(":")
+    assert nonce1 == nonce2 == client.conn_nonce
+    assert declared1 == "call-1"
+    assert declared2 == "call-2"
+
+
+def test_session_contents_preserved():
+    sess = Session(session_id="shared", lang="pt-pt")
+    sess.intent_context["some_key"] = "some_value"
+    client = _make_client(sess)
+
+    message = _install(client, Message("recognizer_loop:utterance",
+                                        {"utterances": ["hi"]}))
+
+    session = message.context["session"]
+    assert session["session_id"] == client.layer1_session_id
+    assert session["session_id"] != "shared"
+    assert session["lang"].lower() == "pt-pt"
+    assert session["intent_context"]["some_key"] == "some_value"
+
+
+def test_same_connection_different_named_payload_still_one_layer1_session():
+    client = _make_client(Session(session_id="shared"))
+
+    # a bus message arriving with a *different* session name already
+    # attached to it (e.g. relayed/replayed) must still be re-stamped with
+    # this connection's own Layer-1 id: the peer names its session at the
+    # connection level, not per message.
+    message = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
+                       {"session": {"session_id": "someone-elses-session"}})
+
+    result = _install(client, message)
+
+    assert result.context["session"]["session_id"] == client.layer1_session_id
+    assert result.context["session"]["session_id"] != "someone-elses-session"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

OVOS `session_id` is a Layer-1 (orchestrator) identity that `SessionManager` keys per-conversation state on. `_install_client_session` in `hivemind_core/protocol.py` was stamping the client-chosen `session_id` verbatim onto every inbound bus message. Two connections that happen to pick the same `session_id` — two satellites both using "default", or any other shared name — collided onto the same OVOS session, so their converse/active-skill/dialog state bled into each other. Response delivery is already correctly peer-routed (by `destination`), so this was a Layer-1 conversational-state bleed, not a misdelivery bug.

The fix derives a Layer-1 session id as `f"{conn_nonce}:{sess.session_id}"`: `conn_nonce` is a per-connection random id minted lazily on first use and stable for the connection's life, and `sess.session_id` is whatever the client currently has declared. `_install_client_session` stamps this derived id onto inbound messages instead of the client's raw `session_id`. Every other session field is passed through unchanged, so session-content fidelity (HIVEMIND-BRIDGE-1 §4) is preserved; only the identity field is translated at this inbound boundary.

The id is deliberately derived rather than cached once per connection. Session travels per message, and the client declares it — a peer may re-HELLO with a new `session_id` mid-connection, and the deployed baresip SIP bridge mints a fresh `session_id` per call on one long-lived connection. Caching the Layer-1 id once per connection would collapse all of a bridge's distinct calls, or a peer's re-HELLO'd sessions, onto a single OVOS session — reintroducing state bleed from a different angle. Namespacing by the connection's own nonce keeps two different connections that pick the same declared name apart, while letting one connection's distinct declared sessions stay distinct from each other too.

Fail-before was verified twice. First, for the base translation: reverting only the `protocol.py` change and rerunning `tests/test_session_nat.py` made all new tests fail with `AttributeError: 'HiveMindClientConnection' object has no attribute 'layer1_session_id'`, including the one that builds two connections sharing `session_id="shared"` and asserts they get distinct stamped ids. Second, for the derived-vs-cached distinction: `test_redeclared_session_gets_a_distinct_layer1_session` stamps one connection with `session_id="call-1"`, reassigns `client.sess = Session(session_id="call-2")`, and stamps again — against an earlier cached-once implementation this failed with both stamped ids equal; against the derived implementation both ids differ while sharing the same nonce prefix. Restoring the fix made every new test pass.

Two existing tests had pinned the old, buggy verbatim-stamp behavior and needed updating to expect the translated id: `tests/e2e/test_bridge1_conformance.py::test_session_inbound_preserved` previously asserted the stamped `session_id` equaled the satellite's own id, and `tests/e2e/test_bus_routing.py::test_satellite_session_id_attached_to_inbound_bus_messages` previously asserted the master-side bus context carried the satellite's own `session_id`. Both now assert the session_id is translated away from the client-chosen value while other session fields remain intact. `tests/test_policy_chain.py`'s `TestProtocolWiring` MagicMock client fixture also needed an explicit `layer1_session_id` string, since it specs `HiveMindClientConnection` and the new property otherwise returned an unconfigured `MagicMock` that broke bus-message JSON serialization.

The full suite passes: 459 passed, 3 skipped, 1 pre-existing unrelated xpass (`test_fifo_order_relay_chain`), no regressions introduced.

Out of scope for this PR: translating the reverse map on the outbound side (`hivemind-ovos-agent-plugin`'s `handle_internal_mycroft`), and any relaxation of the BRIDGE-1 §4.1 "default session forbidden" HELLO check, which is left untouched.