### PR TITLE
fix: fail gracefully on malformed HELLO session and non-conforming config

### DIFF
--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -202,6 +202,19 @@ def get_server_config() -> JsonStorageXDG:
     # satellites included. Deep-merge it against the defaults, like the policy
     # block above, so every sub-key is always present.
     db["upstream"] = upstream_config(db)
+    # `network_protocol` is only backfilled sub-key by sub-key above, so a
+    # hand-edited `null` (or any other non-dict) survives untouched and
+    # `.items()` at the use site (`HiveMindService`) raises AttributeError
+    # before the graceful "no network protocols" exit path ever runs.
+    # Fall back to the default block, like the policy/upstream blocks above.
+    if not isinstance(db.get("network_protocol"), dict):
+        if "network_protocol" in db:
+            LOG.warning(
+                f"server.json 'network_protocol' is "
+                f"{type(db['network_protocol']).__name__}, not a block of "
+                f"settings — using the defaults."
+            )
+        db["network_protocol"] = dict(_DEFAULT["network_protocol"])
     return db
 
 
@@ -248,4 +261,12 @@ def runtime_password_min_bits() -> float:
     if not cfg.get("runtime_password_strength_check",
                    _DEFAULT["runtime_password_strength_check"]):
         return 0.0
-    return float(cfg.get("min_password_bits", _DEFAULT["min_password_bits"]))
+    min_bits = cfg.get("min_password_bits", _DEFAULT["min_password_bits"])
+    try:
+        return float(min_bits)
+    except (TypeError, ValueError):
+        LOG.warning(
+            f"server.json 'min_password_bits' is {min_bits!r}, not a "
+            f"number — using the default ({_DEFAULT['min_password_bits']})."
+        )
+        return float(_DEFAULT["min_password_bits"])

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -16,7 +16,7 @@ from typing import Union, List, Dict, Optional, Callable, Literal
 import pybase64
 from ovos_bus_client import MessageBusClient
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import Session
+from ovos_bus_client.session import MalformedSession, Session
 from ovos_plugin_manager.transformer_services import (DialogTransformersService,
                                                       MetadataTransformersService,
                                                       UtteranceTransformersService)
@@ -1727,7 +1727,15 @@ class HiveMindListenerProtocol:
         LOG.debug("client Hello received, syncing personal session data")
         payload = message.payload
         if "session" in payload:
-            client.sess = Session.deserialize(payload["session"])
+            try:
+                client.sess = Session.deserialize(payload["session"])
+            except MalformedSession as e:
+                LOG.warning(f"malformed HELLO session from {client.peer}: {e}")
+                self._send_denied(
+                    client, str(message.msg_type), MALFORMED_PAYLOAD,
+                    f"HELLO 'session' can not be reconstructed "
+                    f"(HIVEMIND-MSG-1 §4)", {})
+                return
         if "site_id" in payload:
             client.sess.site_id = client.site_id = payload["site_id"]
         if "pubkey" in payload:

--- a/tests/test_malformed_hello_and_config.py
+++ b/tests/test_malformed_hello_and_config.py
@@ -1,0 +1,148 @@
+"""Adversarial regressions for malformed HELLO sessions and non-conforming
+server.json blocks.
+
+Each defect used to take the whole node down (or crash the handling of a
+single connection) instead of failing gracefully.
+"""
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ovos_bus_client.session import Session
+
+from hivemind_bus_client import HiveMessage, HiveMessageType
+from hivemind_core.config import _DEFAULT, get_server_config, runtime_password_min_bits
+from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
+
+
+def _make_protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.callbacks = MagicMock()
+
+    db_user = MagicMock()
+    db_user.allowed_types = []
+    db_user.is_admin = True
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+
+
+def _make_client(protocol):
+    client = HiveMindClientConnection(
+        key="test-key",
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+        sess=Session("a-session"),
+    )
+    client.name = "test-client"
+    client.allowed_types = []
+    client.crypto_key = None
+    return client
+
+
+def _sent(client):
+    return "".join(str(c.args[0]) for c in client.send_msg.call_args_list)
+
+
+class TestMalformedHelloSession(unittest.TestCase):
+    """A HELLO whose 'session' carrier is not a JSON object must not crash
+    the connection handler."""
+
+    def test_non_dict_session_is_rejected_not_crashed(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+        message = HiveMessage(HiveMessageType.HELLO,
+                              payload={"session": "not-a-dict"})
+
+        protocol.handle_message(message, client)  # must not raise
+
+        sent = _sent(client)
+        self.assertIn("hive.policy.denied", sent)
+        self.assertIn("malformed_payload", sent)
+
+    def test_malformed_hello_does_not_kick_the_peer(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+
+        protocol.handle_message(
+            HiveMessage(HiveMessageType.HELLO,
+                       payload={"session": "not-a-dict"}), client)
+
+        client.disconnect.assert_not_called()
+
+    def test_a_well_formed_hello_is_untouched(self):
+        protocol = _make_protocol()
+        client = _make_client(protocol)
+        message = HiveMessage(HiveMessageType.HELLO,
+                              payload={"session": Session("other-session").serialize()})
+
+        protocol.handle_message(message, client)
+
+        self.assertNotIn("malformed_payload", _sent(client))
+        self.assertEqual(client.sess.session_id, "other-session")
+
+
+class TestNetworkProtocolNonConformingConfig(unittest.TestCase):
+    """A hand-edited `network_protocol: null` used to survive the top-level
+    backfill untouched and blow up `.items()` at the use site."""
+
+    def _config(self, tmp_path, monkeypatch, written):
+        from hivemind_core import config as cfg_mod
+        cfgdir = tmp_path / "hivemind-core"
+        cfgdir.mkdir(parents=True)
+        (cfgdir / "server.json").write_text(json.dumps(written))
+        monkeypatch.setattr(cfg_mod, "xdg_config_home", lambda: str(tmp_path))
+        return cfg_mod.get_server_config()
+
+    def test_null_network_protocol_falls_back_to_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "hivemind-core" / "server.json"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps({"network_protocol": None}))
+            with patch("hivemind_core.config.xdg_config_home",
+                       return_value=tmp):
+                cfg = get_server_config()
+            self.assertIsInstance(cfg["network_protocol"], dict)
+            self.assertEqual(cfg["network_protocol"].items(),
+                             _DEFAULT["network_protocol"].items())
+
+    def test_string_network_protocol_falls_back_to_defaults(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "hivemind-core" / "server.json"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps({"network_protocol": "garbage"}))
+            with patch("hivemind_core.config.xdg_config_home",
+                       return_value=tmp):
+                cfg = get_server_config()
+            self.assertIsInstance(cfg["network_protocol"], dict)
+
+
+class TestMinPasswordBitsNonConformingConfig(unittest.TestCase):
+    """A hand-edited `min_password_bits` that is not a number used to raise
+    ValueError/TypeError out of `runtime_password_min_bits`, taking the
+    handshake path down for every client."""
+
+    def test_non_numeric_min_password_bits_falls_back_to_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "hivemind-core" / "server.json"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps({"min_password_bits": "very-strong"}))
+            with patch("hivemind_core.config.xdg_config_home",
+                       return_value=tmp), \
+                 patch.dict("os.environ", {}, clear=False):
+                import os
+                os.environ.pop("HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK", None)
+                bits = runtime_password_min_bits()
+            self.assertEqual(bits, float(_DEFAULT["min_password_bits"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

This fixes three places where a malformed peer message or a hand-edited `server.json` took a node down (or mishandled a connection) instead of degrading gracefully. All three were verified against current source and each has an adversarial regression test that fails against the unfixed code and passes after the fix.

`handle_hello_message` called `Session.deserialize()` on the HELLO payload's `session` key with no guard. Per SESSION-1 §2.5 a non-object session carrier raises `MalformedSession`, and that exception propagated straight out of the message handler uncaught — a single malformed HELLO from a peer would blow up the connection's message loop. It is now caught and answered the same way every other rejected frame is answered: a `hive.policy.denied` with code `malformed_payload`, and the connection stays open.

`get_server_config()` backfills every top-level config block sub-key by sub-key so a partially-specified block keeps its defaults, but that pass never checks whether the block is a dict at all. A hand-edited `network_protocol: null` (or any non-dict value) survived it untouched, and `HiveMindService` calls `.items()` on that block before it ever reaches its own "no transports configured" exit path — so a single bad value in `server.json` crashed the whole node, satellites included. It now falls back to the default block, the same pattern already used for the `policy` and `upstream` blocks in the same function.

`runtime_password_min_bits()` passed `min_password_bits` straight into `float()`. A non-numeric value in `server.json` raised `ValueError` out of that function, and it sits on the runtime handshake path, so every client's connection attempt would fail until the config was hand-fixed. It now falls back to the default bit count with a warning, mirroring the existing config coercions.

Fail-before evidence: `git apply -R` on the source-only diff, keeping the new test file, made 5 of the 6 tests in `tests/test_malformed_hello_and_config.py` fail — `MalformedSession` propagating out of `handle_message`, `AttributeError` from `network_protocol.items()` on a `None` value, and `ValueError` from `float("very-strong")`. The sixth test (a well-formed HELLO) passed both before and after, as a control. Reapplying the fix made all 6 pass.

The full non-e2e suite (`pytest tests --ignore=tests/e2e`) passes: 432 passed, 1 skipped, no regressions. `tests/e2e` collects cleanly (59 tests, no collection error) and is otherwise out of scope for this change — it exercises full network round trips unrelated to these three defects.