### PR TITLE
fix: policy chain fails closed on malformed verdict return and deleted client row

### DIFF
--- a/hivemind_core/policy.py
+++ b/hivemind_core/policy.py
@@ -119,6 +119,11 @@ class PolicyChain:
             is_optional = self._optional[i] if i < len(self._optional) else False
             try:
                 verdict = policy.review(message, client)
+                if not isinstance(verdict, Verdict):
+                    raise TypeError(
+                        f"{type(policy).__name__}.review returned "
+                        f"{type(verdict).__name__}, not a Verdict"
+                    )
             except Exception as e:
                 if is_optional:
                     LOG.warning(
@@ -179,6 +184,11 @@ class PolicyChain:
             is_optional = self._optional[i] if i < len(self._optional) else False
             try:
                 verdict = policy.review_binary(payload, client)
+                if not isinstance(verdict, Verdict):
+                    raise TypeError(
+                        f"{type(policy).__name__}.review_binary returned "
+                        f"{type(verdict).__name__}, not a Verdict"
+                    )
             except Exception as e:
                 if is_optional:
                     LOG.warning(
@@ -315,7 +325,10 @@ class MessageTypeACLPolicy(PolicyPlugin):
             return list(client.allowed_types or [])
         user = client.resolve_user(db)
         if user is None:
-            return list(client.allowed_types or [])
+            # DB present but the row is gone — the client was deleted
+            # (e.g. revoked) while still connected. Deny, don't fall
+            # back to the stale connect-time snapshot.
+            return []
         return list(user.allowed_types or [])
 
     def review(self, message: Message,

--- a/tests/test_policy_chain.py
+++ b/tests/test_policy_chain.py
@@ -312,6 +312,53 @@ class TestMessageTypeACLPolicy(unittest.TestCase):
         self.assertEqual(v.code, "policy_error")
 
 
+class TestMessageTypeACLPolicyDeletedRow(unittest.TestCase):
+    """POLICY-1 §5: a deleted client row (resolve_user returns None with
+    a DB present) must deny, not fall back to the stale connect-time
+    snapshot — otherwise a revoked/deleted client keeps its old grants
+    until it disconnects."""
+
+    def test_deleted_row_denies_not_stale_snapshot(self):
+        from types import SimpleNamespace
+        client = _FakeClient(allowed_types=["speak"], is_admin=False)
+        client.resolve_user = MagicMock(return_value=None)
+        p = MessageTypeACLPolicy(hm_protocol=SimpleNamespace(db=MagicMock()))
+        self.assertEqual(p._allowed_types(client), [])
+        v = p.review(_msg("speak"), client)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "acl_disallowed_type")
+
+    def test_no_db_still_uses_snapshot(self):
+        """Negative control: db is None is the documented exception."""
+        from types import SimpleNamespace
+        client = _FakeClient(allowed_types=["speak"], is_admin=False)
+        client.resolve_user = MagicMock(return_value=None)
+        p = MessageTypeACLPolicy(hm_protocol=SimpleNamespace(db=None))
+        self.assertEqual(p._allowed_types(client), ["speak"])
+
+    def test_present_row_uses_live_allowed_types(self):
+        """Negative control: an existing row's live grants are used."""
+        from types import SimpleNamespace
+        client = _FakeClient(allowed_types=["stale"], is_admin=False)
+        client.resolve_user = MagicMock(
+            return_value=SimpleNamespace(allowed_types=["fresh"]))
+        p = MessageTypeACLPolicy(hm_protocol=SimpleNamespace(db=MagicMock()))
+        self.assertEqual(p._allowed_types(client), ["fresh"])
+
+    def test_resolve_user_raising_still_denies(self):
+        """Negative control: the pre-existing raise-path deny is unchanged."""
+        from types import SimpleNamespace
+        client = _FakeClient(allowed_types=["speak"], is_admin=False)
+
+        def boom(db, ttl=5.0, force=False):
+            raise RuntimeError("db down")
+        client.resolve_user = boom
+        p = MessageTypeACLPolicy(hm_protocol=SimpleNamespace(db=MagicMock()))
+        v = p.review(_msg("speak"), client)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "policy_error")
+
+
 class TestMessageTypeACLPolicyBinary(unittest.TestCase):
     """POLICY-1 §2: BINARY payloads cross the same gate as BUS messages.
     A client whose whitelist grants nothing must not be able to push
@@ -596,6 +643,65 @@ class TestMutationFailure(unittest.TestCase):
         self.assertEqual(v.data.get("mutation"), "_RaisingMutation")
         self.assertEqual(v.data.get("policy"), "_RaisingMutationPolicy")
         self.assertIn("error", v.data)
+
+
+class _NoneReturningPolicy(PolicyPlugin):
+    def review(self, message, client):
+        return None
+
+    def review_binary(self, payload, client):
+        return None
+
+
+class _NonVerdictReturningPolicy(PolicyPlugin):
+    def review(self, message, client):
+        return "allow"
+
+    def review_binary(self, payload, client):
+        return "allow"
+
+
+class TestMalformedVerdictReturn(unittest.TestCase):
+    """A policy that returns None (or any non-Verdict) instead of raising
+    must fail the chain closed the same as a raise — not let an
+    AttributeError escape review()/review_binary()."""
+
+    def test_none_return_fails_closed_on_review(self):
+        chain = PolicyChain(policies=[_NoneReturningPolicy()])
+        v = chain.review(_msg(), client=None)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "policy_error")
+
+    def test_non_verdict_return_fails_closed_on_review(self):
+        chain = PolicyChain(policies=[_NonVerdictReturningPolicy()])
+        v = chain.review(_msg(), client=None)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "policy_error")
+
+    def test_none_return_fails_closed_on_review_binary(self):
+        chain = PolicyChain(policies=[_NoneReturningPolicy()])
+        v = chain.review_binary(b"x", client=None)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "policy_error")
+
+    def test_non_verdict_return_fails_closed_on_review_binary(self):
+        chain = PolicyChain(policies=[_NonVerdictReturningPolicy()])
+        v = chain.review_binary(b"x", client=None)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "policy_error")
+
+    def test_correct_allow_verdict_still_allows(self):
+        """Negative control: a well-behaved policy is unaffected."""
+        chain = PolicyChain(policies=[_AllowPolicy()])
+        v = chain.review(_msg(), client=None)
+        self.assertFalse(v.denied)
+
+    def test_raising_policy_still_denies(self):
+        """Negative control: the pre-existing raise path is unchanged."""
+        chain = PolicyChain(policies=[_RaisingPolicy()])
+        v = chain.review(_msg(), client=None)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "policy_error")
 
 
 class TestStructuredPolicyErrorData(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

This fixes two related admission-chain defects in `hivemind_core/policy.py`, both on the "fail closed" contract the class docstring already promises.

**Defect 1 — malformed verdict return escapes the try block.** `PolicyChain.review` and `review_binary` only wrap the call to `policy.review(...)` / `policy.review_binary(...)` in a try/except, so a raise is converted to a `POLICY_ERROR` deny. But a policy that instead *returns* `None` (or any non-`Verdict` object) doesn't raise there — it raises later, outside the try, when the code touches `verdict.denied`. That `AttributeError` escapes `review()` entirely: the message is dropped with a traceback and no `hive.policy.denied` notification ever reaches the client. Both methods now validate the returned value is a `Verdict` inside the try, so a malformed return converts to the same fail-closed `POLICY_ERROR` deny as a raise, respecting each policy's per-entry `optional` flag exactly like the raise path already does.

**Defect 2 — a deleted client keeps its stale whitelist.** `MessageTypeACLPolicy._allowed_types` calls `client.resolve_user(db)` to refresh the whitelist from the DB on every admission, so a grant or revocation takes effect without a reconnect. But when the client's row is deleted (`delete-client`) while the connection is still open, `resolve_user` returns `None` — not a raise — and the code fell back to the stale connect-time `client.allowed_types` snapshot, keeping a revoked client's old grants alive until it happens to disconnect. Per the method's own docstring, a DB-present-but-row-gone lookup now denies (returns `[]`, empty ⇒ deny-all under this policy's contract); the `db is None` → snapshot fallback is unchanged, since that's the documented exception.

Both regressions are covered by new adversarial tests in `tests/test_policy_chain.py`, verified fail-before/pass-after by reverting just the source hunk with `git apply -R` and rerunning (never `git stash`). Before the fix: a policy returning `None` or a non-`Verdict` raised `AttributeError` out of `review()`/`review_binary()` instead of denying (4 assertions), and a deleted-row client got its stale `["speak"]` snapshot back from `_allowed_types` instead of `[]` (1 assertion) — 5 failures. After the fix all 5 pass, alongside 5 negative controls that were already green and stay unchanged: a correctly-returning `Verdict.allow()` policy still allows, a raising policy still denies with `policy_error`, `db=None` still returns the snapshot, a live DB row's grants are still honoured, and `resolve_user` raising still denies with `policy_error`.

`pytest tests --ignore=tests/e2e` (foreground): 442 passed, 1 skipped on the first clean run in a fresh venv. A subsequent rerun in the same environment hit one unrelated failure (`test_add_client_no_clobber.py`) caused by `ClientDatabase` leaking a real `clients.db` into `~/.local/share/hivemind-core` instead of honouring the test's `xdg_data_home` mock — pre-existing test-isolation state pollution outside `hivemind_core/policy.py`, not touched by this change.

`tests/e2e` was not run — it has a known pre-existing hivescope/bus-client import-skew collection error in some environments, out of scope for this PR.