### PR TITLE
fix: close 1008 on handshake-time auth/credential rejections

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -177,7 +177,7 @@ class HiveMindClientConnection:
     """represents a connection to the hivemind listener"""
     key: str
     send_msg: Callable[[str, bool], None]
-    disconnect: Callable[[], None]
+    disconnect: Callable[..., None]
 
     sess: Session = dataclasses.field(default_factory=Session)  # unique session per client
     name: str = "AnonClient"
@@ -398,7 +398,7 @@ class HiveMindClientConnection:
             # protocol v3 session: only valid Noise transport messages are
             # accepted; tampering/replay/reordering fails AEAD and is fatal
             if not isinstance(payload, bytes):
-                self.disconnect()
+                self.disconnect(1008, "non-Noise message received on a protocol v3 session")
                 raise NoiseTransportFailed(
                     "non-Noise message received on a protocol v3 session")
             try:
@@ -407,7 +407,7 @@ class HiveMindClientConnection:
                 LOG.error(f"rejecting invalid Noise transport message from "
                           f"{self.peer} (tampered, replayed or out-of-order), "
                           "disconnecting")
-                self.disconnect()
+                self.disconnect(1008, "invalid Noise transport message (tampered, replayed or out-of-order)")
                 raise
             # a decoded Noise transport frame is authenticated + encrypted
             encrypted = True
@@ -442,7 +442,7 @@ class HiveMindClientConnection:
                                              HiveMessageType.HANDSHAKE)):
             LOG.error(f"Dropping unencrypted {message.msg_type} message from "
                       f"{self.peer}: server requires crypto")
-            self.disconnect()
+            self.disconnect(1008, "unencrypted message rejected: crypto is required")
             raise UnencryptedMessageError(
                 f"unencrypted {message.msg_type} message rejected: "
                 f"crypto is required")
@@ -978,7 +978,7 @@ class HiveMindListenerProtocol:
                 f">= {int(min_version)} but this connection can offer at most "
                 f"{int(max_version)}"
             )
-            client.disconnect()
+            client.disconnect(1008, "server requires a protocol version this connection cannot offer")
             return
 
         hello_payload = {
@@ -1505,7 +1505,7 @@ class HiveMindListenerProtocol:
         client.noise_handshake = None
         client.noise_transport = None
         self.handle_invalid_key_connected(client)
-        client.disconnect()
+        client.disconnect(1008, reason)
 
     def handle_noise_handshake_message(
             self, message: HiveMessage, client: HiveMindClientConnection
@@ -1634,7 +1634,8 @@ class HiveMindListenerProtocol:
                 f"v{int(attempted_version)} is below the configured minimum "
                 f"v{int(cfg_min)}"
             )
-            client.disconnect()
+            client.disconnect(1008, f"legacy handshake at protocol v{int(attempted_version)} "
+                                     f"is below the configured minimum v{int(cfg_min)}")
             return
 
         LOG.debug("handshake received, generating session key")
@@ -1668,7 +1669,7 @@ class HiveMindListenerProtocol:
             if not ciphers or not encodings:
                 LOG.warning("Client tried to connect with invalid cipher/encoding")
                 # TODO - invalid handshake handler
-                client.disconnect()
+                client.disconnect(1008, "invalid cipher/encoding negotiation")
                 return
 
             # from the allowed options, select the one the client prefers
@@ -1689,7 +1690,7 @@ class HiveMindListenerProtocol:
             if not verified:
                 LOG.warning("Client password handshake verification failed")
                 self.handle_invalid_key_connected(client)
-                client.disconnect()
+                client.disconnect(1008, "password handshake verification failed")
                 return
 
             # key is derived safely from password in both sides
@@ -1703,7 +1704,7 @@ class HiveMindListenerProtocol:
             # self.crypto_key = self.pswd_handshake.secret
         else:
             # TODO - invalid handshake handler
-            client.disconnect()
+            client.disconnect(1008, "invalid or unrecognized handshake")
             return
 
         msg = HiveMessage(HiveMessageType.HANDSHAKE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "json-database>=0.10.2a1,<2.0.0",
     "hivemind-sqlite-database>=0.4.0a2",
     "hivemind-json-db-plugin>=0.0.3a2",
-    "hivemind-websocket-protocol>=0.0.3,<1.0.0",
+    "hivemind-websocket-protocol>=0.2.10a1,<1.0.0",
     "hivemind-ovos-agent-plugin>=0.3.1a1,<1.0.0",
     # transformer pipeline runner services on the text/bus path
     "ovos-plugin-manager>=2.10.0a1,<3.0.0",
@@ -61,12 +61,12 @@ presence = ["hivemind-presence", "hivemind-ggwave"]
 test = [
     "pytest",
     "pytest-cov",
-    "hivescope>=0.5.0a2",
+    "hivescope>=0.8.1a1",
     # client-side Noise (hivemind_bus_client>=1.0.0a1) comes from the runtime
     # dependency above — no git ref, so the wheel stays PyPI-publishable.
 ]
 integration = [
-    "hivescope>=0.5.0a2",
+    "hivescope>=0.8.1a1",
     "ovoscope",
     "ovos-core>=2.1.6a1",
     "ovos-skill-hello-world",

--- a/tests/test_crypto_enforcement.py
+++ b/tests/test_crypto_enforcement.py
@@ -258,6 +258,10 @@ class TestPasswordHandshakeFailFast(unittest.TestCase):
         proto.handle_handshake_message(self._handshake_msg(self._WRONG_PASSWORD), client)
         assert client.crypto_key is None
         client.disconnect.assert_called_once()
+        # a bare/1000 close tells the client the credentials were fine and it
+        # can just reconnect, so it retries the same wrong password forever;
+        # this MUST be a terminal 1008 auth rejection
+        assert client.disconnect.call_args.args[0] == 1008
         client.send_msg.assert_not_called()
 
     def test_garbage_envelope_rejected_at_handshake_time(self):
@@ -269,6 +273,7 @@ class TestPasswordHandshakeFailFast(unittest.TestCase):
         proto.handle_handshake_message(msg, client)
         assert client.crypto_key is None
         client.disconnect.assert_called_once()
+        assert client.disconnect.call_args.args[0] == 1008
 
 
 class TestMinProtocolVersionFloor(unittest.TestCase):
@@ -298,6 +303,7 @@ class TestMinProtocolVersionFloor(unittest.TestCase):
             proto.handle_handshake_message(self._handshake_msg(), client)
         assert client.crypto_key is None
         client.disconnect.assert_called_once()
+        assert client.disconnect.call_args.args[0] == 1008
         client.send_msg.assert_not_called()
 
     def test_v2_password_handshake_accepted_when_floor_is_2(self):
@@ -388,3 +394,20 @@ class TestRejectedIntercomIsNotRelayed(unittest.TestCase):
             HiveMessage(HiveMessageType.ESCALATE,
                         payload=self._forged_intercom()), self.client)
         self._assert_dropped()
+
+
+class TestNoiseHandshakeAbortCloseCode(unittest.TestCase):
+    """Fix for: handshake-time auth/credential rejections closed with a bare
+    (code 1000) close, so a client retrying on any non-1008 close would spin
+    forever on a wrong PSK, tampered negotiation, or a pinned-key
+    contradiction. ``_abort_noise_handshake`` is the single fatal exit for
+    all of those, so it must always close 1008.
+    """
+
+    def test_abort_closes_1008(self):
+        proto = _make_protocol()
+        client = _make_client(proto)
+        proto.handle_invalid_key_connected = MagicMock()
+        proto._abort_noise_handshake(client, "wrong PSK")
+        client.disconnect.assert_called_once()
+        assert client.disconnect.call_args.args == (1008, "wrong PSK")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet (via Claude Code) — NOT human-reviewed. Verify before acting.

Handshake-time credential and crypto-negotiation rejections called `client.disconnect()` with no arguments, which the websocket layer resolves to a bare close (code 1000). A client cannot distinguish "server hung up" from "your credentials are wrong" on a 1000 close, so it treats the rejection as transient and retries the same bad credentials forever. The bus client side already treats 1008 as a terminal auth rejection and only retries on other codes, so the gap was entirely server-side.

`hivemind-websocket-protocol>=0.2.10a1` threads an optional close code through `do_disconnect(code, reason)`. This PR widens `HiveMindClientConnection.disconnect`'s type to `Callable[..., None]` and passes `1008` with a short reason at every credential/handshake-rejection site: password handshake verification failure, Noise handshake abort (wrong PSK, tampered negotiation, pinned-key contradiction, malformed envelope), invalid cipher/encoding negotiation, an unrecognized handshake, a legacy handshake below the configured protocol floor, a protocol version floor the connection cannot satisfy, and a cleartext frame rejected under `crypto_required`. Post-handshake misbehavior kicks (illegal broadcast/propagate/escalate, an unescalated QUERY) and the graceful post-disconnect teardown call are left at a bare close, since those aren't credential rejections and a reconnect re-authenticates fine.

The `hivemind-websocket-protocol` floor pin is bumped to `>=0.2.10a1`, the first published version whose `do_disconnect` accepts a code.

Regression coverage now captures the actual close-code argument passed to `disconnect` for the wrong-password, garbage-envelope, protocol-floor, and Noise-abort paths. Existing tests only asserted `disconnect()` was called, arg-agnostically, which certified nothing about the close code. Reverting only the source change (test kept) makes all four assertions fail with the pre-fix bare call (`IndexError: tuple index out of range` / `args == ()`); reapplying the fix makes them pass. The full non-e2e suite passes at 422 passed, 1 skipped, no other test's status changed.

The e2e suite (`tests/e2e`) surfaced one collateral failure: `test_protocol_v3_matrix.py::test_replayed_v3_transport_message_is_rejected` now fails with `sync_disconnect() takes 0 positional arguments but 2 were given`, coming from `hivescope`'s loopback test-harness plugin (`hivescope/plugins/loopback.py`), which still wires a zero-argument `sync_disconnect` even in its latest published release (0.8.0a1). That plugin needs its own fix to accept the `(code, reason)` signature `hivemind-websocket-protocol>=0.2.10a1` introduced; it's a `hivescope` defect, out of scope for this PR, and confirmed via patch-revert to be a genuine regression from this change (passes on the unfixed source, fails on the fixed source) rather than a pre-existing flake. All 56 other e2e tests plus the pre-existing xfail/skip pass unaffected.
