### PR TITLE
fix: re-assert Layer-1 session after transformers and refresh is_admin for all admin gates

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -563,7 +563,7 @@ class HiveMindListenerProtocol:
     _last_ping_flood: float = field(default=0.0, init=False, repr=False)
     ping_flood_interval: float = field(default=30.0, init=False)
 
-    # OVOS transformer pipelines for the text/bus path (OVOS-TRANSFORM).
+    # OVOS transformer pipelines for the text/bus path.
     # Config-gated and opt-in via the utterance_transformers /
     # metadata_transformers / dialog_transformers blocks in server.json;
     # empty chains are no-ops.
@@ -1172,6 +1172,25 @@ class HiveMindListenerProtocol:
             return
 
         LOG.debug(f"message: {message}")
+
+        # Refresh is_admin from the DB once, here, so every admin-gated
+        # decision downstream of this dispatcher (the session NAT in
+        # _install_client_session, the BROADCAST gate in
+        # handle_broadcast_message, ...) sees a value no staler than
+        # resolve_user's TTL, instead of the connect-time snapshot for the
+        # life of the connection (HIVEMIND-BRIDGE-1 §4/§4.1). The disconnect
+        # lifecycle emit runs on socket close, outside this dispatcher, and
+        # keeps reading whatever is_admin was last refreshed to here.
+        db = getattr(self, "db", None)
+        if db is not None:
+            try:
+                user = client.resolve_user(db)
+            except Exception:
+                LOG.exception("handle_message: failed to resolve user for is_admin refresh")
+            else:
+                if user is not None:
+                    client.is_admin = user.is_admin
+
         # update internal peer ID
         message.update_source_peer(client.peer)
 
@@ -2872,6 +2891,17 @@ class HiveMindListenerProtocol:
         return False
 
     # HiveMind mycroft bus messages -  from slave -> master
+    @staticmethod
+    def _layer1_session_id(client: HiveMindClientConnection, is_admin: bool) -> str:
+        """The Layer-1 (orchestrator) session id this client is allowed to
+        address: the raw, client-declared session id for an admin, or the
+        per-connection NATted id for everyone else (HIVEMIND-BRIDGE-1 §4).
+        Shared by ``_install_client_session`` and the post-transformer
+        re-stamp in ``handle_inject_agent_msg`` so both apply the exact same
+        decision.
+        """
+        return client.sess.session_id if is_admin else client.layer1_session_id
+
     def _install_client_session(self, message: Message,
                                  client: HiveMindClientConnection):
         """Copy the client's serialised session onto an inbound bus message.
@@ -2926,10 +2956,7 @@ class HiveMindListenerProtocol:
             except Exception:
                 LOG.exception("_install_client_session: failed to resolve user for admin check")
         is_admin = user.is_admin if user is not None else client.is_admin
-        if is_admin:
-            session["session_id"] = client.sess.session_id
-        else:
-            session["session_id"] = client.layer1_session_id
+        session["session_id"] = self._layer1_session_id(client, is_admin)
         message.context["session"] = session
         return message
 
@@ -2963,8 +2990,8 @@ class HiveMindListenerProtocol:
             return
 
         # OVOS transformer pipelines: rewrite utterances / context before
-        # they reach the agent bus. A §8.1 cancellation terminates the
-        # lifecycle here (§8.2), the message never reaches the agent.
+        # they reach the agent bus. A cancellation terminates the lifecycle
+        # here, the message never reaches the agent.
         if message.msg_type == "recognizer_loop:utterance":
             message = self._apply_utterance_transformers(message, client)
             if message is None:
@@ -2973,6 +3000,20 @@ class HiveMindListenerProtocol:
         # send client message to internal mycroft bus
         LOG.info(f"Forwarding message '{message.msg_type}' to agent bus from client: {client.peer}")
         message.context["peer"] = message.context["source"] = client.peer
+        # A metadata/utterance transformer wholesale-replaces message.context
+        # (see _apply_utterance_transformers), which could otherwise let a
+        # config-opt-in transformer plugin move this message into another
+        # client's Layer-1 session (e.g. write "default" back into
+        # context["session"]["session_id"]) just like peer/source above must
+        # be re-stamped, the session id installed by _install_client_session
+        # is re-asserted here, after the transformer chain has run and right
+        # before the message reaches the agent bus (HIVEMIND-BRIDGE-1 §4).
+        is_admin = getattr(client, "is_admin", False)
+        session = message.context.get("session")
+        if not isinstance(session, dict):
+            session = {}
+        session["session_id"] = self._layer1_session_id(client, is_admin)
+        message.context["session"] = session
 
         try:
             bus = self.get_bus(client)
@@ -2997,9 +3038,9 @@ class HiveMindListenerProtocol:
         ``recognizer_loop:utterance`` message.
 
         Returns the (possibly rewritten) message, or ``None`` when a
-        transformer canceled the utterance — in that case the OVOS-TRANSFORM
-        §8.2 terminal events are sent back to the client and the message is
-        not injected into the agent bus.
+        transformer canceled the utterance — in that case the terminal
+        events are sent back to the client and the message is not injected
+        into the agent bus.
         """
         if not (self.utterance_transformers.plugins
                 or self.metadata_transformers.plugins):
@@ -3016,7 +3057,7 @@ class HiveMindListenerProtocol:
         if context.get("canceled"):
             LOG.info(f"utterance from {client.peer} canceled by "
                      f"{context.get('cancel_by')}: {context.get('cancel_reason')}")
-            # OVOS-TRANSFORM §8.2 terminal path: cancelled -> handled
+            # terminal path: cancelled -> handled
             for msg_type in ("ovos.utterance.cancelled", "ovos.utterance.handled"):
                 try:
                     client.send(HiveMessage(

--- a/tests/test_admin_refresh.py
+++ b/tests/test_admin_refresh.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
 
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
 from hivemind_core.protocol import (HiveMindClientConnection,
                                     HiveMindListenerProtocol)
 
@@ -83,6 +85,44 @@ def test_granted_admin_takes_effect_at_next_message():
 
     second = _stamp(protocol, client)
     assert second.context["session"]["session_id"] == "default"
+
+
+def _broadcast_hivemessage():
+    inner = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {"utterance": "hi"}))
+    return HiveMessage(HiveMessageType.BROADCAST, payload=inner)
+
+
+def test_revoked_admin_loses_broadcast_at_next_message():
+    """``handle_broadcast_message`` reads ``client.is_admin`` directly, not
+    ``resolve_user``. It must still see a revoked admin's new standing at the
+    connection's next message, because ``handle_message`` — the common
+    dispatcher for every inbound message type — refreshes ``client.is_admin``
+    from the DB before dispatching (HIVEMIND-BRIDGE-1 §4/§4.1)."""
+    db_user = MagicMock(is_admin=True)
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    protocol = _make_protocol(db)
+    client = _make_client(protocol, Session(session_id="default"), is_admin=True)
+    client.can_broadcast = True
+    protocol.clients = {}
+    protocol.illegal_callback = None
+    protocol.broadcast_callback = MagicMock()
+    protocol.identity = MagicMock(public_key="pubkey-master", site_id=None)
+
+    # while still admin, broadcast is allowed
+    protocol.handle_message(_broadcast_hivemessage(), client)
+    protocol.broadcast_callback.assert_called_once()
+    client.disconnect.assert_not_called()
+
+    # operator revokes admin in the DB
+    db_user.is_admin = False
+    protocol.broadcast_callback.reset_mock()
+
+    protocol.handle_message(_broadcast_hivemessage(), client)
+    protocol.broadcast_callback.assert_not_called()
+    client.disconnect.assert_called_once_with()
+    assert client.is_admin is False
 
 
 def test_resolve_failure_falls_back_to_connection_snapshot():

--- a/tests/test_transformer_pipelines.py
+++ b/tests/test_transformer_pipelines.py
@@ -40,7 +40,19 @@ class EmptyService:
     plugins = []
 
 
-def _make_protocol(**services):
+class SessionHijackMetadataService:
+    """A metadata transformer that tries to move the message into the
+    orchestrator's device-local "default" session, e.g. impersonating
+    another connection's Layer-1 session."""
+    plugins = ["fake"]
+
+    def transform(self, context=None):
+        context = dict(context or {})
+        context["session"] = {"session_id": "default"}
+        return context
+
+
+def _make_protocol(db_is_admin=True, **services):
     agent = MagicMock()
     agent.bus = MagicMock()
     agent.get_bus.return_value = agent.bus
@@ -51,7 +63,7 @@ def _make_protocol(**services):
     db_user.intent_blacklist = []
     db_user.message_blacklist = []
     db_user.allowed_types = ["recognizer_loop:utterance"]
-    db_user.is_admin = True
+    db_user.is_admin = db_is_admin
 
     db = MagicMock()
     db.get_client_by_api_key.return_value = db_user
@@ -62,7 +74,7 @@ def _make_protocol(**services):
     return HiveMindListenerProtocol(agent_protocol=agent, db=db, **services)
 
 
-def _make_client(protocol):
+def _make_client(protocol, is_admin=True):
     client = HiveMindClientConnection(
         key="test-key",
         send_msg=MagicMock(),
@@ -71,7 +83,7 @@ def _make_client(protocol):
     )
     client.name = "test-client"
     client.allowed_types = ["recognizer_loop:utterance"]
-    client.is_admin = True
+    client.is_admin = is_admin
     client.sess = Session("session-1", site_id="client-site")
     client.send = MagicMock()
     return client
@@ -131,6 +143,21 @@ class TestInjectPathTransformers(unittest.TestCase):
         cancelled = client.send.call_args_list[0].args[0].payload
         self.assertEqual(cancelled.data["cancel_reason"], "stop_word")
         self.assertEqual(cancelled.data["cancel_by"], "fake")
+
+    def test_metadata_transformer_cannot_hijack_session(self):
+        """A metadata transformer wholesale-replaces message.context, which
+        must not let it move a non-admin's message into another Layer-1
+        session (e.g. the orchestrator's device-local "default") — the
+        session_id installed by _install_client_session is re-asserted
+        after the transformer chain runs (HIVEMIND-BRIDGE-1 §4)."""
+        protocol = _make_protocol(db_is_admin=False,
+                                  metadata_transformers=SessionHijackMetadataService())
+        client = _make_client(protocol, is_admin=False)
+        protocol.handle_inject_agent_msg(_utterance_message(), client)
+        emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
+        session_id = emitted.context["session"]["session_id"]
+        self.assertNotEqual(session_id, "default")
+        self.assertEqual(session_id, client.layer1_session_id)
 
 
 class TestQueryPathTransformers(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

This closes two gaps found in the final audit wave, both in `hivemind_core/protocol.py`, plus a comment cleanup.

The first gap sits in `handle_inject_agent_msg`. `_install_client_session` NATs the inbound session id so a non-admin client's declared session never collides with, or reaches, the orchestrator's device-local "default" session. But the utterance/metadata transformer chain that runs right after wholesale-replaces `message.context`, and the code only re-stamped `context["peer"]`/`context["source"]` afterward, not `context["session"]["session_id"]`. A config-opt-in metadata transformer plugin could therefore write `context["session"]["session_id"] = "default"` and have it survive straight to the agent bus, undoing the Layer-1 isolation the NAT exists for. The fix extracts the "which Layer-1 session id may this client address" decision into a small `_layer1_session_id` helper, used both by `_install_client_session` and by a re-stamp added right after the transformer chain, immediately before `bus.emit`.

The second gap is that `is_admin` was only ever refreshed from the DB inside `_install_client_session`. `handle_broadcast_message`'s BROADCAST gate and the disconnect lifecycle emit kept reading the connect-time `client.is_admin` snapshot, so an admin revoked mid-connection retained broadcast privileges for the rest of that connection's life, unbounded by `resolve_user`'s TTL. `handle_message`, the single dispatcher every inbound message type passes through, now refreshes `client.is_admin` from the DB before dispatching, so every admin-gated decision downstream of it sees a value no staler than the TTL. `_install_client_session` keeps its own resolve as a backstop for callers that reach it directly.

Third, a few comments cited "OVOS-TRANSFORM §8.1/§8.2" section numbers from a spec that doesn't exist in the JarbasHiveMind/architecture repo. Those citations are removed; the surrounding behavioral description is kept.

## Test plan
- `tests/test_transformer_pipelines.py::test_metadata_transformer_cannot_hijack_session`: a non-admin connection with a metadata transformer that tries to set `session_id` to `"default"`; asserts the message that reaches `bus.emit` carries the client's real (NATted) Layer-1 session id instead. Confirmed this fails against the unfixed source (session id lands as `"default"`) and passes after.
- `tests/test_admin_refresh.py::test_revoked_admin_loses_broadcast_at_next_message`: an admin connection is allowed to broadcast, gets revoked in the DB, and is denied (and disconnected) on its very next message — because `handle_message` refreshed `client.is_admin`. Confirmed this fails against the unfixed source (broadcast still allowed) and passes after.
- Full suite (isolated HOME): 473 passed, 3 skipped, 1 xpassed, 0 failed.