### PR TITLE
test: re-enable ping_flood e2e, pin hivescope>=0.8.4a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,12 +68,12 @@ presence = ["hivemind-presence", "hivemind-ggwave"]
 test = [
     "pytest",
     "pytest-cov",
-    "hivescope>=0.8.2a1",
+    "hivescope>=0.8.4a1",
     # client-side Noise (hivemind_bus_client>=1.0.0a1) comes from the runtime
     # dependency above — no git ref, so the wheel stays PyPI-publishable.
 ]
 integration = [
-    "hivescope>=0.8.2a1",
+    "hivescope>=0.8.4a1",
     "ovoscope",
     "ovos-core>=2.1.6a1",
     "ovos-skill-hello-world",

--- a/tests/e2e/test_ping_flood_mesh_e2e.py
+++ b/tests/e2e/test_ping_flood_mesh_e2e.py
@@ -15,17 +15,6 @@ pytest.importorskip("hivescope")
 from hivemind_bus_client.message import HiveMessage, HiveMessageType  # noqa: E402
 from hivescope.topology import TopologyBuilder  # noqa: E402
 
-# TEMP: hivescope's in-process shim delivers synchronously and re-enters the
-# Noise send-lock now held across the multi-frame chunking send path, which
-# deadlocks the relay/flood path. This is a test-harness artifact, not a
-# production bug — chunking is verified over real sockets (HiveMind-voice-relay#45).
-# Re-enabled by the hivescope async-delivery shim fix.
-pytestmark = pytest.mark.xfail(
-    run=False,
-    reason="hivescope in-process shim re-enters the Noise send-lock (deadlock); "
-           "harness fix in hivescope, not a production bug",
-)
-
 
 def _ping(flood_id: str, peer: str) -> HiveMessage:
     inner = HiveMessage(HiveMessageType.PING,

--- a/tests/e2e/test_ping_flood_scale.py
+++ b/tests/e2e/test_ping_flood_scale.py
@@ -24,17 +24,6 @@ pytest.importorskip("hivescope")
 from hivemind_bus_client.message import HiveMessage, HiveMessageType  # noqa: E402
 from hivescope.scenarios import star_topology  # noqa: E402
 
-# TEMP: hivescope's in-process shim delivers synchronously and re-enters the
-# Noise send-lock now held across the multi-frame chunking send path, which
-# deadlocks the relay/flood path. This is a test-harness artifact, not a
-# production bug — chunking is verified over real sockets (HiveMind-voice-relay#45).
-# Re-enabled by the hivescope async-delivery shim fix.
-pytestmark = pytest.mark.xfail(
-    run=False,
-    reason="hivescope in-process shim re-enters the Noise send-lock (deadlock); "
-           "harness fix in hivescope, not a production bug",
-)
-
 NUM_SATELLITES = 6
 
 


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

The two `ping_flood` e2e tests were marked `xfail(run=False)` to unblock #311 while a deadlock in hivescope's in-process shim (it re-entered the Noise send-lock held across the multi-frame chunking send path) was fixed upstream. hivescope 0.8.4a1 ships a non-reentrant delivery pump that resolves the deadlock, so this PR removes the temporary xfail markers from `tests/e2e/test_ping_flood_mesh_e2e.py` and `tests/e2e/test_ping_flood_scale.py` and bumps the `hivescope` floor to `>=0.8.4a1` in the `test` and `integration` extras. Verified in a fresh venv: `uv pip install --prerelease=allow -e .[test]` resolves `hivescope==0.8.4a1`, `hivemind-bus-client==1.1.0a1`, `hivemind-websocket-protocol==1.0.1a1`; the two re-enabled tests pass in 20.56s with no deadlock; the full `tests/e2e` suite passes (59 passed, 2 skipped, 1 unrelated pre-existing xpass in `test_bridge1_conformance.py`); the non-e2e suite passes (452 passed, 1 skipped). The pre-existing `test_add_client_no_clobber` isolation flake was not observed in this run.
