### PR TITLE
feat: identity-scoped durable session namespace (survives reconnect)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2026 Casimiro Ferreira
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
+import hashlib
 import json
 import logging
 import os
@@ -254,16 +255,69 @@ class HiveMindClientConnection:
         return self._conn_nonce
 
     @property
+    def session_namespace(self) -> str:
+        """A DURABLE, identity-scoped namespace token for this client's
+        Layer-1 sessions (HIVEMIND-BRIDGE-1 §4).
+
+        Unlike :attr:`conn_nonce`, which is reminted on every reconnect,
+        this token is derived from the client's durable DB identity, so a
+        satellite that drops and reconnects keeps the same namespace: a
+        session minted before the drop stays routable afterwards, and a
+        scheduler-replayed message carrying that old session_id remains
+        deliverable.
+
+        The token is ``sha256(f"{hub_salt}:{client_id}")[:16]`` where
+        ``client_id`` is the durable DB row id (via :meth:`resolve_user`,
+        which already caches with a TTL) and ``hub_salt`` is the hub's
+        persistent node public key (:attr:`NodeIdentity.public_key`, the
+        same identity the node persists on disk), so the namespace also
+        survives a HUB restart. The token IDENTIFIES, it does not
+        AUTHENTICATE: possession grants nothing and admission still runs
+        the ACL. It is derived from the durable client identity, NOT the
+        secret access key (session_ids are visible to every bus observer),
+        and hub-salted so the same client is not linkable across hubs. The
+        salt also hides the small integer client_id, so the token is not
+        enumerable.
+
+        Falls back to :attr:`conn_nonce` when no DB is reachable or the
+        client_id cannot be resolved (unauthenticated/edge), so nothing
+        crashes — at the cost of losing reconnect durability for that
+        connection.
+        """
+        db = getattr(getattr(self, "hm_protocol", None), "db", None)
+        client_id = None
+        if db is not None:
+            try:
+                user = self.resolve_user(db)
+                client_id = getattr(user, "client_id", None)
+            except Exception:
+                LOG.debug("session_namespace: failed to resolve user; "
+                          "falling back to conn_nonce", exc_info=True)
+        if client_id is None:
+            LOG.debug("session_namespace: no durable client_id; "
+                      "falling back to per-connection nonce")
+            return self.conn_nonce
+        identity = getattr(getattr(self, "hm_protocol", None), "identity", None)
+        hub_salt = getattr(identity, "public_key", None) or ""
+        return hashlib.sha256(
+            f"{hub_salt}:{client_id}".encode()).hexdigest()[:16]
+
+    @property
     def layer1_session_id(self) -> str:
         """The orchestrator-side (Layer-1) session id for this connection's
-        CURRENT declared session — the connection nonce namespaces the
-        client-declared session_id, so two connections that chose the same
-        name get distinct Layer-1 sessions (HIVEMIND-BRIDGE-1 §4) while one
-        connection's distinct declared sessions (a re-HELLO, or a bridge like
-        baresip that mints a fresh session_id per call on one connection)
-        stay distinct too — session travels per message, the client
-        declares it."""
-        return f"{self.conn_nonce}:{self.sess.session_id}"
+        CURRENT declared session — the durable ``session_namespace``
+        namespaces the client-declared session_id, so two connections that
+        chose the same name get distinct Layer-1 sessions (HIVEMIND-BRIDGE-1
+        §4) while one connection's distinct declared sessions (a re-HELLO, or
+        a bridge like baresip that mints a fresh session_id per call on one
+        connection) stay distinct too — session travels per message, the
+        client declares it.
+
+        The namespace is identity-scoped (see ``session_namespace``), so this
+        id — and the disconnect notification that carries it — is stable
+        across a reconnect: it matches the id ``_install_client_session``
+        stamped on the connection's inbound bus messages."""
+        return f"{self.session_namespace}:{self.sess.session_id}"
 
     def resolve_user(self, db, ttl: float = 5.0,
                      force: bool = False) -> Optional[Client]:
@@ -2911,15 +2965,26 @@ class HiveMindListenerProtocol:
                            declared_id: str) -> str:
         """The Layer-1 (orchestrator) session id for a message declaring
         ``declared_id``: the raw declared id for an admin, or the
-        per-connection NATted id ``conn_nonce:declared_id`` for everyone else
-        (HIVEMIND-BRIDGE-1 §4). ``declared_id`` is the per-message session id
-        (session travels per message; the client declares it), falling back
-        to the connection's HELLO baseline when the message declares none.
-        Shared by ``_install_client_session`` and the post-transformer
-        re-stamp in ``handle_inject_agent_msg`` so both apply the exact same
-        decision to the same message.
+        identity-scoped NATted id ``session_namespace:declared_id`` for
+        everyone else (HIVEMIND-BRIDGE-1 §4). ``declared_id`` is the
+        per-message session id (session travels per message; the client
+        declares it), falling back to the connection's HELLO baseline when
+        the message declares none. Shared by ``_install_client_session`` and
+        the post-transformer re-stamp in ``handle_inject_agent_msg`` so both
+        apply the exact same decision to the same message.
+
+        BRIDGE-1 §4: the namespace token IDENTIFIES, it does not
+        AUTHENTICATE — possession grants nothing; admission still runs the
+        ACL. It is derived from the durable client identity (via
+        ``client.session_namespace``), not the secret access key, so a
+        session is a durable route that survives reconnect, and hub-salted
+        so it is not linkable across hubs. Using the durable identity rather
+        than the per-connection ``conn_nonce`` is what keeps a session
+        routable across a reconnect (a new connection reuses the same
+        namespace) and across a hub restart (the salt is the persistent node
+        identity).
         """
-        return declared_id if is_admin else f"{client.conn_nonce}:{declared_id}"
+        return declared_id if is_admin else f"{client.session_namespace}:{declared_id}"
 
     def _install_client_session(self, message: Message,
                                  client: HiveMindClientConnection):

--- a/tests/test_admin_refresh.py
+++ b/tests/test_admin_refresh.py
@@ -161,7 +161,7 @@ def test_revoked_admin_is_natted_after_slow_transformer():
 
     emitted = protocol.get_bus(client).emit.call_args[0][0]
     session_id = emitted.context["session"]["session_id"]
-    assert session_id == f"{client.conn_nonce}:default"
+    assert session_id == f"{client.session_namespace}:default"
     assert session_id != "default"
     assert client.is_admin is False
 

--- a/tests/test_session_namespace_durability.py
+++ b/tests/test_session_namespace_durability.py
@@ -1,0 +1,126 @@
+"""Durable, identity-scoped Layer-1 session namespace (HIVEMIND-BRIDGE-1 §4).
+
+A non-admin's declared session_id is NATted at the inbound boundary to
+``f"{namespace}:{declared_id}"``. If that namespace were the per-connection
+``conn_nonce`` (reminted on every reconnect), a satellite that dropped and
+reconnected would land in a different Layer-1 session, and a message replayed
+by the scheduler carrying the pre-drop session_id would become undeliverable.
+
+``HiveMindClientConnection.session_namespace`` fixes this: the namespace is
+derived from the DURABLE DB identity (client_id) plus the hub's persistent
+node public key, so it survives a reconnect (new nonce, same client_id) and a
+hub restart (the salt is the persistent node identity). The token IDENTIFIES,
+it does not AUTHENTICATE — it is derived from the durable identity, never the
+secret access key, and hub-salted so it is not linkable across hubs.
+"""
+from unittest.mock import MagicMock
+
+from ovos_bus_client.session import Session
+
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+
+def _make_protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.return_value = agent.bus
+
+    db = MagicMock()
+
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+
+
+def _make_client(client_id, key="access-key", public_key="hub-pubkey-A",
+                 db=True):
+    proto = _make_protocol()
+    client = HiveMindClientConnection(
+        key=key,
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=proto,
+        sess=Session(session_id="default"),
+    )
+    # Stub the hub salt to a known value AFTER __post_init__ (which reads the
+    # real RSA key via identity_rsa_key); session_namespace reads only
+    # identity.public_key.
+    proto.identity.public_key = public_key
+    if db:
+        user = MagicMock()
+        user.client_id = client_id
+        proto.db.get_client_by_api_key.return_value = user
+    else:
+        # unauthenticated/edge: no reachable DB -> fallback to conn_nonce
+        proto.db = None
+    return client
+
+
+def test_session_namespace_survives_reconnect():
+    # A client with a stable DB client_id keeps the SAME namespace across a
+    # reconnect, even though conn_nonce is reminted. THIS IS THE FAIL-BEFORE
+    # CASE: with conn_nonce as the namespace, the two ids below would differ.
+    client = _make_client(client_id=42)
+    before = client.session_namespace
+    id_before = HiveMindListenerProtocol._layer1_session_id(
+        client, is_admin=False, declared_id="chat")
+
+    # simulate a reconnect: force a brand-new conn_nonce, same identity
+    old_nonce = client.conn_nonce
+    client._conn_nonce = ""
+    client.invalidate_user()
+    assert client.conn_nonce != old_nonce
+
+    after = client.session_namespace
+    id_after = HiveMindListenerProtocol._layer1_session_id(
+        client, is_admin=False, declared_id="chat")
+
+    assert before == after
+    assert id_before == id_after == f"{before}:chat"
+
+
+def test_distinct_identities_get_distinct_namespaces():
+    a = _make_client(client_id=1)
+    b = _make_client(client_id=2)
+    assert a.session_namespace != b.session_namespace
+
+
+def test_namespace_is_not_the_secret_key():
+    # The token must be derived from the durable identity, not the secret
+    # access key: changing the key (same client_id + salt) does not change
+    # the namespace, and the raw key never appears in the token.
+    base = _make_client(client_id=7, key="secret-one")
+    rotated = _make_client(client_id=7, key="secret-two")
+    assert base.session_namespace == rotated.session_namespace
+    assert "secret-one" not in base.session_namespace
+    assert "secret-two" not in rotated.session_namespace
+
+
+def test_namespace_is_hub_salted_and_stable():
+    # Same client_id + same hub salt -> same token across two separate
+    # connection objects; a different hub salt -> different token (a session
+    # is not linkable across hubs).
+    same_hub_1 = _make_client(client_id=9, public_key="hub-A")
+    same_hub_2 = _make_client(client_id=9, public_key="hub-A")
+    other_hub = _make_client(client_id=9, public_key="hub-B")
+
+    assert same_hub_1.session_namespace == same_hub_2.session_namespace
+    assert same_hub_1.session_namespace != other_hub.session_namespace
+
+
+def test_admin_branch_unchanged():
+    client = _make_client(client_id=5)
+    sid = HiveMindListenerProtocol._layer1_session_id(
+        client, is_admin=True, declared_id="default")
+    assert sid == "default"
+
+
+def test_fallback_to_conn_nonce_without_db():
+    # An unauthenticated/edge client with no DB falls back to conn_nonce
+    # instead of crashing.
+    client = _make_client(client_id=None, db=False)
+    assert client.session_namespace == client.conn_nonce
+    sid = HiveMindListenerProtocol._layer1_session_id(
+        client, is_admin=False, declared_id="x")
+    assert sid == f"{client.conn_nonce}:x"

--- a/tests/test_session_nat.py
+++ b/tests/test_session_nat.py
@@ -9,14 +9,15 @@ state. ``_install_client_session`` must translate the client-chosen
 ``session_id`` to a per-connection Layer-1 id before the message reaches the
 OVOS bus, while leaving every other session field untouched.
 
-The Layer-1 id is derived as ``f"{conn_nonce}:{sess.session_id}"``, NOT
-cached once per connection: session travels per message and the client
+The Layer-1 id is derived as ``f"{session_namespace}:{sess.session_id}"``,
+NOT cached once per connection: session travels per message and the client
 declares it (a peer may re-HELLO with a new session_id, and a bridge like
 the baresip SIP gateway mints a fresh session_id per call on a single,
-long-lived connection). Namespacing by the connection's own nonce keeps two
-different connections that pick the same declared name apart, while letting
-one connection's distinct declared sessions (a fresh call, a re-HELLO) stay
-distinct from each other too.
+long-lived connection). The namespace is the client's durable, identity-
+scoped ``session_namespace`` (see ``test_session_namespace_durability``),
+which keeps two different connections that pick the same declared name apart
+while letting one connection's distinct declared sessions (a fresh call, a
+re-HELLO) stay distinct from each other too.
 """
 from unittest.mock import MagicMock
 
@@ -110,7 +111,7 @@ def test_redeclared_session_gets_a_distinct_layer1_session():
     assert sid1 != sid2
     nonce1, _, declared1 = sid1.partition(":")
     nonce2, _, declared2 = sid2.partition(":")
-    assert nonce1 == nonce2 == client.conn_nonce
+    assert nonce1 == nonce2 == client.session_namespace
     assert declared1 == "call-1"
     assert declared2 == "call-2"
 
@@ -144,11 +145,11 @@ def test_different_named_payload_gets_its_own_layer1_session():
     result = _install(client, message)
 
     sid = result.context["session"]["session_id"]
-    assert sid == f"{client.conn_nonce}:call-42"
+    assert sid == f"{client.session_namespace}:call-42"
     # the declared id is namespaced, never handed through raw
     assert sid != "call-42"
     # and it is NOT the baseline's id — the per-message session wins
-    assert sid != f"{client.conn_nonce}:baseline"
+    assert sid != f"{client.session_namespace}:baseline"
 
 
 def test_multiplexed_sessions_over_one_connection_stay_isolated():
@@ -166,8 +167,8 @@ def test_multiplexed_sessions_over_one_connection_stay_isolated():
     sid_a = a.context["session"]["session_id"]
     sid_b = b.context["session"]["session_id"]
 
-    assert sid_a == f"{client.conn_nonce}:sess-A"
-    assert sid_b == f"{client.conn_nonce}:sess-B"
+    assert sid_a == f"{client.session_namespace}:sess-A"
+    assert sid_b == f"{client.session_namespace}:sess-B"
     assert sid_a != sid_b
 
 
@@ -183,8 +184,8 @@ def test_message_without_declared_session_uses_baseline_id():
                                              {"utterances": ["hi"]},
                                              {"session": {"session_id": "baseline"}}))
 
-    assert none_declared.context["session"]["session_id"] == f"{client.conn_nonce}:baseline"
-    assert same_declared.context["session"]["session_id"] == f"{client.conn_nonce}:baseline"
+    assert none_declared.context["session"]["session_id"] == f"{client.session_namespace}:baseline"
+    assert same_declared.context["session"]["session_id"] == f"{client.session_namespace}:baseline"
 
 
 def test_rich_payload_location_overrides_baseline():
@@ -252,4 +253,4 @@ def test_thin_control_message_does_not_clobber_baseline_location():
     assert loc["timezone"]["code"] == "Europe/Berlin"
     assert loc["city"]["name"] == "Berlin"
     # and the message still got this connection's Layer-1 id
-    assert emitted.context["session"]["session_id"] == f"{client.conn_nonce}:sat-de"
+    assert emitted.context["session"]["session_id"] == f"{client.session_namespace}:sat-de"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

A non-admin client's declared `session_id` is NATted at the inbound boundary to `f"{namespace}:{declared_id}"` so two peers that both pick "default" don't collide onto one OVOS session. That namespace was the per-connection `conn_nonce`, which is reminted on every reconnect. So a satellite that dropped and reconnected landed in a *different* Layer-1 session, and a message the scheduler replayed carrying the pre-drop `session_id` became undeliverable — the session was not a durable route. This was certified failing on a live 3-device rig.

This makes the namespace durable and identity-scoped. `HiveMindClientConnection.session_namespace` returns `sha256(f"{hub_salt}:{client_id}")[:16]`, where `client_id` is the durable DB row id (via `resolve_user`, already TTL-cached) and `hub_salt` is the hub's persistent node public key. Because the input is the durable identity rather than the connection nonce, a reconnect (new nonce, same `client_id`) reuses the same namespace; because the salt is the persistent node identity, the namespace also survives a hub restart — the scheduler case where an alert outlives a hub bounce.

The token IDENTIFIES, it does not AUTHENTICATE (BRIDGE-1 §4): possession grants nothing, admission still runs the ACL. It is derived from the durable client identity, never the secret access key — `session_id`s are visible to every bus observer, so the key must never appear — and it is hub-salted so the same client is not linkable across hubs, and the salt hides the small-integer `client_id` so the token is not enumerable. If no DB is reachable or the `client_id` can't be resolved (unauthenticated/edge), it falls back to `conn_nonce` so nothing crashes.

`_layer1_session_id` and the `layer1_session_id` property (which feeds the disconnect-lifecycle emit, so it must match what the bus saw inbound) now consume `session_namespace` for the non-admin branch. The admin branch (bare `declared_id`) is unchanged. `peer` deliberately stays per-connection (`conn_nonce`): it is the live-connection handle, and a reconnect is a new connection/peer — only the session namespace is durable.

Fail-before via patch-revert (source reverted, tests kept): the reconnect-durability, distinct-identity, non-secret, hub-salt, and fallback tests all fail without the property (the reconnect test's key assertion — same `client_id` across a forced-new `conn_nonce` yields the same namespace and the same `X:declared` id — cannot even be reached, as `session_namespace` does not exist); admin-unchanged passes throughout. After the fix all pass. The NAT-isolation tests were repointed from `conn_nonce` to `session_namespace`. `pytest tests --ignore=tests/e2e`: 447 passed, 1 skipped, 1 pre-existing failure (`test_add_client_no_clobber`, confirmed failing identically on clean `origin/dev`).

hivemind-ovos-agent-plugin #57 consumes `client.session_namespace`; the two co-release.
