### PR TITLE
Re-check is_admin from the DB at the session-NAT boundary

### DIFF
--- a/hivemind_core/policy.py
+++ b/hivemind_core/policy.py
@@ -250,6 +250,15 @@ class DefaultSessionPolicy(PolicyPlugin):
     ``OVOSAgentPolicy`` performs the same check, but operators remove it
     whenever they run a non-OVOS backend. The reserved id is a property of
     the bridge, not of one agent, so the gate belongs in core.
+
+    Defense-in-depth note: in the live call graph,
+    ``_install_client_session`` already NATs a non-admin's declared
+    "default" to a per-connection Layer-1 id *before* the policy chain
+    runs, so this policy currently never actually sees a literal
+    "default" on a non-admin message — the check below is a backstop, not
+    the primary gate. If a future refactor ever reorders the NAT after
+    the policy chain, this policy becomes load-bearing; see
+    ``tests/test_session_nat_ordering.py``.
     """
 
     def review(self, message: Message,

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -2911,8 +2911,22 @@ class HiveMindListenerProtocol:
         # This translation only applies to non-admin connections. An admin is
         # trusted to skip it and address the orchestrator's sessions directly
         # (including the reserved, device-local "default"), per BRIDGE-1
-        # §4/§4.1.
-        if client.is_admin:
+        # §4/§4.1. Admin standing now gates that un-NATted write access, so
+        # (like ``MessageTypeACLPolicy`` does for ``allowed_types``) it is
+        # re-checked from the DB here rather than trusted from the
+        # connect-time snapshot — an operator revoking admin on a live
+        # connection takes effect within ``resolve_user``'s TTL instead of
+        # only on reconnect. Fall back to the connection snapshot only when
+        # the DB row can't be resolved at all.
+        db = getattr(self, "db", None)
+        user = None
+        if db is not None:
+            try:
+                user = client.resolve_user(db)
+            except Exception:
+                LOG.exception("_install_client_session: failed to resolve user for admin check")
+        is_admin = user.is_admin if user is not None else client.is_admin
+        if is_admin:
             session["session_id"] = client.sess.session_id
         else:
             session["session_id"] = client.layer1_session_id

--- a/tests/test_admin_refresh.py
+++ b/tests/test_admin_refresh.py
@@ -1,0 +1,96 @@
+"""``_install_client_session`` decides whether to NAT the session id based on
+admin standing. That standing now gates un-NATted write access to the
+orchestrator's device-local "default" session, so it must be re-checked from
+the DB on each admission -- mirroring how ``MessageTypeACLPolicy`` refreshes
+``allowed_types`` via ``client.resolve_user(db)`` -- instead of trusted from
+the connect-time ``client.is_admin`` snapshot forever (HIVEMIND-BRIDGE-1
+§4/§4.1).
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+
+def _make_protocol(db):
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.return_value = agent.bus
+    agent.callbacks = MagicMock()
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+
+
+def _make_client(protocol, sess, is_admin, key="test-key", name="test-client"):
+    client = HiveMindClientConnection(
+        key=key,
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+        sess=sess,
+    )
+    client.name = name
+    client.is_admin = is_admin
+    client.allowed_types = ["recognizer_loop:utterance"]
+    return client
+
+
+def _stamp(protocol, client):
+    return protocol._install_client_session(
+        Message("recognizer_loop:utterance", {"utterances": ["hi"]}), client)
+
+
+def test_revoked_admin_is_natted_at_next_message():
+    db_user = MagicMock(is_admin=True)
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    protocol = _make_protocol(db)
+    client = _make_client(protocol, Session(session_id="default"), is_admin=True)
+
+    first = _stamp(protocol, client)
+    assert first.context["session"]["session_id"] == "default"
+
+    # operator revokes admin in the DB, then forces the connection's cached
+    # resolved-user to expire (mirrors resolve_user's TTL elapsing).
+    db_user.is_admin = False
+    client.invalidate_user()
+
+    second = _stamp(protocol, client)
+    session_id = second.context["session"]["session_id"]
+    assert session_id != "default"
+    assert session_id.endswith(":default")
+
+
+def test_granted_admin_takes_effect_at_next_message():
+    db_user = MagicMock(is_admin=False)
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    protocol = _make_protocol(db)
+    client = _make_client(protocol, Session(session_id="default"), is_admin=False)
+
+    first = _stamp(protocol, client)
+    assert first.context["session"]["session_id"] != "default"
+
+    db_user.is_admin = True
+    client.invalidate_user()
+
+    second = _stamp(protocol, client)
+    assert second.context["session"]["session_id"] == "default"
+
+
+def test_resolve_failure_falls_back_to_connection_snapshot():
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = None
+
+    protocol = _make_protocol(db)
+    client = _make_client(protocol, Session(session_id="default"), is_admin=True)
+
+    message = _stamp(protocol, client)
+    assert message.context["session"]["session_id"] == "default"

--- a/tests/test_default_session_relax.py
+++ b/tests/test_default_session_relax.py
@@ -24,6 +24,10 @@ def _make_protocol():
     agent.callbacks = MagicMock()
 
     db = MagicMock()
+    # No DB-backed user by default: _install_client_session falls back to
+    # the connection's is_admin snapshot, which is what these tests pin.
+    # See tests/test_admin_refresh.py for the DB-refresh behavior itself.
+    db.get_client_by_api_key.return_value = None
 
     return HiveMindListenerProtocol(agent_protocol=agent, db=db,
                                     require_crypto=False,

--- a/tests/test_session_nat_ordering.py
+++ b/tests/test_session_nat_ordering.py
@@ -1,0 +1,79 @@
+"""``DefaultSessionPolicy`` denies a non-admin message whose ``session_id``
+is the reserved, device-local ``"default"``. In the live call graph
+``_install_client_session`` NATs that id to a per-connection Layer-1 id
+(``"<nonce>:default"``) *before* ``handle_inject_agent_msg`` hands the
+message to the policy chain (HIVEMIND-BRIDGE-1 §4/§4.1), so
+``DefaultSessionPolicy`` is a defense-in-depth backstop, not the primary
+gate, for non-admins today.
+
+This test pins that ordering behaviorally: a non-admin "default" message
+driven through ``handle_inject_agent_msg`` must be admitted (not denied
+with ``session_id_default_forbidden``) because the session was already
+rewritten by the time the policy chain reviews it. If a future refactor
+ever moves the NAT after the policy chain, this test fails.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+
+def _make_protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.return_value = agent.bus
+    agent.callbacks = MagicMock()
+
+    db_user = MagicMock()
+    db_user.is_admin = False
+    db_user.allowed_types = ["recognizer_loop:utterance"]
+    db_user.skill_blacklist = []
+    db_user.intent_blacklist = []
+    db_user.message_blacklist = []
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+
+
+def _make_client(protocol):
+    client = HiveMindClientConnection(
+        key="test-key",
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+        sess=Session(session_id="default"),
+    )
+    client.name = "test-client"
+    client.is_admin = False
+    client.allowed_types = ["recognizer_loop:utterance"]
+    client.send = MagicMock()
+    return client
+
+
+def test_non_admin_default_message_is_admitted_because_nat_precedes_policy():
+    protocol = _make_protocol()
+    client = _make_client(protocol)
+
+    message = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
+                       {"session": {"session_id": "default"}})
+
+    protocol.handle_inject_agent_msg(message, client)
+
+    # not denied: no policy-denied notice sent to the client
+    for call in client.send.call_args_list:
+        payload = call.args[0]
+        assert "session_id_default_forbidden" not in str(payload)
+
+    # the message that reached the agent bus carries the NATted id, not
+    # the bare, device-local "default"
+    emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
+    session_id = emitted.context["session"]["session_id"]
+    assert session_id != "default"
+    assert session_id.endswith(":default")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

`_install_client_session` decides whether an inbound message's session id gets NATted (non-admin gets `"<nonce>:session"`, admin gets the raw id) based on `client.is_admin`, which is a connect-time snapshot the transport never refreshes for the life of the connection. Since admin standing now gates un-NATted write access to the orchestrator's device-local `"default"` session (HIVEMIND-BRIDGE-1 §4/§4.1), revoking admin on a live connection previously left that connection able to keep writing to `"default"` until it reconnected. `MessageTypeACLPolicy` already refreshes `allowed_types` from the DB on every admission via `client.resolve_user(db)`, so a message-type revocation is instant while an admin revocation was not — an inconsistency in how quickly two comparable capability changes take effect.

The fix resolves a fresh `is_admin` from the DB at the NAT decision, using the same TTL-cached `client.resolve_user(self.db)` path `MessageTypeACLPolicy` already uses, and falls back to the connect-time `client.is_admin` snapshot only when no DB row can be resolved (DB unreachable, or a bypass-built protocol object with no `db` at all, which a couple of existing unit tests construct directly). The disconnect-emit and the broadcast gate, which still read the raw connection snapshot, are intentionally out of scope here.

Separately, `DefaultSessionPolicy` denies a non-admin message whose `session_id` is literally `"default"`, but in the live call graph `_install_client_session` already rewrites that id before the policy chain ever runs, so the policy is defense-in-depth rather than the primary gate today. This PR documents that ordering dependency on the policy and adds a behavioral test that fails if a future refactor ever moves the session NAT after the policy chain.

Fail-before: reverting only the `protocol.py` change made `test_revoked_admin_is_natted_at_next_message` and `test_granted_admin_takes_effect_at_next_message` fail — both still produced the raw, un-NATted session id after the DB revoked or granted admin — while `test_resolve_failure_falls_back_to_connection_snapshot` continued to pass. Reapplying the fix made all three pass.

Full suite: 471 passed, 3 skipped, 1 pre-existing xpass in `tests/e2e/test_bridge1_conformance.py::test_fifo_order_relay_chain`, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Administrative status changes now take effect on active connections during the next message, including admin revocation and granting.
  - Added a safe fallback when the database user cannot be resolved.
  - Non-admin default sessions are correctly isolated before policy checks, preventing valid messages from being rejected.

- **Tests**
  - Added coverage for administrator status refresh, fallback behavior, and session-ID handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->