### PR TITLE
fix: handshake decision keys on negotiated connection capability, not a provisioned crypto_key (prevents transport downgrade)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1046,7 +1046,14 @@ class HiveMindListenerProtocol:
         LOG.debug(f"saying HELLO to: {client.peer}")
         client.send(msg)
 
-        needs_handshake = not client.crypto_key and self.handshake_enabled
+        # The handshake decision keys on the negotiated connection capability,
+        # never on a provisioning artifact. A v3-capable connection (client has
+        # a password -> pswd_handshake set) always handshakes when it is
+        # enabled, so a lingering DB crypto_key column cannot downgrade a v3
+        # transport (the stray key goes unused and is cleared post-handshake).
+        # A connection that is not v3-capable still uses the legacy crypto_key
+        # AES path its handshake actually negotiates.
+        needs_handshake = self.handshake_enabled and v3_capable
 
         cfg = get_server_config()
         allowed_ciphers = cfg.get("allowed_ciphers") or [SupportedCiphers.AES_GCM]

--- a/tests/test_handshake_not_downgraded_by_crypto_key.py
+++ b/tests/test_handshake_not_downgraded_by_crypto_key.py
@@ -1,0 +1,107 @@
+"""The handshake decision must key on the negotiated connection capability,
+never on a provisioned ``crypto_key`` (HIVEMIND-CRYPTO-1, transport downgrade).
+
+A v3-capable connection is one whose client presented a password, so
+``pswd_handshake`` is set and the Noise handshake is available. Such a
+connection must always run the handshake when it is enabled, even if the DB row
+still carries a legacy ``crypto_key`` column: a provisioning artifact must not
+downgrade the transport to the v2 AES path (the stray key is cleared
+post-handshake). A connection that is not v3-capable keeps using the legacy
+crypto_key path its handshake actually negotiates.
+
+The observable contract is the ``handshake`` field of the HANDSHAKE payload the
+server emits during ``handle_new_client``.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from hivemind_bus_client import HiveMessageType
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol, ProtocolVersion)
+
+
+def _make_protocol(handshake_enabled=True):
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.callbacks = MagicMock()
+
+    db_user = MagicMock()
+    db_user.skill_blacklist = []
+    db_user.intent_blacklist = []
+    db_user.message_blacklist = []
+    db_user.allowed_types = ["speak", "recognizer_loop:utterance"]
+    db_user.is_admin = True
+
+    db = MagicMock()
+    db.get_client_by_api_key.return_value = db_user
+
+    protocol = HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                        require_crypto=False)
+    protocol.handshake_enabled = handshake_enabled
+    return protocol
+
+
+def _make_client(protocol, pswd_handshake, crypto_key):
+    client = HiveMindClientConnection(
+        key="test-key",
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=protocol,
+    )
+    client.name = "test-client"
+    client.pswd_handshake = pswd_handshake
+    client.crypto_key = crypto_key
+    return client
+
+
+def _handshake_flag(protocol, client, noise_supported=True):
+    """Run handle_new_client and return the ``handshake`` field the server
+    advertised in the emitted HANDSHAKE payload."""
+    sent = []
+    client.send = lambda msg, plaintext=None: sent.append(msg)
+    # Keep version negotiation from rejecting the legacy (v1) connection before
+    # HANDSHAKE is emitted; the handshake decision under test is independent of
+    # the configured floor.
+    with patch("hivemind_core.protocol.NOISE_SUPPORTED", noise_supported), \
+         patch("hivemind_core.protocol._configured_min_protocol_version",
+               return_value=ProtocolVersion.ZERO):
+        protocol.handle_new_client(client)
+    handshakes = [m.payload for m in sent
+                  if m.msg_type == HiveMessageType.HANDSHAKE]
+    assert handshakes, "no HANDSHAKE message was emitted"
+    return handshakes[-1]["handshake"]
+
+
+class TestHandshakeNotDowngradedByCryptoKey(unittest.TestCase):
+    def test_v3_capable_with_stray_crypto_key_still_handshakes(self):
+        # THE DOWNGRADE CASE: password present (v3-capable) AND a lingering
+        # provisioned crypto_key. The stray key must NOT suppress the handshake.
+        protocol = _make_protocol(handshake_enabled=True)
+        client = _make_client(protocol, pswd_handshake=MagicMock(),
+                              crypto_key="provisioned-legacy-key")
+        self.assertTrue(_handshake_flag(protocol, client))
+
+    def test_v3_capable_no_crypto_key_handshakes(self):
+        protocol = _make_protocol(handshake_enabled=True)
+        client = _make_client(protocol, pswd_handshake=MagicMock(),
+                              crypto_key=None)
+        self.assertTrue(_handshake_flag(protocol, client))
+
+    def test_not_v3_capable_with_crypto_key_uses_legacy_path(self):
+        # No password -> not v3-capable -> the legacy crypto_key AES path its
+        # connection actually negotiates is preserved (no handshake requested).
+        protocol = _make_protocol(handshake_enabled=True)
+        client = _make_client(protocol, pswd_handshake=None,
+                              crypto_key="legacy-shared-key")
+        self.assertFalse(_handshake_flag(protocol, client))
+
+    def test_handshake_disabled_never_handshakes(self):
+        protocol = _make_protocol(handshake_enabled=False)
+        client = _make_client(protocol, pswd_handshake=MagicMock(),
+                              crypto_key=None)
+        self.assertFalse(_handshake_flag(protocol, client))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

A provisioned `crypto_key` column on a client row silently suppressed the v3 Noise handshake. In `handle_new_client` (`hivemind_core/protocol.py`) the handshake decision was `needs_handshake = not client.crypto_key and self.handshake_enabled`. When the DB row carried a legacy `crypto_key`, `needs_handshake` became `False`, so the server advertised `handshake:false` in its HANDSHAKE payload and expected the legacy v2 AES path. But a v3-capable connection — one where the client presented a password, so the `v3_capable = NOISE_SUPPORTED and client.pswd_handshake is not None` computed just above is true — speaks Noise. The two sides disagree on the transport, producing a `DecryptionKeyError` on every message, mis-surfaced to the user as an invalid access key/password. A provisioning artifact must never dictate the transport: this is a downgrade-attack shape.

The fix keys the decision on what the connection actually negotiates rather than on a stored row: `needs_handshake = self.handshake_enabled and v3_capable`. A v3-capable connection always runs the handshake when it is enabled, regardless of a lingering `crypto_key` (which then goes unused and is already cleared post-handshake). A connection that is not v3-capable — no password, so no `pswd_handshake` — keeps using the legacy `crypto_key` AES path its handshake genuinely negotiates, preserving real v1/v2 clients. The version negotiation, the `v3_capable` computation, and the post-handshake key clearing are untouched.

This pairs with the merged #303 provisioning guard as defense-in-depth: #303 refuses to provision a legacy `crypto_key` on a node that requires the handshake at the add-client boundary; this change ensures that even a `crypto_key` that already exists on the row cannot downgrade a v3 connection at runtime.

Fail-before evidence (patch-file revert of `protocol.py` only, test kept): the stray-`crypto_key` v3 case asserted the advertised `handshake` flag is `True` but got `False`; restoring the fix makes all four cases pass. The new tests assert on the observable contract — the `handshake` field of the emitted HANDSHAKE payload — across: v3-capable + stray crypto_key (the downgrade case), v3-capable + no crypto_key, not-v3-capable + crypto_key (legacy path preserved), and handshake disabled. Full suite `pytest tests --ignore=tests/e2e`: 456 passed, 1 skipped.

Acceptance: a peer will run a live rig cell — provision a `crypto_key` on a v3 node, confirm the handshake runs and the session works end to end.
