### PR TITLE
fix: derive Layer-1 session per message and merge session contents

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1773,11 +1773,16 @@ class HiveMindListenerProtocol:
     def handle_bus_message(
             self, message: HiveMessage, client: HiveMindClientConnection
     ):
-        # track any Session updates from client side
-        """
-        Handles internal bus messages from a client, enforcing session restrictions and forwarding to the agent bus.
+        """Forward a client's internal bus message to the agent bus.
 
-        If a non-admin client attempts to use the "default" session ID, the client is disconnected. Otherwise, updates the client's session if the session ID matches and is not "default", then injects the message into the internal agent bus and invokes the agent bus callback if set.
+        A bus payload never mutates ``client.sess``: that stays the
+        connection's HELLO-established baseline and changes only on
+        (re-)HELLO. Each message declares its own session;
+        ``_install_client_session`` derives that message's Layer-1
+        (orchestrator) session id and merges the payload's session contents
+        over the baseline (HIVEMIND-BRIDGE-1 §4). The "default" session id is
+        gated by ``OVOSAgentPolicy.review`` — a non-admin payload using it is
+        denied and dropped, not forwarded.
         """
         try:
             payload = message.payload
@@ -1789,11 +1794,6 @@ class HiveMindListenerProtocol:
             LOG.warning("Ignoring BUS payload with invalid message/context shape")
             return
 
-        raw_session = payload.context.get("session") or {}
-        sent_pipeline = isinstance(raw_session, dict) and "pipeline" in raw_session
-        sess = Session.from_message(payload)
-        if sent_pipeline:
-            sess.pipeline = raw_session.get("pipeline")
         # The per-message "session_id == 'default'" gate moved to
         # OVOSAgentPolicy.review (HiveMind-core#85). Non-admin clients
         # injecting a default-session payload get Verdict.deny(
@@ -1801,13 +1801,14 @@ class HiveMindListenerProtocol:
         # with a hive.policy.denied response — replacing the previous
         # severe `client.disconnect()` reaction. The HELLO-time check at
         # handle_hello_message stays as connection-establishment gate.
-
-        if sess.session_id != "default" and client.sess.session_id == sess.session_id:
-            if not sent_pipeline:
-                sess.pipeline = client.sess.pipeline
-            client.sess = sess
-            LOG.debug(f"Client session updated from payload: {sess.serialize()}")
-
+        #
+        # A bus payload NEVER mutates ``client.sess``: that stays the
+        # HELLO-established baseline for the connection and only changes on
+        # (re-)HELLO (handle_hello_message). A single connection may
+        # multiplex several declared sessions (a relay, or a per-call bridge
+        # like baresip); each message declares its own session and
+        # ``_install_client_session`` derives that message's Layer-1 identity
+        # and merges its contents over the baseline (HIVEMIND-BRIDGE-1 §4).
         self.handle_inject_agent_msg(payload, client)
 
     def handle_broadcast_message(
@@ -2892,15 +2893,19 @@ class HiveMindListenerProtocol:
 
     # HiveMind mycroft bus messages -  from slave -> master
     @staticmethod
-    def _layer1_session_id(client: HiveMindClientConnection, is_admin: bool) -> str:
-        """The Layer-1 (orchestrator) session id this client is allowed to
-        address: the raw, client-declared session id for an admin, or the
-        per-connection NATted id for everyone else (HIVEMIND-BRIDGE-1 §4).
+    def _layer1_session_id(client: HiveMindClientConnection, is_admin: bool,
+                           declared_id: str) -> str:
+        """The Layer-1 (orchestrator) session id for a message declaring
+        ``declared_id``: the raw declared id for an admin, or the
+        per-connection NATted id ``conn_nonce:declared_id`` for everyone else
+        (HIVEMIND-BRIDGE-1 §4). ``declared_id`` is the per-message session id
+        (session travels per message; the client declares it), falling back
+        to the connection's HELLO baseline when the message declares none.
         Shared by ``_install_client_session`` and the post-transformer
         re-stamp in ``handle_inject_agent_msg`` so both apply the exact same
-        decision.
+        decision to the same message.
         """
-        return client.sess.session_id if is_admin else client.layer1_session_id
+        return declared_id if is_admin else f"{client.conn_nonce}:{declared_id}"
 
     def _install_client_session(self, message: Message,
                                  client: HiveMindClientConnection):
@@ -2922,13 +2927,26 @@ class HiveMindListenerProtocol:
         it to the message context so downstream consumers never see them.
         """
         raw_session = message.context.get("session") or {}
+        if not isinstance(raw_session, dict):
+            raw_session = {}
+        # ``client.sess`` is the connection's HELLO-established baseline. Start
+        # from it and OVERLAY the per-message declared session's present,
+        # non-null fields (merge, not replace): a thin control message keeps
+        # the baseline's location/lang/etc., while a rich message overrides
+        # them. The overlay is taken from the raw wire dict, NEVER by building
+        # a fresh Session (Session.__init__ fabricates Configuration() defaults
+        # — e.g. the master's own location — for absent fields, which would
+        # clobber the satellite's real values; that was the session-contents
+        # bleed bug).
         session = client.sess.serialize()
-        if not isinstance(raw_session, dict) or raw_session.get("pipeline") is None:
+        overlay = {k: v for k, v in raw_session.items() if v is not None}
+        session.update(overlay)
+        if raw_session.get("pipeline") is None:
             # Each bus message owns its outbound pipeline; do not reattach
-            # one from an earlier message. Per SESSION-1 §2 an explicit
-            # null pipeline is malformed and treated as absent; strip it
-            # here explicitly (serializers may render a None pipeline as
-            # [], which the generic null-strip below would not catch).
+            # one from the baseline. Per SESSION-1 §2 an explicit null
+            # pipeline is malformed and treated as absent; strip it here
+            # explicitly (serializers may render a None pipeline as [], which
+            # the generic null-strip below would not catch).
             session.pop("pipeline", None)
         # SESSION-1 §2: strip null-valued fields — null is malformed, treat as absent.
         session = {k: v for k, v in session.items() if v is not None}
@@ -2956,7 +2974,8 @@ class HiveMindListenerProtocol:
             except Exception:
                 LOG.exception("_install_client_session: failed to resolve user for admin check")
         is_admin = user.is_admin if user is not None else client.is_admin
-        session["session_id"] = self._layer1_session_id(client, is_admin)
+        declared_id = raw_session.get("session_id") or client.sess.session_id
+        session["session_id"] = self._layer1_session_id(client, is_admin, declared_id)
         message.context["session"] = session
         return message
 
@@ -2973,6 +2992,16 @@ class HiveMindListenerProtocol:
         if not client.authorize(message):
             LOG.warning(client.peer + " sent an unauthorized bus message")
             return
+
+        # Capture the per-message declared session id BEFORE
+        # _install_client_session rewrites context["session"]["session_id"]
+        # to the derived Layer-1 id. The post-transformer re-stamp below
+        # re-derives from this raw declared id, not from the already-NATted
+        # value, so it re-asserts the SAME Layer-1 id instead of double-NATting.
+        _raw_declared = message.context.get("session") or {}
+        declared_id = (_raw_declared.get("session_id")
+                       if isinstance(_raw_declared, dict) else None) \
+            or client.sess.session_id
 
         # ensure client specific session data is injected in query to ovos
         message = self._install_client_session(message, client)
@@ -3024,7 +3053,7 @@ class HiveMindListenerProtocol:
         session = message.context.get("session")
         if not isinstance(session, dict):
             session = {}
-        session["session_id"] = self._layer1_session_id(client, is_admin)
+        session["session_id"] = self._layer1_session_id(client, is_admin, declared_id)
         message.context["session"] = session
 
         try:

--- a/tests/test_session_nat.py
+++ b/tests/test_session_nat.py
@@ -23,6 +23,8 @@ from unittest.mock import MagicMock
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
 
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
 from hivemind_core.protocol import (HiveMindClientConnection,
                                     HiveMindListenerProtocol)
 
@@ -128,17 +130,126 @@ def test_session_contents_preserved():
     assert session["intent_context"]["some_key"] == "some_value"
 
 
-def test_same_connection_different_named_payload_still_one_layer1_session():
-    client = _make_client(Session(session_id="shared"))
+def test_different_named_payload_gets_its_own_layer1_session():
+    # Session travels PER MESSAGE and the client declares it (BRIDGE-1 §4).
+    # A single connection may multiplex several declared sessions (a relay, or
+    # a per-call bridge like baresip). A payload declaring its OWN session_id
+    # must map to that declared id namespaced by the connection nonce —
+    # ``nonce:declared`` — NOT collapse onto the connection's HELLO baseline.
+    client = _make_client(Session(session_id="baseline"))
 
-    # a bus message arriving with a *different* session name already
-    # attached to it (e.g. relayed/replayed) must still be re-stamped with
-    # this connection's own Layer-1 id: the peer names its session at the
-    # connection level, not per message.
     message = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
-                       {"session": {"session_id": "someone-elses-session"}})
+                       {"session": {"session_id": "call-42"}})
 
     result = _install(client, message)
 
-    assert result.context["session"]["session_id"] == client.layer1_session_id
-    assert result.context["session"]["session_id"] != "someone-elses-session"
+    sid = result.context["session"]["session_id"]
+    assert sid == f"{client.conn_nonce}:call-42"
+    # the declared id is namespaced, never handed through raw
+    assert sid != "call-42"
+    # and it is NOT the baseline's id — the per-message session wins
+    assert sid != f"{client.conn_nonce}:baseline"
+
+
+def test_multiplexed_sessions_over_one_connection_stay_isolated():
+    # DEFECT A: two DIFFERENT declared session_ids over ONE connection must
+    # resolve to two DISTINCT Layer-1 ids, each ``nonce:declared``. Collapsing
+    # them onto the connection baseline would merge a relay's / bridge's
+    # independent conversations into one OVOS session.
+    client = _make_client(Session(session_id="baseline"))
+
+    a = _install(client, Message("recognizer_loop:utterance", {"utterances": ["a"]},
+                                 {"session": {"session_id": "sess-A"}}))
+    b = _install(client, Message("recognizer_loop:utterance", {"utterances": ["b"]},
+                                 {"session": {"session_id": "sess-B"}}))
+
+    sid_a = a.context["session"]["session_id"]
+    sid_b = b.context["session"]["session_id"]
+
+    assert sid_a == f"{client.conn_nonce}:sess-A"
+    assert sid_b == f"{client.conn_nonce}:sess-B"
+    assert sid_a != sid_b
+
+
+def test_message_without_declared_session_uses_baseline_id():
+    # The unchanged single-session path, pinned explicitly: a client that
+    # declares no per-message session (or declares its own baseline id) gets
+    # ``nonce:baseline_session_id``.
+    client = _make_client(Session(session_id="baseline"))
+
+    none_declared = _install(client, Message("recognizer_loop:utterance",
+                                             {"utterances": ["hi"]}))
+    same_declared = _install(client, Message("recognizer_loop:utterance",
+                                             {"utterances": ["hi"]},
+                                             {"session": {"session_id": "baseline"}}))
+
+    assert none_declared.context["session"]["session_id"] == f"{client.conn_nonce}:baseline"
+    assert same_declared.context["session"]["session_id"] == f"{client.conn_nonce}:baseline"
+
+
+def test_rich_payload_location_overrides_baseline():
+    # Contents merge lets a message's OWN present fields win over the baseline:
+    # a rich payload declaring a new location overrides the HELLO baseline's
+    # location on that message.
+    baseline = Session(session_id="baseline", lang="de-DE")
+    baseline.location_preferences = {"city": {"name": "Berlin"},
+                                     "timezone": {"code": "Europe/Berlin"}}
+    client = _make_client(baseline)
+
+    message = Message("recognizer_loop:utterance", {"utterances": ["hi"]},
+                       {"session": {"session_id": "baseline",
+                                    "location": {"city": {"name": "Lisbon"},
+                                                 "timezone": {"code": "Europe/Lisbon"}}}})
+
+    result = _install(client, message)
+    session = result.context["session"]
+    assert session["location"]["timezone"]["code"] == "Europe/Lisbon"
+    assert session["location"]["city"]["name"] == "Lisbon"
+
+
+def test_thin_control_message_does_not_clobber_baseline_location():
+    # DEFECT B (session-contents bleed): a thin control bus message (same
+    # session_id, no location, lang: null) must NOT destroy the HELLO
+    # baseline's location. The old code wholesale-replaced ``client.sess``
+    # with a Session built from the thin payload, whose absent location was
+    # fabricated from the master's own Configuration() default — so a German
+    # satellite's Berlin location was silently replaced by the master default
+    # and time queries answered hours off. The message's emitted session must
+    # still carry Berlin, merged from the baseline.
+    baseline = Session(session_id="sat-de", lang="de-DE")
+    baseline.location_preferences = {"city": {"name": "Berlin"},
+                                     "timezone": {"code": "Europe/Berlin"}}
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = MagicMock(is_admin=False)
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.return_value = agent.bus
+    protocol = HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                        require_crypto=False,
+                                        handshake_enabled=False)
+    protocol.policy_chain = MagicMock()
+    protocol.policy_chain.review.return_value = MagicMock(denied=False)
+
+    client = HiveMindClientConnection(
+        key="k", send_msg=MagicMock(), disconnect=MagicMock(),
+        hm_protocol=protocol, sess=baseline)
+    client.name = "sat-de"
+    client.allowed_types = ["mycroft.volume.get"]
+    client.is_admin = False
+
+    thin = Message("mycroft.volume.get", {},
+                   {"session": {"session_id": "sat-de", "site_id": "default",
+                                "lang": None}})
+    protocol.handle_bus_message(HiveMessage(HiveMessageType.BUS, payload=thin),
+                                client)
+
+    # baseline was NOT mutated by the bus payload
+    assert client.sess.location_preferences["timezone"]["code"] == "Europe/Berlin"
+
+    emitted = agent.bus.emit.call_args[0][0]
+    loc = emitted.context["session"]["location"]
+    assert loc["timezone"]["code"] == "Europe/Berlin"
+    assert loc["city"]["name"] == "Berlin"
+    # and the message still got this connection's Layer-1 id
+    assert emitted.context["session"]["session_id"] == f"{client.conn_nonce}:sat-de"

--- a/tests/test_session_pipeline.py
+++ b/tests/test_session_pipeline.py
@@ -103,7 +103,9 @@ class TestSessionPipelineHandling(unittest.TestCase):
         self.assertEqual(
             emitted.context["session"]["pipeline"], ["client-sent-pipeline"]
         )
-        self.assertEqual(client.sess.pipeline, ["client-sent-pipeline"])
+        # A bus payload owns its outbound pipeline but does NOT mutate the
+        # connection's HELLO baseline: client.sess stays what HELLO set.
+        self.assertEqual(client.sess.pipeline, ["old-pipeline"])
 
     def test_explicit_none_pipeline_is_treated_as_absent(self):
         # OVOS-SESSION-1 §2: a null field is treated as omitted; the bridge
@@ -123,7 +125,9 @@ class TestSessionPipelineHandling(unittest.TestCase):
 
         emitted = protocol.agent_protocol.bus.emit.call_args[0][0]
         self.assertNotIn("pipeline", emitted.context["session"])
-        self.assertIsNone(client.sess.pipeline)
+        # A bus payload does NOT mutate the connection's HELLO baseline; the
+        # null pipeline is stripped from the emitted message only.
+        self.assertEqual(client.sess.pipeline, ["old-pipeline"])
 
     def test_invalid_bus_payload_is_ignored(self):
         protocol = _make_protocol()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus (via Claude Code) — NOT human-reviewed. Verify before acting.

Two related session-model defects lived in the same pair of functions in `hivemind_core/protocol.py`, and both are user-facing.

The first is a multiplex-isolation defect. `handle_bus_message` only adopted a per-message session when its `session_id` matched `client.sess.session_id`, and `_install_client_session` derived the Layer-1 (orchestrator) session id from `client.sess`. A single connection that multiplexes several declared sessions — a relay, or a per-call bridge like the baresip SIP gateway that mints a fresh `session_id` per call over one long-lived connection — therefore collapsed all of them onto one Layer-1 session, merging independent conversations' converse/active-skill/dialog state.

The second is a session-contents bleed reported by a real user. When the id did match, `handle_bus_message` did `client.sess = Session.from_message(payload)`, a wholesale replace. A thin control message (`mycroft.volume.get`, same `session_id`, no location, `lang: null`) replaced the rich HELLO session, and `Session.__init__` refilled the now-absent location from the master's own `Configuration()` default (America/Chicago). A German satellite's Berlin location was silently destroyed and time queries answered hours off. The existing null-strip could not catch it because the fabricated value is not null.

The fix makes `client.sess` the connection's HELLO-established baseline only: a bus payload never mutates it (the match-gate block is removed; the baseline changes solely via HELLO/re-HELLO). Each message now carries its own session. `_install_client_session` derives the Layer-1 id from the per-message declared id (`nonce:declared` for non-admins, the raw declared id for admins, admin re-resolve preserved), and overlays the raw wire session's present, non-null fields over the baseline — a merge, not a replace, so a thin message keeps the baseline's location/lang while a rich message overrides them. Crucially the overlay is taken from the raw wire dict, never by constructing a fresh `Session`, which is what fabricated the master-default location. The post-transformer re-stamp in `handle_inject_agent_msg` re-derives from the same captured per-message declared id so it re-asserts the same Layer-1 id instead of double-NATting.

Fail-before was verified per test via patch-revert (revert the source only, keep the tests). On the unfixed source the two multiplex tests receive the collapsed baseline id (`nonce:baseline` instead of `nonce:call-42`/`nonce:sess-A`), the location regression asserts `Europe/Berlin` but gets `America/Chicago`, and the override test fails; all pass after restore. Full suite: 421 passed / 1 skipped (non-e2e) and 57 passed / 2 skipped (e2e). The one e2e xpass (`test_fifo_order_relay_chain`) is a stale xfail marker present on `dev` before this change too.

Pre-existing tests updated: the obsolete pin `test_same_connection_different_named_payload_still_one_layer1_session` (which asserted a differently-named payload collapses onto the connection id) was rewritten to `test_different_named_payload_gets_its_own_layer1_session` for the new per-message contract, and two `test_session_pipeline` assertions that checked the now-removed `client.sess` mutation were changed to assert the baseline is preserved instead. No unrelated pins were weakened.
