### PR TITLE
feat: un-NAT the client session in core send() (BRIDGE-1 §4 outbound half)

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1,6 +1,7 @@
 # hivemind-core
 # Copyright (C) 2026 Casimiro Ferreira
 # SPDX-License-Identifier: Apache-2.0
+import copy
 import dataclasses
 import hashlib
 import json
@@ -390,6 +391,26 @@ class HiveMindClientConnection:
                                  else message.payload.msg_type)
                 _log.debug("mycroft_type %s", _payload_type)
 
+                # OUTBOUND half of the BRIDGE-1 §4 session NAT, symmetric with
+                # the inbound _install_client_session / _layer1_session_id: the
+                # bus stamps every inbound message with the Layer-1 id
+                # f"{session_namespace}:{declared}", so on the way back to the
+                # client we strip this connection's namespace prefix and restore
+                # the client's own declared session_id. A client only ever sees
+                # its own declared ids; the internal namespace never crosses the
+                # wire. Living in core (the single per-client delivery choke
+                # point) means every agent/binary protocol plugin inherits it
+                # instead of each having to reimplement the un-NAT.
+                unnatted = self._unnat_outbound_session(message)
+                if unnatted is not message:
+                    # A per-peer deepcopy was made because the prefix matched;
+                    # the input ``message`` is shared across a fan-out and was
+                    # NOT mutated. Any ``plaintext`` passed in was serialized
+                    # from the still-NATted shared message and is wrong for this
+                    # peer, so drop it and reserialize the un-NATted copy below.
+                    message = unnatted
+                    plaintext = None
+
             _log.debug("sending to %s: %s", self.peer, message.msg_type)
 
             # WIRE-1 §4.3: a type with no assigned 5-bit code (INTERCOM) travels
@@ -436,6 +457,41 @@ class HiveMindClientConnection:
                 _log.debug("sent unencrypted!")
 
             self.send_msg(payload, is_bin)
+
+    def _unnat_outbound_session(self, message: HiveMessage) -> HiveMessage:
+        """Restore this connection's declared session_id on an outbound BUS
+        message, undoing the inbound NAT (BRIDGE-1 §4).
+
+        The inbound boundary rewrites a non-admin client's declared session_id
+        to ``f"{session_namespace}:{declared}"``. Here we recover ``declared``
+        by stripping this connection's namespace prefix. The payload is either
+        an ``ovos_bus_client`` ``Message`` or a raw dict (mirroring the
+        dict-vs-Message handling in :meth:`send`).
+
+        Returns a per-peer deepcopy with the session_id restored when the
+        prefix matches, otherwise the input ``message`` unchanged. The input is
+        shared across a fan-out to multiple peers and is never mutated. When the
+        session id carries no namespace prefix (an admin bare id, another
+        client's namespace, or no session at all) the message is left as-is.
+        """
+        payload = message.payload
+        if isinstance(payload, dict):
+            session = (payload.get("context") or {}).get("session")
+        else:
+            session = getattr(payload, "context", {}).get("session")
+        sid = session.get("session_id") if isinstance(session, dict) else None
+        prefix = f"{self.session_namespace}:"
+        if not isinstance(sid, str) or not sid.startswith(prefix):
+            return message
+        declared = sid[len(prefix):]
+        if not declared:
+            return message
+        out = copy.deepcopy(message)
+        if isinstance(out.payload, dict):
+            out.payload["context"]["session"]["session_id"] = declared
+        else:
+            out.payload.context["session"]["session_id"] = declared
+        return out
 
     @property
     def crypto_required(self) -> bool:

--- a/tests/test_session_unnat_outbound.py
+++ b/tests/test_session_unnat_outbound.py
@@ -1,0 +1,132 @@
+"""Outbound session_id un-NAT at the bridge (HIVEMIND-BRIDGE-1 §4).
+
+The symmetric counterpart of the inbound NAT (see ``test_session_nat``): the
+bus stamps every inbound BUS message with the Layer-1 id
+``f"{session_namespace}:{declared}"``. On the way back to the client,
+``HiveMindClientConnection.send`` must strip this connection's namespace prefix
+so the client only ever sees its OWN declared session_id — the internal
+namespace never crosses the wire. Living in core means every agent/binary
+protocol plugin inherits it instead of reimplementing an outbound un-NAT.
+
+The un-NAT works on a per-peer deepcopy: the input message is shared across a
+fan-out to multiple peers and must never be mutated.
+"""
+import json
+from unittest.mock import MagicMock
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+
+from hivemind_core.protocol import (HiveMindClientConnection,
+                                    HiveMindListenerProtocol)
+
+
+def _make_protocol():
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.get_bus.return_value = agent.bus
+    db = MagicMock()
+    return HiveMindListenerProtocol(agent_protocol=agent, db=db,
+                                    require_crypto=False,
+                                    handshake_enabled=False)
+
+
+def _make_client(namespace, key="k", name="sat"):
+    client = HiveMindClientConnection(
+        key=key,
+        send_msg=MagicMock(),
+        disconnect=MagicMock(),
+        hm_protocol=_make_protocol(),
+        sess=Session(session_id="default"),
+    )
+    client.name = name
+    # pin the namespace deterministically (per instance, so two clients in one
+    # test keep distinct namespaces) instead of the db-derived derivation
+    client.__class__ = type(
+        "PinnedNamespaceConnection", (HiveMindClientConnection,),
+        {"session_namespace": property(lambda self, _ns=namespace: _ns)})
+    return client
+
+
+def _sent_session_id(client):
+    """The session_id in the payload actually handed to the transport."""
+    payload = client.send_msg.call_args[0][0]
+    data = json.loads(payload)
+    # HiveMessage.serialize wraps the bus payload under "payload"
+    inner = data.get("payload", data)
+    return inner["context"]["session"]["session_id"]
+
+
+def _bus_msg(session_id):
+    return HiveMessage(
+        HiveMessageType.BUS,
+        payload=Message("speak", {"utterance": "hi"},
+                        {"session": {"session_id": session_id}}),
+    )
+
+
+def test_namespaced_session_is_unnatted_and_input_not_mutated():
+    # FAIL-BEFORE case: a namespaced Layer-1 id must reach the client stripped
+    # back to its declared form, AND the shared input message must be untouched.
+    client = _make_client("ns1")
+    msg = _bus_msg("ns1:default")
+
+    client.send(msg)
+
+    assert _sent_session_id(client) == "default"
+    # per-peer copy: the shared input still carries the NATted id
+    assert msg.payload.context["session"]["session_id"] == "ns1:default"
+
+
+def test_two_namespaces_no_cross_contamination():
+    a = _make_client("nsA", key="a", name="a")
+    b = _make_client("nsB", key="b", name="b")
+
+    # a's own message and b's own message, each namespaced for that peer
+    a.send(_bus_msg("nsA:default"))
+    b.send(_bus_msg("nsB:kitchen"))
+
+    assert _sent_session_id(a) == "default"
+    assert _sent_session_id(b) == "kitchen"
+
+
+def test_non_matching_prefix_sent_unchanged():
+    client = _make_client("ns1")
+    # another client's namespace — leave untouched
+    client.send(_bus_msg("other:default"))
+    assert _sent_session_id(client) == "other:default"
+
+
+def test_admin_bare_session_sent_unchanged():
+    client = _make_client("ns1")
+    client.send(_bus_msg("default"))
+    assert _sent_session_id(client) == "default"
+
+
+def test_empty_remainder_sent_unchanged():
+    client = _make_client("ns1")
+    client.send(_bus_msg("ns1:"))
+    assert _sent_session_id(client) == "ns1:"
+
+
+def test_plaintext_ignored_when_unnat_applied():
+    # A fan-out caller may pass a pre-serialized plaintext computed from the
+    # still-NATted shared message. When the un-NAT applies, that plaintext is
+    # wrong for this peer and must be dropped in favour of the un-NATted copy.
+    client = _make_client("ns1")
+    msg = _bus_msg("ns1:default")
+    stale_plaintext = msg.serialize()  # carries ns1:default
+
+    client.send(msg, plaintext=stale_plaintext)
+
+    assert _sent_session_id(client) == "default"
+
+
+def test_hello_message_unchanged():
+    client = _make_client("ns1")
+    hello = HiveMessage(HiveMessageType.HELLO, payload={"foo": "bar"})
+    client.send(hello)
+    # delivered verbatim, no crash on a non-BUS payload
+    assert client.send_msg.called


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

The inbound session NAT is a core invariant: `_install_client_session` / `_layer1_session_id` rewrite a non-admin client's declared `session_id` to `f"{session_namespace}:{declared}"` on the way in to the OVOS bus, so two satellites that both pick `"default"` never collide. The matching outbound un-NAT — restoring the declared id on the way back to the client — was implemented only in one agent plugin, hivemind-ovos-agent-plugin's `_nat_outbound_session`. Because the agent and binary protocols are pluggable, any other plugin that does not copy that method (hivemind-media-player's agent, a Wyoming plugin, and so on) leaks the internal namespaced id to the client. That breaks client-side session gating (`require_default_session` in ovos-media / ovos-audio) and pollutes the client's `SessionManager` with a foreign `{ns}:default` session.

This moves the un-NAT into core so it is symmetric with the inbound half and every agent/binary protocol inherits it for free. The fix lives in `HiveMindClientConnection.send`, the single per-client delivery choke point. For a BUS message whose session id starts with this connection's `f"{session_namespace}:"`, the declared remainder is restored. The payload may be an `ovos_bus_client` `Message` or a raw dict, mirroring the existing dict-vs-Message handling already in `send()`.

The restore happens on a per-peer `deepcopy`; the input `message` is shared across a fan-out to multiple peers and is never mutated. There is a plaintext caveat: `send()`'s `plaintext` param is a pre-serialized payload shared across a fan-out, so once the un-NAT applies that shared plaintext still carries the NATted id and is wrong for this peer — when un-NAT is applied it is dropped and the un-NATted copy is reserialized. Admin bare ids, another client's namespace, an empty remainder, no session, and non-BUS (binary / HELLO / handshake) messages are all delivered unchanged.

With this in core, hivemind-ovos-agent-plugin's `_nat_outbound_session` becomes redundant but harmless: it un-NATs first, so core then sees no prefix and no-ops. A follow-up can remove it and relock. This PR does not touch that plugin, the inbound NAT, or `session_namespace`.

Fail-before was proven by patch-reverting only the source: the three un-NAT assertions failed (namespaced id delivered verbatim, shared input mutated, stale plaintext leaked) and pass after the fix; the four unchanged-path assertions pass both ways. Full suite: `pytest tests --ignore=tests/e2e` → 458 passed, 1 skipped, 1 failed. The single failure is the known pre-existing `tests/test_add_client_no_clobber.py` XDG-mock flake, confirmed to fail identically on clean `dev`. A peer will run a rig cell: a satellite declares `"default"` and must receive `"default"` back.



## Rig6 delta characterization (verified)

On the plugin-covered path (agent-plugin handle_internal_mycroft, which already pre-strips via _nat_outbound_session) the core un-NAT is a verified NO-OP — this is an invariant relocation, not a behavior change there. The genuine behavioral delta is on the uncovered path: PROPAGATE/BROADCAST go handle_outgoing -> client.send() directly with no plugin pre-strip, so dev leaks the raw namespaced session id onto the wire and this PR restores the declared remainder. Verified in-process against installed code on both trees; round-trip held live (inbound NAT intact, `default` restored outbound, no foreign session in the client SessionManager, client-side default gate accepts); input non-mutation confirmed by object identity.
