### PR TITLE
chore(deps): require hivemind-ovos-agent-plugin>=0.4.0a1 for session-owned routing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "hivemind-sqlite-database>=0.4.0a2",
     "hivemind-json-db-plugin>=0.0.3a2",
     "hivemind-websocket-protocol>=0.2.10a1,<1.0.0",
-    "hivemind-ovos-agent-plugin>=0.3.1a1,<1.0.0",
+    "hivemind-ovos-agent-plugin>=0.4.0a1,<1.0.0",
     # transformer pipeline runner services on the text/bus path
     "ovos-plugin-manager>=2.10.0a1,<3.0.0",
     "setuptools",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

Bumps the floor pin on `hivemind-ovos-agent-plugin` from `>=0.3.1a1` to `>=0.4.0a1` (cap `<1.0.0` unchanged).

hivemind-core 4.14.0a1 provides `session_namespace`, which the agent plugin's session-owned message routing and twin fix consume starting at 0.4.0a1 (the feature shipped as a minor bump, not a patch — 0.3.10a1 does not contain it). Installing hivemind-core without this floor can resolve a plugin build that lacks that consumer, silently losing session-owned routing. This relocks the dependency so a fresh install always pulls a routing-capable plugin.

No other dependency changed.

**Verification performed** (claims below verified by re-running the commands myself, not just reading the model's report):
- Built a venv inside the worktree with `uv venv` and installed with `uv pip install --prerelease=allow -e ".[test]"`.
- `uv pip show hivemind-ovos-agent-plugin` resolved `0.4.0a1`, satisfying the new `>=0.4.0a1` floor.
- `pytest tests --ignore=tests/e2e`: 448 passed, 1 skipped, 0 failed.
- `tests/test_add_client_no_clobber.py` (both cases) passed in isolation.

Draft — not merging.
