### PR TITLE
fix: refresh can_escalate/can_propagate/can_broadcast per message

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1173,23 +1173,28 @@ class HiveMindListenerProtocol:
 
         LOG.debug(f"message: {message}")
 
-        # Refresh is_admin from the DB once, here, so every admin-gated
-        # decision downstream of this dispatcher (the session NAT in
-        # _install_client_session, the BROADCAST gate in
-        # handle_broadcast_message, ...) sees a value no staler than
+        # Refresh is_admin and the can_broadcast/can_propagate/can_escalate
+        # grants from the DB once, here, so every privilege-gated decision
+        # downstream of this dispatcher (the session NAT in
+        # _install_client_session, the BROADCAST/ESCALATE/PROPAGATE gates in
+        # handle_broadcast_message/handle_escalate_message/
+        # handle_propagate_message, ...) sees a value no staler than
         # resolve_user's TTL, instead of the connect-time snapshot for the
         # life of the connection (HIVEMIND-BRIDGE-1 §4/§4.1). The disconnect
         # lifecycle emit runs on socket close, outside this dispatcher, and
-        # keeps reading whatever is_admin was last refreshed to here.
+        # keeps reading whatever these grants were last refreshed to here.
         db = getattr(self, "db", None)
         if db is not None:
             try:
                 user = client.resolve_user(db)
             except Exception:
-                LOG.exception("handle_message: failed to resolve user for is_admin refresh")
+                LOG.exception("handle_message: failed to resolve user for privilege refresh")
             else:
                 if user is not None:
                     client.is_admin = user.is_admin
+                    client.can_broadcast = user.can_broadcast
+                    client.can_propagate = user.can_propagate
+                    client.can_escalate = user.can_escalate
 
         # update internal peer ID
         message.update_source_peer(client.peer)

--- a/tests/test_admin_refresh.py
+++ b/tests/test_admin_refresh.py
@@ -166,6 +166,82 @@ def test_revoked_admin_is_natted_after_slow_transformer():
     assert client.is_admin is False
 
 
+def _escalate_hivemessage():
+    inner = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {"utterance": "hi"}))
+    return HiveMessage(HiveMessageType.ESCALATE, payload=inner)
+
+
+def _propagate_hivemessage():
+    inner = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {"utterance": "hi"}))
+    return HiveMessage(HiveMessageType.PROPAGATE, payload=inner)
+
+
+def test_revoked_can_escalate_is_denied_at_next_message():
+    """``handle_escalate_message`` reads ``client.can_escalate`` directly, not
+    ``resolve_user``. A live revoke of ``can_escalate`` must still take effect
+    at the connection's next message, because ``handle_message`` -- the common
+    dispatcher for every inbound message type -- refreshes ``client.can_escalate``
+    from the DB before dispatching (HIVEMIND-BRIDGE-1 §4/§4.1)."""
+    db_user = MagicMock(is_admin=False, can_broadcast=False, can_propagate=False,
+                         can_escalate=True)
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    protocol = _make_protocol(db)
+    client = _make_client(protocol, Session(session_id="default"), is_admin=False)
+    client.can_escalate = True
+    client.can_propagate = False
+    client.can_broadcast = False
+    protocol.clients = {}
+    protocol.illegal_callback = None
+    protocol.escalate_callback = MagicMock()
+
+    # while still granted, escalate is allowed
+    protocol.handle_message(_escalate_hivemessage(), client)
+    protocol.escalate_callback.assert_called_once()
+    client.disconnect.assert_not_called()
+
+    # operator revokes can_escalate in the DB
+    db_user.can_escalate = False
+    protocol.escalate_callback.reset_mock()
+
+    protocol.handle_message(_escalate_hivemessage(), client)
+    protocol.escalate_callback.assert_not_called()
+    client.disconnect.assert_called_once_with()
+    assert client.can_escalate is False
+
+
+def test_revoked_can_propagate_is_denied_at_next_message():
+    """Same as above, for ``can_propagate`` / ``handle_propagate_message``."""
+    db_user = MagicMock(is_admin=False, can_broadcast=False, can_propagate=True,
+                         can_escalate=False)
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    protocol = _make_protocol(db)
+    client = _make_client(protocol, Session(session_id="default"), is_admin=False)
+    client.can_propagate = True
+    client.can_escalate = False
+    client.can_broadcast = False
+    protocol.clients = {}
+    protocol.illegal_callback = None
+    protocol.propagate_callback = MagicMock()
+
+    # while still granted, propagate is allowed
+    protocol.handle_message(_propagate_hivemessage(), client)
+    protocol.propagate_callback.assert_called_once()
+    client.disconnect.assert_not_called()
+
+    # operator revokes can_propagate in the DB
+    db_user.can_propagate = False
+    protocol.propagate_callback.reset_mock()
+
+    protocol.handle_message(_propagate_hivemessage(), client)
+    protocol.propagate_callback.assert_not_called()
+    client.disconnect.assert_called_once_with()
+    assert client.can_propagate is False
+
+
 def test_resolve_failure_falls_back_to_connection_snapshot():
     db = MagicMock()
     db.get_client_by_api_key.return_value = None


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

`handle_message` already re-resolves `is_admin` from the DB on every inbound message, so a revoked admin loses that standing at the connection's next message rather than only on reconnect (HIVEMIND-BRIDGE-1 §4/§4.1). The three per-connection grants `can_broadcast`, `can_escalate`, and `can_propagate` were only ever snapshotted once at connect time and never refreshed for the life of the connection.

`handle_escalate_message` and `handle_propagate_message` gate solely on `can_escalate`/`can_propagate`, with no `is_admin` co-gate (broadcast is incidentally protected because it does co-gate on `is_admin`, which is refreshed). That meant an operator revoking `can_escalate` or `can_propagate` via the DB could not stop a live, already-connected client from continuing to escalate or propagate messages until it disconnected and reconnected.

The fix reuses the same `client.resolve_user(db)` call already made in the dispatcher for the `is_admin` refresh, and also refreshes `can_broadcast`, `can_escalate`, and `can_propagate` from that same DB row, so a live revocation of any of the three takes effect within `resolve_user`'s TTL instead of only at the next reconnect.

Two tests were added to `tests/test_admin_refresh.py`, mirroring the existing `test_revoked_admin_loses_broadcast_at_next_message` pattern: a live DB revocation of `can_escalate` (or `can_propagate`) causes the next ESCALATE (or PROPAGATE) from that connection to be denied, where it was allowed before the revoke. Both new tests were confirmed to fail against the unfixed `protocol.py` (via patch-revert, not stash) and pass after the fix.

Full suite: 424 passed, 1 skipped, running `tests/` with `tests/e2e` excluded — the e2e directory fails to collect due to a pre-existing API mismatch against the installed `hivescope` package, unrelated to this change.