### PR TITLE
fix: derive the Noise PSK off the IOLoop, early, and persist it per client

### DIFF
--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -1,6 +1,7 @@
 # hivemind-core
 # Copyright (C) 2026 Casimiro Ferreira
 # SPDX-License-Identifier: Apache-2.0
+import asyncio
 import copy
 import dataclasses
 import hashlib
@@ -11,9 +12,10 @@ import threading
 import time
 import uuid
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum
-from typing import Union, List, Dict, Optional, Callable, Literal
+from typing import Union, List, Dict, Optional, Callable, Literal, Tuple
 
 import pybase64
 from ovos_bus_client import MessageBusClient
@@ -202,6 +204,13 @@ class HiveMindClientConnection:
     # dropped (only HELLO/HANDSHAKE ever travel before it exists).
     noise_handshake: Optional[object] = field(default=None, repr=False)
     noise_transport: Optional[NoiseTransport] = field(default=None, repr=False)
+    # Noise message 1 is parked while this connection's pre-shared key is
+    # derived off the IOLoop; a second HANDSHAKE frame meanwhile is rejected
+    noise_psk_pending: bool = field(default=False, init=False, repr=False)
+    # set once this connection is being torn down (a handshake abort, the
+    # transport reporting the peer gone) so work parked on it, a PSK
+    # derivation in flight, knows not to resume it
+    disconnected: bool = field(default=False, init=False, repr=False)
     # exact payloads of the cleartext HELLO + parameter HANDSHAKE sent to this
     # client, retained for Noise prologue binding (CRYPTO-1 §3.3)
     _hello_payload: Optional[dict] = field(default=None, init=False, repr=False)
@@ -907,34 +916,263 @@ class HiveMindListenerProtocol:
 
     # how many distinct passwords keep a derived PSK in memory at once
     NOISE_PSK_CACHE_SIZE = 256
+    # Threads deriving PSKs off the IOLoop. argon2-cffi releases the GIL, but
+    # every derivation holds a 64 MiB arena, so keep this small. The pool is
+    # never shut down: the listener has no stop method, and at interpreter
+    # exit the worker threads finish their current derivation (well under a
+    # second each) and drop anything still queued.
+    NOISE_PSK_WORKERS = 2
+    # Client-row metadata keys holding the persisted PSK and the binding
+    # that says which (node id, password) pair it was derived for. They live
+    # beside the TOFU pin, noise_pubkey, in the row that already holds the
+    # password the key derives from. The key is password-equivalent for the
+    # protocol v3 handshake: anything that redacts ``password`` when it
+    # serializes a row must redact ``metadata.noise_psk`` the same way.
+    NOISE_PSK_METADATA_KEY = "noise_psk"
+    NOISE_PSK_BINDING_METADATA_KEY = "noise_psk_for"
+    # lazily created; class defaults keep a bypass-built instance safe.
+    # init=False/repr=False like the other backing fields: this is a
+    # dataclass, and the futures are keyed by the client password.
+    _noise_psk_executor: Optional[ThreadPoolExecutor] = field(
+        default=None, init=False, repr=False)
+    _noise_psk_futures: Optional[dict] = field(default=None, init=False, repr=False)
+    # api keys whose row is known to carry the persisted key already, so a
+    # memory hit does not re-read the row; bounded by the number of client
+    # rows, and only ever grows within one process
+    _noise_psk_persisted_keys: Optional[set] = field(default=None, init=False, repr=False)
+    # Guards the memory cache and the persisted-keys set: the websocket and
+    # HTTP transports call in on the IOLoop thread, the MQTT transport from
+    # its own, and both reach the cache.
+    _noise_psk_lock: Optional[threading.Lock] = field(default=None, init=False, repr=False)
 
-    def noise_psk(self, password: Union[str, bytes]) -> bytes:
+    @property
+    def _psk_lock(self) -> threading.Lock:
+        if self._noise_psk_lock is None:
+            self._noise_psk_lock = threading.Lock()
+        return self._noise_psk_lock
+
+    def _noise_psk_key(self, password: Union[str, bytes]) -> Tuple[bytes, str]:
+        if isinstance(password, str):
+            password = password.encode("utf-8")
+        return (password, self._node_id)
+
+    def _noise_psk_binding(self, password: bytes) -> str:
+        """What a persisted key is bound to: this node's id and the password.
+
+        A digest rather than the values themselves so the binding is one
+        short field; not a secret in its own right, since the row it sits in
+        holds the password in the clear and the key it guards is
+        password-equivalent already. It makes staleness a deterministic
+        check: a key persisted under a different password or node id simply
+        does not match and is derived afresh.
+        """
+        material = b"hivemind-noise-psk-binding\x00" + self._node_id.encode("utf-8") \
+            + b"\x00" + password
+        return hashlib.sha256(material).hexdigest()
+
+    def _remember_noise_psk(self, key: Tuple[bytes, str], psk: bytes) -> None:
+        with self._psk_lock:
+            self._noise_psks[key] = psk
+            self._noise_psks.move_to_end(key)
+            while len(self._noise_psks) > self.NOISE_PSK_CACHE_SIZE:
+                self._noise_psks.popitem(last=False)
+
+    def _recall_noise_psk(self, key: Tuple[bytes, str]) -> Optional[bytes]:
+        with self._psk_lock:
+            psk = self._noise_psks.get(key)
+            if psk is not None:
+                self._noise_psks.move_to_end(key)
+            return psk
+
+    def noise_psk(self, password: Union[str, bytes],
+                  client: Optional[HiveMindClientConnection] = None) -> bytes:
         """The Noise pre-shared key for ``password``, derived at most once.
 
-        derive_psk runs argon2id (time_cost=3, 64 MiB) and measured
-        152-333ms per call on the single IOLoop thread that serves every
-        connected client. It is cacheable because its salt is
-        SHA-256(node_id): the result depends only on the password and this
-        node's id, both constant for the life of the node, so the same pair
-        always yields the same key.
+        derive_psk runs argon2id (time_cost=3, 64 MiB): 152-333ms on a
+        developer machine, ~750ms on a half-core container. It is cacheable
+        because its salt is SHA-256(node_id): the result depends only on the
+        password and this node's id, both constant for the life of the node,
+        so the same pair always yields the same key.
 
         Keyed on the password (and this node's id) rather than on the node
         id alone: Client rows carry their own password, so two clients may
         legitimately present different ones, and handing a client another
         client's PSK would silently break its handshake.
+
+        Lookup order: the in-memory LRU, then the key persisted in
+        ``client``'s database row (so a restart re-derives nothing for a
+        client seen before), then a fresh derivation, which is persisted.
+        This form derives inline; the handshake path prefers
+        ``_derive_noise_psk_async`` so the IOLoop keeps serving everyone
+        else while argon2id runs.
         """
-        if isinstance(password, str):
-            password = password.encode("utf-8")
-        key = (password, self._node_id)
-        psk = self._noise_psks.get(key)
+        key = self._noise_psk_key(password)
+        psk = self._cached_noise_psk(key, client)
         if psk is None:
-            psk = derive_psk(password, node_id=self._node_id)
-            self._noise_psks[key] = psk
-            while len(self._noise_psks) > self.NOISE_PSK_CACHE_SIZE:
-                self._noise_psks.popitem(last=False)
-        else:
-            self._noise_psks.move_to_end(key)
+            psk = derive_psk(key[0], node_id=self._node_id)
+            self._remember_noise_psk(key, psk)
+            self._persist_noise_psk(client, key, psk)
         return psk
+
+    def _cached_noise_psk(self, key: Tuple[bytes, str],
+                          client: Optional[HiveMindClientConnection]) -> Optional[bytes]:
+        """The PSK for ``key`` without deriving: memory, then the client row."""
+        psk = self._recall_noise_psk(key)
+        if psk is not None:
+            # another client with the same password derived it; make sure
+            # this client's own row carries it too, once per process
+            if client is not None and client.key not in self._persisted_noise_psk_keys():
+                self._persist_noise_psk(client, key, psk)
+            return psk
+        psk = self._load_persisted_noise_psk(client, key)
+        if psk is not None:
+            self._remember_noise_psk(key, psk)
+        return psk
+
+    def _persisted_noise_psk_keys(self) -> set:
+        with self._psk_lock:
+            if self._noise_psk_persisted_keys is None:
+                self._noise_psk_persisted_keys = set()
+            return self._noise_psk_persisted_keys
+
+    def _noise_psk_row(self, client: HiveMindClientConnection) -> Optional[Client]:
+        """The client's DB row, through the connection's short-lived cache.
+
+        The handshake already resolved the row for admission moments ago;
+        a second uncached lookup per connection on the IOLoop is what this
+        avoids.
+        """
+        try:
+            return client.resolve_user(self.db)
+        except Exception:
+            LOG.exception("failed to look up the client row for the Noise PSK")
+            return None
+
+    def _load_persisted_noise_psk(self, client: Optional[HiveMindClientConnection],
+                                  key: Tuple[bytes, str]) -> Optional[bytes]:
+        """The PSK persisted in ``client``'s row, if bound to this node and password."""
+        if client is None:
+            return None
+        user = self._noise_psk_row(client)
+        metadata = getattr(user, "metadata", None)
+        if not isinstance(metadata, dict):
+            return None
+        if metadata.get(self.NOISE_PSK_BINDING_METADATA_KEY) != self._noise_psk_binding(key[0]):
+            return None
+        raw = metadata.get(self.NOISE_PSK_METADATA_KEY)
+        if not isinstance(raw, str):
+            return None
+        try:
+            psk = bytes.fromhex(raw)
+        except ValueError:
+            return None
+        if len(psk) != 32:
+            return None
+        self._persisted_noise_psk_keys().add(client.key)
+        return psk
+
+    def _persist_noise_psk(self, client: Optional[HiveMindClientConnection],
+                           key: Tuple[bytes, str], psk: bytes) -> None:
+        """Store ``psk`` in ``client``'s row so a restart need not re-derive it.
+
+        The value is a pure function of the row's own password and this
+        node's id, so a peer presenting the wrong password causes at most
+        one idempotent write of the right key.
+        """
+        if client is None:
+            return
+        try:
+            binding = self._noise_psk_binding(key[0])
+            with self.db:
+                user = self._noise_psk_row(client)
+                if user is None:
+                    return
+                metadata = user.metadata if isinstance(user.metadata, dict) else {}
+                if metadata.get(self.NOISE_PSK_METADATA_KEY) != psk.hex() or \
+                        metadata.get(self.NOISE_PSK_BINDING_METADATA_KEY) != binding:
+                    metadata[self.NOISE_PSK_METADATA_KEY] = psk.hex()
+                    metadata[self.NOISE_PSK_BINDING_METADATA_KEY] = binding
+                    user.metadata = metadata
+                    self.db.update_item(user)
+            self._persisted_noise_psk_keys().add(client.key)
+        except Exception:
+            LOG.exception("failed to persist the derived Noise PSK")
+
+    def _derive_noise_psk_async(
+            self, password: Union[str, bytes],
+            client: Optional[HiveMindClientConnection]) -> Optional[asyncio.Future]:
+        """Derive the PSK for ``password`` on a worker thread.
+
+        Returns a future resolving to the key, shared by every caller asking
+        for the same password while it is in flight; the LRU and the client
+        row are filled when it completes. Returns None when no event loop is
+        running on this thread (a transport that calls in from its own
+        thread, e.g. MQTT), in which case the caller derives inline.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+        key = self._noise_psk_key(password)
+        if self._noise_psk_futures is None:
+            self._noise_psk_futures = {}
+        futures = self._noise_psk_futures
+        future = futures.get(key)
+        if future is not None:
+            if future.get_loop().is_closed():
+                # bound to a loop that is gone: it can never complete
+                futures.pop(key, None)
+            elif not future.done():
+                return future
+            elif not future.cancelled() and future.exception() is None:
+                # Finished, but its completion callback has not run yet
+                # (the callback is queued behind whoever is asking now).
+                # The key exists: hand it over instead of deriving again.
+                self._remember_noise_psk(key, future.result())
+                return future
+        if self._noise_psk_executor is None:
+            self._noise_psk_executor = ThreadPoolExecutor(
+                max_workers=self.NOISE_PSK_WORKERS, thread_name_prefix="noise-psk")
+        future = asyncio.wrap_future(
+            self._noise_psk_executor.submit(derive_psk, key[0], node_id=self._node_id),
+            loop=loop)
+        futures[key] = future
+
+        def _derived(done: asyncio.Future) -> None:
+            # only this future's own entry: a same-key caller may already
+            # have replaced it, and that replacement must stay shared
+            if futures.get(key) is done:
+                futures.pop(key, None)
+            if done.cancelled():
+                return
+            error = done.exception()
+            if error is not None:
+                # the key never existed, so nothing here can leak it
+                LOG.error(f"Noise PSK derivation failed: "
+                          f"{type(error).__name__}: {error}")
+                return
+            self._remember_noise_psk(key, done.result())
+            self._persist_noise_psk(client, key, done.result())
+
+        future.add_done_callback(_derived)
+        return future
+
+    def _prewarm_noise_psk(self, client: HiveMindClientConnection) -> None:
+        """Start deriving ``client``'s PSK as soon as the offer goes out.
+
+        The node derives the same key on its side before it can send Noise
+        message 1, so this overlaps the two derivations instead of
+        serializing them; by the time message 1 arrives the key is usually
+        ready. Off the IOLoop; a no-op when the key is already known.
+        """
+        if client.pswd_handshake is None:
+            return
+        password = client.pswd_handshake.password
+        try:
+            if self._cached_noise_psk(self._noise_psk_key(password), client) is None:
+                self._derive_noise_psk_async(password, client)
+        except Exception:
+            LOG.exception("failed to start the Noise PSK derivation")
 
     def _with_builtin_policies(self, chain: PolicyChain) -> PolicyChain:
         """Return ``chain`` with the non-removable builtin policies first.
@@ -1077,7 +1315,9 @@ class HiveMindListenerProtocol:
         msg = HiveMessage(HiveMessageType.HANDSHAKE, payload)
         LOG.debug(f"starting {client.peer} HANDSHAKE: {payload}")
         client.send(msg)
-        # the client answers with its first Noise message -> handle_handshake_message
+        # the client answers with its first Noise message -> handle_handshake_message;
+        # meanwhile derive its PSK so the two derivations overlap
+        self._prewarm_noise_psk(client)
 
     def update_last_seen(self, client: HiveMindClientConnection):
         """track timestamps of last client interaction"""
@@ -1102,6 +1342,7 @@ class HiveMindListenerProtocol:
                 self._last_seen_updates[client.key] = mono_now
 
     def handle_client_disconnected(self, client: HiveMindClientConnection):
+        client.disconnected = True
         try:
             self.callbacks.on_disconnect(client)
         except:
@@ -1561,6 +1802,10 @@ class HiveMindListenerProtocol:
         LOG.error(f"protocol v3 handshake with {client.peer} FAILED: {reason}")
         client.noise_handshake = None
         client.noise_transport = None
+        # the transport reports the close a few loop turns later; a PSK
+        # derivation parked on this connection must not resume in between
+        client.disconnected = True
+        client.noise_psk_pending = False
         self.handle_invalid_key_connected(client)
         client.disconnect(1008, reason)
 
@@ -1606,10 +1851,46 @@ class HiveMindListenerProtocol:
             name = noise_protocol_name(pattern, suite)
             prologue = build_prologue(client._hello_payload or {},
                                       client._handshake_payload or {}, name)
+            if client.noise_psk_pending:
+                # message 1 is parked on this connection already; a second
+                # frame is a client-controlled duplicate, rejected before it
+                # can start a handshake of its own
+                self._abort_noise_handshake(
+                    client, "unexpected HANDSHAKE frame while the Noise "
+                            "pre-shared key is being derived")
+                return
+            password = client.pswd_handshake.password
+            psk = self._cached_noise_psk(self._noise_psk_key(password), client)
+            if psk is None:
+                # Not known yet: derive off the IOLoop and park message 1
+                # until the key arrives, so argon2id never stalls the loop
+                # that serves every other connected client.
+                pending = self._derive_noise_psk_async(password, client)
+                if pending is not None:
+                    client.noise_psk_pending = True
+
+                    def _resume(done: asyncio.Future) -> None:
+                        if not client.noise_psk_pending:
+                            return  # aborted while parked
+                        client.noise_psk_pending = False
+                        if client.disconnected or client.noise_transport is not None \
+                                or client.noise_handshake is not None:
+                            return
+                        if done.cancelled() or done.exception() is not None:
+                            self._abort_noise_handshake(
+                                client, "handshake failure: the Noise "
+                                        "pre-shared key could not be derived")
+                            return
+                        self.handle_noise_handshake_message(message, client)
+
+                    pending.add_done_callback(_resume)
+                    return
+                # no event loop on this thread: derive inline
+                psk = self.noise_psk(password, client)
             try:
                 client.noise_handshake = start_noise_handshake(
                     initiator=False, pattern=pattern, suite=suite,
-                    psk=self.noise_psk(client.pswd_handshake.password),
+                    psk=psk,
                     password=None,
                     node_id=self._node_id, prologue=prologue,
                     key_path=self.identity.noise_key,

--- a/tests/test_noise_psk_off_loop.py
+++ b/tests/test_noise_psk_off_loop.py
@@ -1,0 +1,491 @@
+"""The Noise PSK is derived off the IOLoop and persisted in the client row.
+
+argon2id (time_cost=3, 64 MiB) costs ~750 ms on a half-core container and
+used to run inline in ``handle_noise_handshake_message`` on the single
+IOLoop thread serving every connected client: N first-time passwords after
+a restart meant N x 750 ms of frozen message delivery, serialized however
+many cores the node had. Now message 1 is parked while a worker thread
+derives the key, the derivation is started as soon as the offer goes out,
+and the key is stored in the client's database row (beside the TOFU pin, in
+the row that already holds the password it derives from) bound to the node
+id and password it was derived for, so a restart re-derives nothing for a
+client seen before and a stale key is simply not matched.
+"""
+import asyncio
+import dataclasses
+import json
+import threading
+import unittest
+from concurrent.futures import Future as ConcurrentFuture
+from types import SimpleNamespace
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from hivemind_bus_client import HiveMessage, HiveMessageType
+from hivemind_bus_client.noise import (
+    NOISE_PATTERN_XX,
+    NOISE_SUITES,
+    build_prologue,
+    noise_protocol_name,
+    start_noise_handshake,
+)
+
+import hivemind_core.protocol as protocol_module
+from hivemind_core.protocol import HiveMindClientConnection, HiveMindListenerProtocol
+
+NODE_ID = "node-A"
+SUITE = NOISE_SUITES[0]
+PSK = bytes(range(32))
+PASSWORD = "site-password"
+
+
+class _Row:
+    """A client row the way a database plugin hands it back."""
+
+    def __init__(self, metadata=None):
+        self.metadata = metadata
+
+
+class _Db:
+    def __init__(self, row):
+        self.row = row
+        self.updates = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def get_client_by_api_key(self, key):
+        return self.row
+
+    def update_item(self, user):
+        self.updates.append(dict(user.metadata or {}))
+
+
+class _ManualExecutor:
+    """A worker pool whose derivations the test completes by hand."""
+
+    def __init__(self):
+        self.pending = []
+
+    def submit(self, fn, *args, **kwargs):
+        future = ConcurrentFuture()
+        self.pending.append(future)
+        return future
+
+    def finish(self, index=0, result=PSK):
+        # from a thread, as a real worker would: the state copy is queued
+        # on the loop, the completion callbacks behind it
+        worker = threading.Thread(target=self.pending[index].set_result, args=(result,))
+        worker.start()
+        worker.join()
+
+
+def _make_protocol(row, node_id=NODE_ID):
+    agent = MagicMock()
+    agent.bus = MagicMock()
+    agent.callbacks = MagicMock()
+    proto = HiveMindListenerProtocol(agent_protocol=agent, db=_Db(row))
+    patcher = patch.object(HiveMindListenerProtocol, "_node_id",
+                           new_callable=PropertyMock, return_value=node_id)
+    patcher.start()
+    return proto, patcher
+
+
+def _make_client(proto, password=PASSWORD):
+    client = HiveMindClientConnection(
+        key="api-key", send_msg=MagicMock(), disconnect=MagicMock(),
+        hm_protocol=proto, pswd_handshake=SimpleNamespace(password=password))
+    client.name = "test-client"
+    client.send = MagicMock()
+    client._hello_payload = {"node_id": NODE_ID}
+    client._handshake_payload = {
+        "max_protocol_version": 3,
+        "noise": {"patterns": [NOISE_PATTERN_XX], "suites": [SUITE]}}
+    return client
+
+
+def _message_1(client, password=PASSWORD):
+    """A real initiator's Noise message 1 for ``client``'s offer."""
+    prologue = build_prologue(client._hello_payload, client._handshake_payload,
+                              noise_protocol_name(NOISE_PATTERN_XX, SUITE))
+    initiator = start_noise_handshake(
+        initiator=True, pattern=NOISE_PATTERN_XX, suite=SUITE,
+        password=password, node_id=NODE_ID, prologue=prologue)
+    msg = initiator.write_message(json.dumps({"binarize": False}).encode())
+    return initiator, HiveMessage(HiveMessageType.HANDSHAKE, {
+        "noise": {"pattern": NOISE_PATTERN_XX, "suite": SUITE, "msg": msg.hex()}})
+
+
+def _finish_handshake(proto, client, initiator):
+    (msg2,), _ = client.send.call_args
+    initiator.read_message(bytes.fromhex(msg2.payload["noise"]["msg"]))
+    proto.handle_noise_handshake_message(HiveMessage(HiveMessageType.HANDSHAKE, {
+        "noise": {"msg": initiator.write_message(b"").hex()}}), client)
+
+
+def _bound_row(proto, psk=PSK, password=PASSWORD, **extra):
+    metadata = {proto.NOISE_PSK_METADATA_KEY: psk.hex(),
+                proto.NOISE_PSK_BINDING_METADATA_KEY: proto._noise_psk_binding(
+                    password.encode("utf-8"))}
+    metadata.update(extra)
+    return _Row(metadata)
+
+
+async def _settle(turns=3):
+    for _ in range(turns):
+        await asyncio.sleep(0)
+
+
+class TestPersistedKey(unittest.TestCase):
+    def setUp(self):
+        self.row = _Row()
+        self.protocol, patcher = _make_protocol(self.row)
+        self.addCleanup(patcher.stop)
+
+    def test_a_key_persisted_in_the_row_is_used_without_deriving(self):
+        self.row.metadata = _bound_row(self.protocol).metadata
+        with patch.object(protocol_module, "derive_psk") as derive:
+            psk = self.protocol.noise_psk(PASSWORD, _make_client(self.protocol))
+        derive.assert_not_called()
+        self.assertEqual(psk, PSK)
+
+    def test_a_derived_key_is_persisted_beside_the_pin_with_its_binding(self):
+        self.row.metadata = {"noise_pubkey": "pinned"}
+        with patch.object(protocol_module, "derive_psk", return_value=PSK):
+            self.protocol.noise_psk(PASSWORD, _make_client(self.protocol))
+        self.assertEqual(self.protocol.db.updates, [{
+            "noise_pubkey": "pinned", "noise_psk": PSK.hex(),
+            "noise_psk_for": self.protocol._noise_psk_binding(PASSWORD.encode())}])
+
+    def test_a_key_bound_to_another_node_id_is_not_matched(self):
+        with patch.object(HiveMindListenerProtocol, "_node_id",
+                          new_callable=PropertyMock, return_value="node-B"):
+            self.row.metadata = _bound_row(self.protocol).metadata  # bound to node-B
+        with patch.object(protocol_module, "derive_psk", return_value=b"x" * 32) as derive:
+            psk = self.protocol.noise_psk(PASSWORD, _make_client(self.protocol))
+        derive.assert_called_once()
+        self.assertEqual(psk, b"x" * 32)
+
+    def test_a_key_bound_to_another_password_is_not_matched(self):
+        """The password changed under a persisted key: the binding says so,
+        deterministically, before any handshake is attempted."""
+        self.row.metadata = _bound_row(self.protocol, password="old-password").metadata
+        with patch.object(protocol_module, "derive_psk", return_value=b"y" * 32) as derive:
+            psk = self.protocol.noise_psk(PASSWORD, _make_client(self.protocol))
+        derive.assert_called_once()
+        self.assertEqual(psk, b"y" * 32)
+        # and the row now carries the key for the current password
+        self.assertEqual(self.row.metadata["noise_psk"], (b"y" * 32).hex())
+
+    def test_malformed_persisted_values_are_ignored(self):
+        binding = self.protocol._noise_psk_binding(PASSWORD.encode())
+        for bad in ("zz", "ab" * 31, 42, None, ["ab" * 32]):
+            self.row.metadata = {"noise_psk": bad, "noise_psk_for": binding}
+            self.protocol._noise_psks.clear()
+            with patch.object(protocol_module, "derive_psk", return_value=b"y" * 32) as derive:
+                self.protocol.noise_psk(PASSWORD, _make_client(self.protocol))
+            derive.assert_called_once()
+
+    def test_a_row_whose_metadata_is_not_a_dict_is_tolerated(self):
+        self.row.metadata = "not a dict"
+        with patch.object(protocol_module, "derive_psk", return_value=PSK):
+            psk = self.protocol.noise_psk(PASSWORD, _make_client(self.protocol))
+        self.assertEqual(psk, PSK)
+        self.assertEqual(self.row.metadata["noise_psk"], PSK.hex())
+
+    def test_a_row_without_a_key_gets_one_on_a_memory_hit(self):
+        with patch.object(protocol_module, "derive_psk", return_value=PSK):
+            self.protocol.noise_psk(PASSWORD, _make_client(self.protocol))
+        other_row = _Row()
+        self.protocol.db.row = other_row
+        other = _make_client(self.protocol)
+        other.key = "other-api-key"
+        with patch.object(protocol_module, "derive_psk") as derive:
+            self.protocol.noise_psk(PASSWORD, other)
+        derive.assert_not_called()
+        self.assertEqual(other_row.metadata["noise_psk"], PSK.hex())
+
+    def test_a_node_with_the_wrong_password_causes_one_idempotent_write(self):
+        """The persisted value is a function of the row's own password, so a
+        peer that knows only the api key cannot make the node write anything
+        but the right key, and only once. (XXpsk2 mixes the PSK into message
+        2, so the wrong password fails on the node, not here.)"""
+        for _ in range(3):
+            client = _make_client(self.protocol)
+            initiator, message = _message_1(client, password="wrong-password")
+            self.protocol.handle_noise_handshake_message(message, client)
+            (msg2,), _ = client.send.call_args
+            with self.assertRaises(Exception):
+                initiator.read_message(bytes.fromhex(msg2.payload["noise"]["msg"]))
+        self.assertEqual(len(self.protocol.db.updates), 1)
+        self.assertEqual(self.row.metadata["noise_psk_for"],
+                         self.protocol._noise_psk_binding(PASSWORD.encode()))
+        self.assertEqual(len(self.protocol._noise_psks), 1)
+
+    def test_the_key_never_reaches_the_logs(self):
+        lines = []
+        with patch.object(protocol_module.LOG, "debug", lines.append), \
+                patch.object(protocol_module.LOG, "info", lines.append), \
+                patch.object(protocol_module.LOG, "warning", lines.append), \
+                patch.object(protocol_module.LOG, "error", lines.append), \
+                patch.object(protocol_module.LOG, "exception", lines.append):
+            self.protocol.noise_psk("very-secret-password", _make_client(self.protocol))
+        self.assertEqual(lines, [])
+
+
+class TestOffLoopHandshake(unittest.TestCase):
+    """With an event loop running, message 1 is parked, not derived inline.
+
+    The worker pool is replaced by one whose derivations the test completes
+    by hand, from a thread, exactly as a real worker's completion arrives:
+    nothing here depends on argon2's speed.
+    """
+
+    def setUp(self):
+        self.row = _Row({})
+        self.proto, patcher = _make_protocol(self.row)
+        self.addCleanup(patcher.stop)
+        self.executor = _ManualExecutor()
+        self.proto._noise_psk_executor = self.executor
+
+    def test_message_1_is_parked_and_completes_when_the_key_arrives(self):
+        client = _make_client(self.proto)
+        initiator, message = _message_1(client)
+        real_psk = protocol_module.derive_psk(PASSWORD.encode(), node_id=NODE_ID)
+
+        async def scenario():
+            self.proto.handle_noise_handshake_message(message, client)
+            # parked: nothing sent, nothing derived on this thread
+            self.assertTrue(client.noise_psk_pending)
+            client.send.assert_not_called()
+            self.assertIsNone(client.noise_handshake)
+            self.assertEqual(len(self.executor.pending), 1)
+            self.executor.finish(result=real_psk)
+            await self.proto._noise_psk_futures[(PASSWORD.encode(), NODE_ID)]
+            await _settle()
+
+        asyncio.run(scenario())
+        self.assertFalse(client.noise_psk_pending)
+        client.disconnect.assert_not_called()
+        # message 2 went out, the initiator finishes the handshake, the key
+        # was remembered and persisted
+        _finish_handshake(self.proto, client, initiator)
+        self.assertIsNotNone(client.noise_transport)
+        self.assertEqual(self.row.metadata["noise_psk"], real_psk.hex())
+        self.assertIn((PASSWORD.encode(), NODE_ID), self.proto._noise_psks)
+
+    def test_a_duplicate_frame_while_parked_is_rejected_even_if_the_key_arrived(self):
+        """The completion callback that fills the cache is queued separately
+        from the one that resumes the parked frame; a duplicate landing in
+        between must not start a second handshake off the cache."""
+        client = _make_client(self.proto)
+        _initiator, message = _message_1(client)
+
+        async def scenario():
+            self.proto.handle_noise_handshake_message(message, client)
+            self.assertTrue(client.noise_psk_pending)
+            self.proto._remember_noise_psk((PASSWORD.encode(), NODE_ID), PSK)  # the gap
+            self.proto.handle_noise_handshake_message(message, client)  # duplicate
+
+        asyncio.run(scenario())
+        client.disconnect.assert_called_once_with(1008, unittest.mock.ANY)
+        client.send.assert_not_called()
+
+    def test_concurrent_connections_share_one_derivation(self):
+        async def scenario():
+            futures = [self.proto._derive_noise_psk_async(PASSWORD, None) for _ in range(20)]
+            self.assertEqual(len({id(f) for f in futures}), 1)
+            self.executor.finish()
+            await futures[0]
+            await _settle()
+
+        asyncio.run(scenario())
+        self.assertEqual(len(self.executor.pending), 1)
+        self.assertIn((PASSWORD.encode(), NODE_ID), self.proto._noise_psks)
+
+    def test_the_offer_starts_the_derivation_that_message_1_then_shares(self):
+        client = _make_client(self.proto)
+        _initiator, message = _message_1(client)
+
+        async def scenario():
+            self.proto._prewarm_noise_psk(client)
+            self.assertEqual(len(self.executor.pending), 1)
+            self.proto.handle_noise_handshake_message(message, client)
+            self.assertTrue(client.noise_psk_pending)
+            self.assertEqual(len(self.executor.pending), 1, "message 1 joined the prewarm")
+            self.executor.finish()
+            await self.proto._noise_psk_futures[(PASSWORD.encode(), NODE_ID)]
+            await _settle()
+
+        asyncio.run(scenario())
+        self.assertFalse(client.noise_psk_pending)
+        self.assertEqual(client.send.call_count, 1)
+
+    def test_a_client_gone_while_deriving_is_not_resumed(self):
+        client = _make_client(self.proto)
+        _initiator, message = _message_1(client)
+
+        async def scenario():
+            self.proto.handle_noise_handshake_message(message, client)
+            self.assertTrue(client.noise_psk_pending)
+            self.proto.handle_client_disconnected(client)
+            self.executor.finish()
+            await self.proto._noise_psk_futures[(PASSWORD.encode(), NODE_ID)]
+            await _settle()
+
+        asyncio.run(scenario())
+        self.assertTrue(client.disconnected)
+        self.assertFalse(client.noise_psk_pending)
+        client.send.assert_not_called()
+
+    def test_an_abort_while_parked_does_not_resume_the_frame(self):
+        """The transport reports the close a few loop turns after the abort;
+        the parked frame must not run in between."""
+        client = _make_client(self.proto)
+        _initiator, message = _message_1(client)
+
+        async def scenario():
+            self.proto.handle_noise_handshake_message(message, client)
+            self.proto._abort_noise_handshake(client, "duplicate")
+            self.executor.finish()
+            await self.proto._noise_psk_futures[(PASSWORD.encode(), NODE_ID)]
+            await _settle()
+
+        asyncio.run(scenario())
+        client.send.assert_not_called()
+        self.assertFalse(client.noise_psk_pending)
+        client.disconnect.assert_called_once_with(1008, unittest.mock.ANY)
+
+    def test_a_failed_derivation_aborts_the_parked_handshake(self):
+        client = _make_client(self.proto)
+        _initiator, message = _message_1(client)
+
+        async def scenario():
+            self.proto.handle_noise_handshake_message(message, client)
+            worker = threading.Thread(
+                target=self.executor.pending[0].set_exception, args=(RuntimeError("argon2"),))
+            worker.start()
+            worker.join()
+            with self.assertRaises(RuntimeError):
+                await self.proto._noise_psk_futures[(PASSWORD.encode(), NODE_ID)]
+            await _settle()
+
+        with patch.object(protocol_module.LOG, "error") as error:
+            asyncio.run(scenario())
+        client.disconnect.assert_called_once_with(1008, unittest.mock.ANY)
+        client.send.assert_not_called()
+        self.assertTrue(any("RuntimeError" in str(c) for c in error.call_args_list))
+        self.assertFalse(any(PASSWORD in str(c) for c in error.call_args_list))
+
+    def test_without_a_loop_the_key_is_derived_inline(self):
+        self.proto._noise_psk_executor = None
+        client = _make_client(self.proto)
+        _initiator, message = _message_1(client)
+        self.proto.handle_noise_handshake_message(message, client)
+        self.assertFalse(client.noise_psk_pending)
+        self.assertEqual(client.send.call_count, 1)
+
+    def test_a_transport_thread_derives_inline_while_the_loop_serves_others(self):
+        """The MQTT transport calls in from its own thread with no running
+        loop while the websocket transport's loop is up: that path derives
+        inline and shares the same cache."""
+        results = []
+
+        def from_transport_thread():
+            with patch.object(protocol_module, "derive_psk", return_value=PSK):
+                results.append(self.proto.noise_psk(PASSWORD, _make_client(self.proto)))
+
+        async def scenario():
+            worker = threading.Thread(target=from_transport_thread)
+            worker.start()
+            while worker.is_alive():
+                await asyncio.sleep(0.01)
+
+        asyncio.run(scenario())
+        self.assertEqual(results, [PSK])
+        self.assertEqual(self.executor.pending, [], "nothing went through the pool")
+        self.assertIn((PASSWORD.encode(), NODE_ID), self.proto._noise_psks)
+
+    def test_a_future_from_a_closed_loop_is_replaced(self):
+        async def first():
+            self.proto._derive_noise_psk_async(PASSWORD, None)
+
+        async def second():
+            future = self.proto._derive_noise_psk_async(PASSWORD, None)
+            self.assertIs(future.get_loop(), asyncio.get_running_loop())
+
+        asyncio.run(first())  # the loop closes with the derivation unfinished
+        asyncio.run(second())
+        self.assertEqual(len(self.executor.pending), 2, "a fresh derivation was started")
+
+
+class TestCompletedFutureRace(unittest.TestCase):
+    """A worker finishes: the result is copied onto the asyncio future by a
+    queued call, and the completion callback is queued behind that. A same-key
+    caller landing between the two used to see ``done()`` and start a second
+    argon2 derivation, and the stale callback then evicted that replacement
+    so a third caller started yet another one."""
+
+    def test_a_caller_in_the_completion_gap_shares_the_finished_key(self):
+        proto, patcher = _make_protocol(_Row({}))
+        self.addCleanup(patcher.stop)
+        executor = _ManualExecutor()
+        proto._noise_psk_executor = executor
+        seen = {}
+
+        async def scenario():
+            loop = asyncio.get_running_loop()
+            first = proto._derive_noise_psk_async(PASSWORD, None)
+            self.assertFalse(first.done())
+            executor.finish()  # state copy queued; our caller queues behind it
+
+            def in_the_gap():
+                seen["first_done"] = first.done()
+                seen["second"] = proto._derive_noise_psk_async(PASSWORD, None)
+
+            loop.call_soon(in_the_gap)
+            await _settle(4)
+            # a later caller takes the handshake path's first step: the cache
+            seen["third"] = proto._cached_noise_psk((PASSWORD.encode(), NODE_ID), None)
+
+        asyncio.run(scenario())
+        self.assertTrue(seen["first_done"], "the gap was reproduced")
+        self.assertEqual(len(executor.pending), 1, "one derivation for three callers")
+        self.assertEqual(seen["second"].result(), PSK)
+        self.assertEqual(seen["third"], PSK)
+        self.assertEqual(proto._noise_psk_futures, {}, "no stale or orphaned entry")
+
+
+class TestBackingFields(unittest.TestCase):
+    def test_backing_fields_stay_out_of_init_and_repr(self):
+        fields = {f.name: f for f in dataclasses.fields(HiveMindListenerProtocol)}
+        for name in ("_noise_psk_executor", "_noise_psk_futures",
+                     "_noise_psk_persisted_keys", "_noise_psk_lock"):
+            self.assertFalse(fields[name].init, name)
+            self.assertFalse(fields[name].repr, name)
+
+    def test_a_failed_derivation_is_logged_without_the_password(self):
+        proto, patcher = _make_protocol(_Row({}))
+        self.addCleanup(patcher.stop)
+        lines = []
+
+        async def scenario():
+            with patch.object(protocol_module, "derive_psk",
+                              side_effect=RuntimeError("argon2 exploded")), \
+                    patch.object(protocol_module.LOG, "error", lines.append):
+                future = proto._derive_noise_psk_async("very-secret-password", None)
+                with self.assertRaises(RuntimeError):
+                    await future
+                await _settle()
+
+        asyncio.run(scenario())
+        self.assertEqual(len(lines), 1)
+        self.assertIn("RuntimeError", lines[0])
+        self.assertNotIn("very-secret-password", lines[0])
+        self.assertEqual(proto._noise_psks, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 via Claude Code — NOT human-reviewed. Verify before acting.

`derive_psk` (argon2id, time_cost 3, 64 MiB) runs inline in `handle_noise_handshake_message` on the IOLoop thread. Measured on a listener with a half-core CPU limit that is about 0.75 s per derivation, during which no other client receives a message, and handshakes serialize regardless of core count: a 100-client soak spent minutes in handshakes. The in-memory LRU only helps within one process lifetime, so every restart replays the whole storm.

Three changes, all inside the listener protocol. When the key is not cached, Noise message 1 is parked and a two-thread pool derives it (argon2-cffi releases the GIL); the parked frame resumes on the loop when the key arrives. Concurrent connections sharing a password share one derivation, including a caller that lands between a worker finishing and its completion callback running. A duplicate HANDSHAKE frame while parked is rejected before it can start a handshake of its own, and an abort or a disconnect while parked leaves the frame parked for good. A transport calling in from its own thread with no running loop (MQTT) keeps deriving inline; the memory cache is lock-protected because that thread and the IOLoop both reach it. The derivation also starts as soon as the HANDSHAKE offer goes out, since the node derives the same key on its side before it can send message 1, so the two overlap instead of serializing.

The key is persisted in the client row beside the TOFU pin as `metadata.noise_psk`, together with `metadata.noise_psk_for`, a digest of the node id and password it was derived for. A restart re-derives nothing for a client seen before, and a key persisted under a different password or node id simply does not match and is derived afresh, deterministically, without a failed handshake. The row already holds the password in the clear, so the digest widens nothing, but the key itself is password-equivalent for the v3 handshake: anything that redacts `password` when serializing a row must redact `metadata.noise_psk` the same way (nothing in this repository serializes metadata onto the wire or into `list-clients`). A peer that knows only the api key causes at most one idempotent write of the right key, since the value is a function of the row's own password. The row is read through the connection's existing short-lived cache rather than a second uncached lookup per connection. `reset-noise-pin` deliberately leaves the key alone; the pin and the key are independent. The pool is never shut down: the listener has no stop method, and at interpreter exit the workers finish their current derivation and drop the rest. No configuration is added; the first start after this change still derives at two-wide, and only later restarts are free.

Tests replace the worker pool with one whose derivations the test completes from a thread, so nothing depends on argon2's speed: message 1 parked with a real initiator and completed on arrival, the duplicate frame rejected even when the key arrived in the gap, shared derivation, the offer's derivation joined by message 1, a client gone or aborted while parked, a failed derivation aborting the handshake with the password absent from the log, the inline path from a transport thread while the loop runs, a future bound to a closed loop replaced, the completion-gap race, the persisted key used, written with its binding, unmatched for another node id or password, malformed values, a non-dict metadata, a wrong-password peer causing one write, and the dataclass backing fields kept out of `__init__` and `__repr__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Noise security key derivation now runs asynchronously, improving responsiveness during handshakes.
  * Concurrent requests can share in-progress derivation work.

* **Reliability**
  * Persisted security keys are validated against the connecting node and password before reuse.
  * Handshakes now handle duplicate, disconnected, failed, or already-established connections more safely.
  * Derivation failures are logged without exposing sensitive information.

* **Compatibility**
  * Previously persisted key data can be recovered or regenerated when malformed or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->