### PR TITLE
fix: add-client refuses to overwrite an existing access key instead of silently demoting

### DIFF
--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -171,11 +171,22 @@ def add_client(name, access_key, password, crypto_key, admin, metadata, allow_we
                 f"{e}\nPass --allow-weak-password to override.", param_hint="--password"
             )
 
+    requested_access_key = access_key
     password = password or os.urandom(16).hex()
     access_key = access_key or os.urandom(16).hex()
     client_metadata = parse_client_metadata(metadata)
 
     with ClientDatabase() as db:
+        if requested_access_key:
+            existing = db.get_client_by_api_key(requested_access_key)
+            if existing is not None:
+                raise click.ClickException(
+                    f"A client already exists for access key '{requested_access_key}' "
+                    f"(Node ID: {existing.client_id}, Friendly Name: {existing.name}).\n"
+                    "add-client would overwrite its admin status and password. "
+                    "Use rename-client / allow-* / blacklist-* / delete-client to "
+                    "modify the existing client instead."
+                )
         name = name or f"HiveMind-Node-{db.total_clients()}"
         print(f"Database backend: {db.db.__class__.__name__}")
         success = db.add_client(name, access_key, crypto_key=key, password=password,

--- a/tests/test_add_client_no_clobber.py
+++ b/tests/test_add_client_no_clobber.py
@@ -1,0 +1,58 @@
+"""``add-client`` used to be a silent upsert at the CLI layer: re-running it
+with an access key that already exists would demote an admin client to
+non-admin and reset its password, while still printing success. Since the hub
+now live-refreshes is_admin/can_* per message, that demotion hits a live
+connection immediately. The CLI must refuse to overwrite an existing,
+explicitly-named access key instead.
+"""
+import tempfile
+from unittest import mock
+
+from click.testing import CliRunner
+
+from hivemind_core import config as C
+from hivemind_core.database import ClientDatabase
+from hivemind_core.scripts import add_client
+
+ACCESS_KEY = "existing-access-key-0001"
+
+
+def test_add_client_refuses_to_overwrite_existing_access_key():
+    tmp = tempfile.mkdtemp()
+    with mock.patch.object(C, "xdg_data_home", return_value=tmp):
+        runner = CliRunner()
+
+        # 1. create an admin client with a known password.
+        result = runner.invoke(add_client, [
+            "--access-key", ACCESS_KEY,
+            "--password", "correct horse battery staple 9!",
+            "--admin", "True",
+            "--allow-weak-password",
+        ])
+        assert result.exit_code == 0, result.output
+
+        db = ClientDatabase()
+        original = db.get_client_by_api_key(ACCESS_KEY)
+        assert original is not None
+        assert original.is_admin is True
+        original_password = original.password
+
+        # 2. re-run add-client on the SAME access key, no --admin/--password.
+        result2 = runner.invoke(add_client, ["--access-key", ACCESS_KEY])
+        assert result2.exit_code != 0
+        assert "already exists" in result2.output
+
+        # 3. the existing client must be untouched.
+        db2 = ClientDatabase()
+        after = db2.get_client_by_api_key(ACCESS_KEY)
+        assert after.is_admin is True, "add-client must not demote an existing admin"
+        assert after.password == original_password, "add-client must not reset an existing password"
+
+
+def test_add_client_with_a_fresh_auto_generated_key_still_succeeds():
+    tmp = tempfile.mkdtemp()
+    with mock.patch.object(C, "xdg_data_home", return_value=tmp):
+        runner = CliRunner()
+        result = runner.invoke(add_client, [])
+        assert result.exit_code == 0, result.output
+        assert "Credentials added to database!" in result.output


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

The `add-client` CLI command silently clobbered an existing client whenever the operator re-ran it with an access key that already existed. Click's `--admin` option always resolves to a concrete boolean (default `False`), and the password defaults to a freshly generated one when `--password` is omitted, so a re-run passed those straight into the database's upsert. The result was that an admin client got silently demoted to non-admin and had its password reset, while the command still printed "Credentials added to database!" as if nothing was wrong. Since the hub now live-refreshes `is_admin`/`can_*` per message, that demotion hits a connected client immediately rather than waiting for a reconnect.

The database layer's upsert semantics are intentional and documented for programmatic callers, so `database.py` is unchanged. The fix is entirely at the CLI layer: when the operator supplies an explicit `--access-key`, `add-client` now looks it up first, and if a client already exists it raises a `ClickException` naming the existing Node ID and friendly name and pointing the operator at `rename-client`/`allow-*`/`delete-client` instead of touching the database. A freshly auto-generated access key (the common case, when `--access-key` is omitted) is unaffected.

Added `tests/test_add_client_no_clobber.py`. It creates an admin client with a known password, re-invokes `add-client` on the same access key with no `--admin`/`--password`, and asserts the command exits non-zero while the existing client's admin flag and password are untouched. A negative-control test confirms adding with a fresh auto-generated key still succeeds. Verified via patch-revert that the test fails against the pre-fix code (the re-add succeeds and the client's `is_admin`/`password` assertions fail) and passes after the fix.

Full non-e2e suite (`pytest tests --ignore=tests/e2e`): 426 passed, 1 skipped (pre-existing sqlite-plugin-version skip, unrelated).