### PR TITLE
fix: re-resolve is_admin fresh in the post-transformer session re-stamp

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -3008,7 +3008,19 @@ class HiveMindListenerProtocol:
         # be re-stamped, the session id installed by _install_client_session
         # is re-asserted here, after the transformer chain has run and right
         # before the message reaches the agent bus (HIVEMIND-BRIDGE-1 §4).
-        is_admin = getattr(client, "is_admin", False)
+        # A transformer plugin can block long enough (an LLM call, a network
+        # round trip) for the DB row to change mid-flight, so is_admin is
+        # re-resolved fresh here too, same as _install_client_session, rather
+        # than re-asserting the dispatch-time snapshot taken before the chain ran.
+        db = getattr(self, "db", None)
+        user = None
+        if db is not None:
+            try:
+                user = client.resolve_user(db)
+            except Exception:
+                LOG.exception("handle_inject_agent_msg: failed to resolve user for admin check")
+        is_admin = user.is_admin if user is not None else client.is_admin
+        client.is_admin = is_admin
         session = message.context.get("session")
         if not isinstance(session, dict):
             session = {}

--- a/tests/test_admin_refresh.py
+++ b/tests/test_admin_refresh.py
@@ -125,6 +125,47 @@ def test_revoked_admin_loses_broadcast_at_next_message():
     assert client.is_admin is False
 
 
+def test_revoked_admin_is_natted_after_slow_transformer():
+    """A transformer plugin can outlive resolve_user's TTL (an LLM call, a
+    network round trip). If the DB revokes the admin while it runs, the
+    post-transformer session-id re-stamp in handle_inject_agent_msg must see
+    the fresh standing, not the dispatch-time ``client.is_admin`` snapshot
+    taken before the chain ran."""
+    db_user = MagicMock(is_admin=True)
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    protocol = _make_protocol(db)
+    protocol.policy_chain = MagicMock()
+    protocol.policy_chain.review.return_value = MagicMock(denied=False)
+
+    client = _make_client(protocol, Session(session_id="default"), is_admin=True)
+
+    def revoke_mid_transform(context):
+        # models the DB row changing + the cached resolve TTL elapsing while
+        # this transformer was blocked on something slow.
+        db_user.is_admin = False
+        client.invalidate_user()
+        return context
+
+    protocol.metadata_transformers = MagicMock()
+    protocol.metadata_transformers.plugins = {"fake": MagicMock()}
+    protocol.metadata_transformers.transform.side_effect = revoke_mid_transform
+    protocol.utterance_transformers = MagicMock()
+    protocol.utterance_transformers.plugins = {}
+
+    message = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
+                       {"session": {"session_id": "default"}})
+
+    protocol.handle_inject_agent_msg(message, client)
+
+    emitted = protocol.get_bus(client).emit.call_args[0][0]
+    session_id = emitted.context["session"]["session_id"]
+    assert session_id == f"{client.conn_nonce}:default"
+    assert session_id != "default"
+    assert client.is_admin is False
+
+
 def test_resolve_failure_falls_back_to_connection_snapshot():
     db = MagicMock()
     db.get_client_by_api_key.return_value = None


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet (via Claude Code) — NOT human-reviewed. Verify before acting.

`handle_inject_agent_msg` re-asserts the Layer-1 session id after the transformer chain runs, so a transformer plugin cannot smuggle a message into another client's session by rewriting `message.context`. That re-stamp computed `is_admin` via `getattr(client, "is_admin", False)` — the dispatch-time snapshot taken before the chain ran — rather than re-resolving it from the database, unlike `_install_client_session`, which already resolves fresh via `client.resolve_user(db)` with a guarded fallback.

The gap: a transformer plugin (an LLM call, a network round trip) can block longer than `resolve_user`'s TTL. If an operator revokes an admin's standing in the database while that admin's utterance is still inside the transformer chain, the stale `getattr` re-asserted the pre-revocation "admin" decision on the way out to the agent bus — handing the revoked admin one more un-NATted write to the orchestrator's device-local `"default"` session, even though the database already says they are no longer admin.

The fix mirrors `_install_client_session`'s pattern exactly: the re-stamp now calls `client.resolve_user(db)` fresh, falls back to the connection snapshot only if resolution fails or returns nothing, and writes the resolved value back to `client.is_admin` so any other admin gate reached later in the same handler call agrees with it.

I added `test_revoked_admin_is_natted_after_slow_transformer` to `tests/test_admin_refresh.py`, following the existing file's harness pattern (real `HiveMindListenerProtocol`/`HiveMindClientConnection`, policy chain stubbed to allow). An admin sends a `recognizer_loop:utterance` through `handle_inject_agent_msg`; a stubbed metadata transformer revokes the DB user's `is_admin` and calls `client.invalidate_user()` mid-transform, modeling the TTL elapsing during a slow plugin call. The test asserts the emitted bus message's `session_id` is the NATted `f"{client.conn_nonce}:default"`, not the raw `"default"`.

Fail-before via patch-revert (not stash): with only the test added and the source change reverted, the new test failed with `AssertionError: assert 'default' == '<nonce>:default'`. Re-applying the fix made it pass, along with the file's four pre-existing admin-refresh tests (5 passed total).

Full suite after the fix: `pytest tests/ --ignore=tests/e2e` → 417 passed, 1 skipped (baseline 416 + the new test). `pytest tests/e2e` → 57 passed, 2 skipped, 1 pre-existing xpass unrelated to this change (`test_fifo_order_relay_chain`, already marked as a known xfail-that-now-passes before this branch).

Verified against current `origin/dev` source: the three separate `is_admin` computation sites in `hivemind_core/protocol.py` (`handle_message`'s dispatch-time refresh, `_install_client_session`'s fresh resolve, and the pre-fix `getattr` re-stamp in `handle_inject_agent_msg`) match the defect description exactly, confirmed by reading the current file rather than the report that described it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session handling when administrator permissions change during message processing.
  * Ensured revoked administrator access is reflected before the session information is updated.
  * Preserved correct default-session messaging after permission changes.

* **Tests**
  * Added coverage for administrator revocation during delayed message transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->