### PR TITLE
fix: persist the INTERCOM origin pin in the client database

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -103,6 +103,10 @@ WRAPPER_TYPES = (HiveMessageType.PROPAGATE, HiveMessageType.BROADCAST,
                  HiveMessageType.CASCADE)
 
 
+
+class IntercomPinUnavailable(RuntimeError):
+    """The INTERCOM pin store could not be read or written; callers fail closed."""
+
 class ProtocolVersion(IntEnum):
     ZERO = 0  # json only, no handshake, no binary
     ONE = 1  # handshake https://github.com/JarbasHiveMind/HiveMind-core/pull/29
@@ -1527,6 +1531,57 @@ class HiveMindListenerProtocol:
         else:
             LOG.warning(f"Ignoring received untyped binary data: {len(bin_data)} bytes")
 
+    # ------------------------------------------------- INTERCOM pin store
+    def _pinned_intercom_key(self, client: HiveMindClientConnection) -> Optional[str]:
+        """The RSA public key pinned for this client identity, or None when
+        the row holds no pin yet.
+
+        CRYPTO-1 §4: the pin is per access credential and outlives the
+        connection, so it lives in the client database row's metadata and is
+        cached in ``trusted_pubkeys`` once read. A listener restart therefore
+        keeps the pin; a HELLO after the restart cannot seize it.
+
+        Raises IntercomPinUnavailable when the row cannot be read. That is
+        not "no pin": a caller that treated it so would let a peer pin its
+        own key during a database outage, so callers fail closed instead.
+        """
+        pinned = self.trusted_pubkeys.get(client.key)
+        if pinned is not None:
+            return pinned
+        try:
+            with self.db:
+                user = self.db.get_client_by_api_key(client.key)
+        except Exception as e:
+            raise IntercomPinUnavailable(
+                f"cannot read the INTERCOM pin for {client.peer}: {e}") from e
+        if user is None or not isinstance(user.metadata, dict):
+            return None
+        pinned = user.metadata.get("intercom_pubkey")
+        if pinned:
+            self.trusted_pubkeys[client.key] = pinned
+        return pinned
+
+    def _pin_intercom_key(self, client: HiveMindClientConnection, pubkey: str) -> None:
+        """Pin ``pubkey`` for this client identity in the database, then in
+        memory. A pin that did not reach the database is no pin at all, so a
+        failed write raises IntercomPinUnavailable and leaves memory alone."""
+        try:
+            with self.db:
+                user = self.db.get_client_by_api_key(client.key)
+                if user is None:
+                    raise IntercomPinUnavailable(
+                        f"no client row for {client.peer} to pin against")
+                if not isinstance(user.metadata, dict):
+                    user.metadata = {}
+                user.metadata["intercom_pubkey"] = pubkey
+                self.db.update_item(user)
+        except IntercomPinUnavailable:
+            raise
+        except Exception as e:
+            raise IntercomPinUnavailable(
+                f"cannot persist the INTERCOM pin for {client.peer}: {e}") from e
+        self.trusted_pubkeys[client.key] = pubkey
+
     # ------------------------------------------------- protocol v3 (Noise)
     def _get_pinned_client_noise_key(self, client: HiveMindClientConnection) -> Optional[str]:
         """Pinned Noise static public key for this client identity, if any.
@@ -1707,11 +1762,19 @@ class HiveMindListenerProtocol:
             # TOFU pin: first pubkey seen for this access key becomes the
             # trust anchor for INTERCOM signature verification. A later HELLO
             # presenting a different key does NOT overwrite the pin.
-            pinned = self.trusted_pubkeys.get(client.key)
-            if pinned is None:
-                self.trusted_pubkeys[client.key] = client.pub_key
-                LOG.debug(f"pinned public key for {client.peer}")
-            elif pinned != client.pub_key:
+            try:
+                pinned = self._pinned_intercom_key(client)
+                if pinned is None:
+                    self._pin_intercom_key(client, client.pub_key)
+                    LOG.debug(f"pinned public key for {client.peer}")
+                    pinned = client.pub_key
+            except IntercomPinUnavailable as e:
+                # Fail closed: without the row we cannot know whether a pin
+                # exists, so this HELLO pins nothing and its INTERCOM frames
+                # stay unverifiable until the database is back.
+                LOG.error(f"not pinning {client.peer}: {e}")
+                pinned = client.pub_key
+            if pinned != client.pub_key:
                 LOG.warning(f"client {client.peer} presented a public key that "
                             f"does not match its pinned key; keeping the pin")
         else:
@@ -2778,7 +2841,11 @@ class HiveMindListenerProtocol:
                 # fail closed and drop rather than dispatch unverified.
                 # A rejection returns True: the frame is consumed here, it is
                 # not relayed to peers nor escalated upstream.
-                pub = self.trusted_pubkeys.get(client.key) or client.pub_key
+                try:
+                    pub = self._pinned_intercom_key(client) or client.pub_key
+                except IntercomPinUnavailable as e:
+                    LOG.error(f"INTERCOM from {client.peer} dropped: {e}")
+                    return True
                 if not pub:
                     LOG.warning(f"INTERCOM from {client.peer} has no pinned/known "
                                 f"public key: dropping unverifiable origin")
@@ -2796,8 +2863,15 @@ class HiveMindListenerProtocol:
                     LOG.error(f"INTERCOM signature verification failed for "
                               f"{client.peer}: dropping forged/mismatched message")
                     return True
-                # first verified sighting pins the key for this listener's lifetime
-                self.trusted_pubkeys.setdefault(client.key, pub)
+                # first verified sighting pins the key for this identity; a
+                # pin that cannot be persisted is no pin, so the frame is
+                # dropped rather than dispatched on a promise
+                if client.key not in self.trusted_pubkeys:
+                    try:
+                        self._pin_intercom_key(client, pub)
+                    except IntercomPinUnavailable as e:
+                        LOG.error(f"INTERCOM from {client.peer} dropped: {e}")
+                        return True
 
                 private_key = load_RSA_key(self.identity.private_key)
 

--- a/tests/test_crypto_enforcement.py
+++ b/tests/test_crypto_enforcement.py
@@ -179,6 +179,69 @@ class TestIntercomSignatureVerification(unittest.TestCase):
         assert mock_log.warning.called
         assert "no signature" in mock_log.warning.call_args[0][0]
 
+    def test_pin_survives_a_listener_restart(self):
+        """CRYPTO-1 §4: the pin belongs to the access credential, not to the
+        listener process. A second protocol instance over the same client
+        database must see the first instance's pin, and a HELLO presenting a
+        different key after the restart must not seize it."""
+        db_user = self.proto.db.get_client_by_api_key.return_value
+        db_user.metadata = {}
+        self.client.is_admin = True
+        self.proto.handle_hello_message(
+            HiveMessage(HiveMessageType.HELLO, payload={"pubkey": self.client_pub}),
+            self.client)
+        assert db_user.metadata["intercom_pubkey"] == self.client_pub
+        self.proto.db.update_item.assert_called_with(db_user)
+
+        restarted = _make_protocol()
+        restarted.db.get_client_by_api_key.return_value = db_user
+        restarted.identity = self.proto.identity
+        client = _make_client(restarted)
+        client.is_admin = True
+        assert "test-key" not in restarted.trusted_pubkeys
+        restarted.handle_hello_message(
+            HiveMessage(HiveMessageType.HELLO, payload={"pubkey": self.forger_pub}),
+            client)
+        assert restarted.trusted_pubkeys["test-key"] == self.client_pub
+        assert db_user.metadata["intercom_pubkey"] == self.client_pub
+        restarted.handle_client_shared_bus = MagicMock()
+        assert restarted.handle_intercom_message(
+            self._intercom(self.forger_priv), client) is True
+        restarted.handle_client_shared_bus.assert_not_called()
+
+    def test_a_failed_pin_lookup_pins_nothing_and_refuses_intercom(self):
+        """A database outage must not be read as "no pin yet": a peer holding
+        the credential could otherwise seize the pin with its own key. The
+        HELLO pins nothing and the forger's INTERCOM is dropped."""
+        self.proto.db.get_client_by_api_key.side_effect = OSError("db down")
+        self.client.is_admin = True
+        with patch("hivemind_core.protocol.LOG") as mock_log:
+            self.proto.handle_hello_message(
+                HiveMessage(HiveMessageType.HELLO, payload={"pubkey": self.forger_pub}),
+                self.client)
+        assert "test-key" not in self.proto.trusted_pubkeys
+        assert mock_log.error.called
+        self.proto.handle_client_shared_bus = MagicMock()
+        assert self.proto.handle_intercom_message(
+            self._intercom(self.forger_priv), self.client) is True
+        self.proto.handle_client_shared_bus.assert_not_called()
+        assert "test-key" not in self.proto.trusted_pubkeys
+
+    def test_a_failed_pin_write_leaves_no_pin_in_memory(self):
+        """A pin that did not reach the database is no pin: memory must not
+        say otherwise, and the failure is reported."""
+        db_user = self.proto.db.get_client_by_api_key.return_value
+        db_user.metadata = {}
+        self.proto.db.update_item.side_effect = OSError("disk full")
+        self.client.is_admin = True
+        with patch("hivemind_core.protocol.LOG") as mock_log:
+            self.proto.handle_hello_message(
+                HiveMessage(HiveMessageType.HELLO, payload={"pubkey": self.client_pub}),
+                self.client)
+        assert "test-key" not in self.proto.trusted_pubkeys
+        assert mock_log.error.called
+        assert "persist" in mock_log.error.call_args[0][0]
+
     def test_hello_pins_pubkey_and_keeps_first_pin(self):
         hello = HiveMessage(HiveMessageType.HELLO,
                             payload={"pubkey": self.client_pub})


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

Tracks #33 (the key-storage half; signature verification already landed).

HIVEMIND-CRYPTO-1 §4: a peer's public key "is pinned the first time it is seen for a given access credential, and a later HELLO MUST NOT move an existing pin." The pin lived only in `trusted_pubkeys`, an in-memory dict, so a listener restart emptied it and the first HELLO afterwards owned the pin. A peer holding a leaked credential only had to wait for a restart to present its own key and have its forged INTERCOM frames verify.

The pin is now persisted in the client database row's metadata under `intercom_pubkey`, the same place and shape as the Noise static key pin, and read back into the in-memory store on first use. The HELLO and INTERCOM paths both consult the persisted pin before falling back to the key presented on the wire. The disconnect sweep is unchanged: it already dropped a pin only when the credential itself was gone from the database.

The store fails closed. A row that cannot be read is not "no pin yet": that HELLO pins nothing and the peer's INTERCOM frames are dropped until the database is back, so a transient outage cannot become a pin seizure. A pin that cannot be written is no pin: memory is left alone and the failure is logged at error, so a restart never reveals a pin that was only ever in memory.

| check | result |
|---|---|
| new `test_pin_survives_a_listener_restart` on dev | fails: nothing persisted, restarted listener re-pins the forger's key |
| after the fix | passes: restarted listener keeps the first pin and rejects the forged INTERCOM |
| lookup raises during HELLO from a forger, then a forged INTERCOM | nothing pinned, frame dropped |
| write raises during HELLO | nothing pinned in memory, error logged |
| `pytest tests --ignore=tests/e2e` | 455 passed, 1 skipped |

Verified by the model that wrote the change by running the suite; not human-reviewed.

Closes #33: signature verification is on `dev` (`verify_RSA` in `handle_intercom_message`); this PR supplies the persistent key storage the issue tracks.
