### PR TITLE
fix: add-client refuses a legacy crypto_key on a node that requires the v3 Noise handshake

### DIFF
--- a/hivemind_core/scripts.py
+++ b/hivemind_core/scripts.py
@@ -140,10 +140,36 @@ def derive_psk(password, node_id):
 @click.option("--allow-weak-password", is_flag=True, default=False,
               help="Skip the password-strength check (not recommended). By default a "
                    "guessable/low-entropy --password is refused.")
-def add_client(name, access_key, password, crypto_key, admin, metadata, allow_weak_password):
+@click.option("--allow-legacy-crypto-key", is_flag=True, default=False,
+              help="Confirm this client really is a legacy v1/v2 AES client on a node "
+                   "that permits it, bypassing the refusal below.")
+def add_client(name, access_key, password, crypto_key, admin, metadata, allow_weak_password,
+               allow_legacy_crypto_key):
     """Add a client, generating any credential the operator did not supply."""
     key = crypto_key
     if key:
+        # `min_protocol_version` >= 2 (the default) means every client must
+        # negotiate the v3 Noise handshake (protocol.ProtocolVersion.THREE),
+        # which uses the password-derived PSK, not this legacy v1/v2 AES
+        # pre-shared key. A crypto_key set on such a node is never used for
+        # decryption but IS stored, so the client keeps sending frames
+        # encrypted with it — every one fails server-side decryption
+        # (DecryptionKeyError) and the client surfaces that as a misleading
+        # "invalid access key/password" error instead of the real cause.
+        requires_noise_handshake = get_server_config().get("min_protocol_version", 2) >= 2
+        if requires_noise_handshake and not allow_legacy_crypto_key:
+            raise click.ClickException(
+                "--crypto-key is a legacy v1/v2 AES pre-shared key, incompatible with "
+                "the v3 Noise handshake this node requires (min_protocol_version >= 2).\n"
+                "Setting it will not break the connection outright — it breaks every "
+                "message after: the client keeps encrypting with this key, the server's "
+                "Noise session can't decrypt it, and the client reports that as an "
+                "\"invalid access key/password\" error, hiding the real cause.\n"
+                "Omit --crypto-key: v3 clients use the password-derived PSK instead "
+                "(see 'hivemind-core derive-psk').\n"
+                "If this really is a legacy v1/v2 client on a node that permits it, "
+                "pass --allow-legacy-crypto-key to proceed anyway."
+            )
         print(
             "WARNING: crypto key is deprecated, use password instead if your client supports it"
         )

--- a/tests/test_add_client_crypto_key_noise_guard.py
+++ b/tests/test_add_client_crypto_key_noise_guard.py
@@ -1,0 +1,115 @@
+"""``add-client --crypto-key`` sets a LEGACY v1/v2 AES pre-shared key. On a
+node whose ``min_protocol_version`` requires the v3 Noise handshake (the
+default), that key is never used for decryption — the client keeps
+encrypting with it, the server's Noise session can't decrypt the result, and
+the client surfaces that as a misleading "invalid access key/password" error
+instead of the real cause. ``add-client`` used to only print a soft
+deprecation warning and proceed; it must refuse instead, with an explicit
+``--allow-legacy-crypto-key`` escape hatch for operators who genuinely run
+v1/v2 clients on a node that permits them.
+
+Isolation note: ``ClientDatabase`` resolves its sqlite path via
+``hivemind_sqlite_database``, which imported ``xdg_data_home`` directly from
+``ovos_utils.xdg_utils`` — patching only ``hivemind_core.config.xdg_data_home``
+(as tests/test_add_client_no_clobber.py does) leaves that reference live and
+the client lands in the real ``~/.local/share`` database. Both import sites
+are patched here so these tests never touch the real db.
+"""
+import json
+import os
+import tempfile
+from unittest import mock
+
+from click.testing import CliRunner
+
+from hivemind_core import config as C
+from hivemind_core.database import ClientDatabase
+from hivemind_core.scripts import add_client
+
+import hivemind_sqlite_database as _sqlite_plugin
+
+
+def _isolated_xdg(data_tmp, cfg_tmp):
+    return (
+        mock.patch.object(C, "xdg_data_home", return_value=data_tmp),
+        mock.patch.object(C, "xdg_config_home", return_value=cfg_tmp),
+        mock.patch.object(_sqlite_plugin, "xdg_data_home", return_value=data_tmp),
+    )
+
+
+def _seed_server_config(cfg_tmp, config):
+    cfg_dir = os.path.join(cfg_tmp, "hivemind-core")
+    os.makedirs(cfg_dir, exist_ok=True)
+    with open(os.path.join(cfg_dir, "server.json"), "w") as f:
+        json.dump(config, f)
+
+
+def test_crypto_key_refused_on_node_requiring_noise_handshake():
+    """FAIL-BEFORE: today this succeeds with only a soft warning and creates
+    a client whose crypto_key will silently break every message it sends."""
+    data_tmp, cfg_tmp = tempfile.mkdtemp(), tempfile.mkdtemp()
+    p1, p2, p3 = _isolated_xdg(data_tmp, cfg_tmp)  # min_protocol_version defaults to 2
+    with p1, p2, p3:
+        runner = CliRunner()
+        result = runner.invoke(add_client, [
+            "--access-key", "legacy-refused-0001",
+            "--crypto-key", "0123456789abcdef",
+        ])
+        assert result.exit_code != 0, result.output
+        assert "Noise handshake" in result.output
+        assert "--allow-legacy-crypto-key" in result.output
+
+        db = ClientDatabase()
+        assert db.get_client_by_api_key("legacy-refused-0001") is None, \
+            "refused add-client must not create the client"
+
+
+def test_crypto_key_allowed_with_escape_hatch_on_node_requiring_noise_handshake():
+    data_tmp, cfg_tmp = tempfile.mkdtemp(), tempfile.mkdtemp()
+    p1, p2, p3 = _isolated_xdg(data_tmp, cfg_tmp)
+    with p1, p2, p3:
+        runner = CliRunner()
+        result = runner.invoke(add_client, [
+            "--access-key", "legacy-allowed-0002",
+            "--crypto-key", "0123456789abcdef",
+            "--allow-legacy-crypto-key",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "deprecated" in result.output
+
+        db = ClientDatabase()
+        client = db.get_client_by_api_key("legacy-allowed-0002")
+        assert client is not None
+        assert client.crypto_key == "0123456789abcdef"
+
+
+def test_crypto_key_allowed_on_node_permitting_legacy_clients():
+    data_tmp, cfg_tmp = tempfile.mkdtemp(), tempfile.mkdtemp()
+    _seed_server_config(cfg_tmp, {"min_protocol_version": 0})
+    p1, p2, p3 = _isolated_xdg(data_tmp, cfg_tmp)
+    with p1, p2, p3:
+        runner = CliRunner()
+        result = runner.invoke(add_client, [
+            "--access-key", "legacy-permitted-0003",
+            "--crypto-key", "0123456789abcdef",
+        ])
+        assert result.exit_code == 0, result.output
+        assert "deprecated" in result.output
+
+        db = ClientDatabase()
+        client = db.get_client_by_api_key("legacy-permitted-0003")
+        assert client is not None
+        assert client.crypto_key == "0123456789abcdef"
+
+
+def test_add_client_without_crypto_key_still_works():
+    data_tmp, cfg_tmp = tempfile.mkdtemp(), tempfile.mkdtemp()
+    p1, p2, p3 = _isolated_xdg(data_tmp, cfg_tmp)
+    with p1, p2, p3:
+        runner = CliRunner()
+        result = runner.invoke(add_client, ["--access-key", "no-crypto-key-0004"])
+        assert result.exit_code == 0, result.output
+        assert "Credentials added to database!" in result.output
+
+        db = ClientDatabase()
+        assert db.get_client_by_api_key("no-crypto-key-0004") is not None


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Problem

`add-client --crypto-key` sets a legacy v1/v2 AES pre-shared key. When the node requires the v3 Noise handshake (`min_protocol_version >= 2`, the default), that key is never used for decryption. The client keeps encrypting every frame with it, the server's Noise session can't decrypt any of it, and the client reports that as an "invalid access key/password" error — hiding the real cause. Today `add-client` only prints a soft deprecation warning and proceeds.

## Fix

`add-client` now checks the node's configured `min_protocol_version` and refuses `--crypto-key` when the node requires the v3 handshake, with a clear error naming the incompatibility and pointing to the password-derived PSK (`derive-psk`). `--allow-legacy-crypto-key` is an explicit escape hatch that restores the old soft-deprecation behavior for operators who genuinely run v1/v2 clients on a node that permits them. Nodes with a lower `min_protocol_version` are unaffected — the soft warning still applies there.

The runtime crypto/decode path is untouched by this PR.

## Verification

- Added `tests/test_add_client_crypto_key_noise_guard.py`: refusal on a node requiring the handshake, escape hatch works, permitted on a node with a lowered `min_protocol_version`, and a negative control confirming `add-client` without `--crypto-key` is unaffected.
- Confirmed each new assertion fails against the pre-fix code (verified via a local patch-revert, not committed) and passes after the fix.
- `pytest tests --ignore=tests/e2e`: 452 passed, 1 skipped, 0 failed (includes the known pre-existing `tests/test_add_client_no_clobber.py`, which passed cleanly in this environment; it is unrelated to this change and not touched here).
- Read the server-side inbound decode ordering (`hivemind_core/protocol.py`): it prefers `noise_transport` over `crypto_key` identically to the client (`hivemind_bus_client/client.py`), and clears `client.crypto_key = None` once a v3 handshake completes. No secondary runtime bug found there.

## Scope

Only `hivemind_core/scripts.py` and the new test file are touched. No runtime protocol/crypto changes.