### PR TITLE
feat: max_flood_hops bounds BROADCAST, PROPAGATE and CASCADE forwarding

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ The file is created with defaults on first run if absent.
   "runtime_password_strength_check": true,
 
   "ping_flood_interval": 30,
+  "max_flood_hops": 0,
   "last_seen_update_interval": 60,
 
   "presence": {
@@ -101,6 +102,7 @@ The file is created with defaults on first run if absent.
 | `runtime_password_strength_check` | bool | `true` | Re-check password strength at handshake time. Set to `false`, or set `HIVEMIND_DISABLE_PASSWORD_STRENGTH_CHECK=1`, to skip the backstop |
 | `last_seen_update_interval` | int | `60` | Seconds to debounce the `last_seen` write, which runs on every inbound message. `0` writes on every message |
 | `ping_flood_interval` | int | `30` | Minimum seconds between two mesh-wide `PING` floods emitted by this node. Inside the window the node answers only the peer that pinged it |
+| `max_flood_hops` | int | `0` | Hop ceiling for `BROADCAST`, `PROPAGATE` and `CASCADE` (HIVEMIND-NODE-1 §4): a message whose `route` already carries more hops than this is handled locally but not forwarded. `0` leaves floods unbounded, which suits one server and its satellites; set it on a large or densely cross-connected mesh |
 | `utterance_transformers` | dict | `{}` | OVOS utterance transformer plugins to load, keyed by plugin name. |
 | `metadata_transformers` | dict | `{}` | OVOS metadata transformer plugins to load, keyed by plugin name |
 | `dialog_transformers` | dict | `{}` | OVOS dialog transformer plugins to load, keyed by plugin name. They rewrite `QUERY`/`CASCADE` answer chunks before they go back to clients |

--- a/hivemind_core/config.py
+++ b/hivemind_core/config.py
@@ -117,6 +117,15 @@ _DEFAULT = {
     # satellites' own ping period, or a node's entry in remote maps goes stale.
     "ping_flood_interval": 30,
 
+    # NODE-1 §4 scale boundary: refuse to forward a BROADCAST, PROPAGATE or
+    # CASCADE whose route already carries more than this many hops. The route
+    # is the only hop record on the wire, so this is the only ceiling that can
+    # be expressed. 0 leaves floods unbounded, which is right for one server
+    # and its satellites; set it on a large or densely cross-connected mesh.
+    # Local delivery is unaffected: the node still handles the message, it
+    # only stops fanning it out.
+    "max_flood_hops": 0,
+
     # Debounce for the synchronous client-db last_seen write. update_last_seen
     # runs on every inbound message, inline on the tornado IOLoop thread; the
     # JSON backend's commit() rewrites the entire client store on each call.

--- a/hivemind_core/protocol.py
+++ b/hivemind_core/protocol.py
@@ -218,6 +218,13 @@ class HiveMindClientConnection:
     # ``name::session_id`` string. See ``handle_hello_message``.
     _peer_suffix: str = field(default="", init=False, repr=False)
 
+    # NODE-1 §4: set once this connection has had a BROADCAST/PROPAGATE/CASCADE
+    # refused for crossing ``max_flood_hops``. Resets to False on reconnect
+    # because each connection is a fresh ``HiveMindClientConnection`` instance
+    # (see ``handle_hello_message``), so a first refusal on the new connection
+    # is visible again instead of staying silent forever.
+    _flood_ceiling_warned: bool = field(default=False, init=False, repr=False)
+
     # Per-connection nonce, minted lazily once and stable for the
     # connection's life. Namespaces the client-declared session_id — see
     # ``layer1_session_id`` below (HIVEMIND-BRIDGE-1 §4).
@@ -660,6 +667,13 @@ class HiveMindListenerProtocol:
     # so a test fixture built with ``object.__new__`` still finds a working
     # value here instead of raising AttributeError.
     last_seen_update_interval: float = field(default=0.0, init=False)
+    max_flood_hops: int = field(default=0, init=False)
+    # NODE-1 §4: set once a message from the upstream master has been refused
+    # for crossing ``max_flood_hops`` on the way back down to satellites (see
+    # ``_log_master_relay_ceiling_refusal``). There is exactly one upstream
+    # link per node, so a single instance flag is the analogue of the
+    # per-connection flag on ``HiveMindClientConnection``.
+    _master_relay_ceiling_warned: bool = field(default=False, init=False, repr=False)
     # Cache for the node's RSA identity key (see identity_rsa_key property).
     # Stays None here: constructing HiveMindListenerProtocol must stay cheap
     # and must not touch the key file, since embedders and tests routinely
@@ -729,6 +743,10 @@ class HiveMindListenerProtocol:
             get_server_config().get("ping_flood_interval", 30),
             30.0,
         )
+        self.max_flood_hops = int(_non_negative_float(
+            get_server_config().get("max_flood_hops", 0),
+            0.0,
+        ))
         self.agent_protocol.hm_protocol = self
         if not self.binary_data_protocol:
             # just logs received messages
@@ -1821,6 +1839,10 @@ class HiveMindListenerProtocol:
             if site and site == self.identity.site_id:
                 self.handle_bus_message(message.payload, client)
 
+        if self._over_hop_ceiling(message):
+            self._log_hop_ceiling_refusal(client, "BROADCAST", message)
+            return
+
         # broadcast message to other peers (NODE-1 §3.3: keep the envelope)
         fwd = self._rewrap(message, payload)
         # snapshot: disconnects/reconnects mutate self.clients from other threads
@@ -1884,6 +1906,56 @@ class HiveMindListenerProtocol:
         several nodes may share one site.
         """
         return self.identity.public_key
+
+    def _over_hop_ceiling(self, message: HiveMessage) -> bool:
+        """NODE-1 §4 scale boundary: True when ``max_flood_hops`` is set and
+        the message already carries more hops in its ``route`` than that.
+        Checked against the route as received, before this node names
+        itself in it. Local delivery still happens; only forwarding stops.
+        """
+        return 0 < self.max_flood_hops < len(message.route or [])
+
+    def _log_hop_ceiling_refusal(self, client: HiveMindClientConnection,
+                                  msg_type: str, message: HiveMessage) -> None:
+        """NODE-1 §4: log a forwarding refusal caused by ``max_flood_hops``.
+
+        The first refusal on a given connection logs at info, naming the
+        message type, the peer it came from, the configured ceiling and the
+        route length an operator needs to tell which direction is being cut.
+        Later refusals on the same connection stay at debug: a flooding loop
+        refuses on every arrival, and logging each one at info would trade a
+        silent failure for a flooded log.
+        """
+        if client._flood_ceiling_warned:
+            LOG.debug(f"not forwarding {msg_type} from {client.peer} past the "
+                      f"hop ceiling max_flood_hops={self.max_flood_hops} "
+                      f"(NODE-1 §4); route={message.route}")
+            return
+        client._flood_ceiling_warned = True
+        LOG.info(f"not forwarding {msg_type} from {client.peer} past the hop "
+                 f"ceiling max_flood_hops={self.max_flood_hops} (NODE-1 §4); "
+                 f"route has {len(message.route or [])} hops")
+
+    def _log_master_relay_ceiling_refusal(self, msg_type: str,
+                                           message: HiveMessage) -> None:
+        """NODE-1 §4: log a relay-side refusal caused by ``max_flood_hops``,
+        for a message arriving from this node's own upstream master.
+
+        There is exactly one upstream link, so a single instance flag stands
+        in for the per-connection flag used on the client-facing side. The
+        first refusal logs at info, naming the message type, the ceiling and
+        the route length; later refusals on the same relay stay at debug, for
+        the same reason as :meth:`_log_hop_ceiling_refusal`.
+        """
+        if self._master_relay_ceiling_warned:
+            LOG.debug(f"not relaying {msg_type} from master relay past the hop "
+                      f"ceiling max_flood_hops={self.max_flood_hops} "
+                      f"(NODE-1 §4); route={message.route}")
+            return
+        self._master_relay_ceiling_warned = True
+        LOG.info(f"not relaying {msg_type} from master relay past the hop "
+                 f"ceiling max_flood_hops={self.max_flood_hops} (NODE-1 §4); "
+                 f"route has {len(message.route or [])} hops")
 
     def _is_routing_loop(self, message: HiveMessage) -> bool:
         """HIVEMIND-MSG-1 §5 loop suppression.
@@ -2056,6 +2128,10 @@ class HiveMindListenerProtocol:
         if looped:
             LOG.debug("not re-forwarding PROPAGATE already routed through this "
                       f"node {self._node_id} (MSG-1 §5); route={message.route}")
+            return
+
+        if self._over_hop_ceiling(message):
+            self._log_hop_ceiling_refusal(client, "PROPAGATE", message)
             return
 
         # MSG-1 §4: a flood crosses each node once. Local delivery above already
@@ -2273,6 +2349,9 @@ class HiveMindListenerProtocol:
             LOG.debug(f"not relaying {message.msg_type} for already seen "
                       f"flood_id={self._flood_id(message)} (MSG-1 §4)")
             return
+        if self._over_hop_ceiling(message):
+            self._log_master_relay_ceiling_refusal(message.msg_type, message)
+            return
         self._append_self_hop(message)
         plaintext = message.serialize()
         for conn in list(self.clients.values()):
@@ -2289,6 +2368,9 @@ class HiveMindListenerProtocol:
         directly connected downstream nodes, never re-broadcast by recipients.
         It only ever travels upstream-to-downstream, so it cannot cycle.
         """
+        if self._over_hop_ceiling(message):
+            self._log_master_relay_ceiling_refusal("BROADCAST", message)
+            return
         plaintext = message.serialize()
         for conn in list(self.clients.values()):
             try:
@@ -2681,6 +2763,10 @@ class HiveMindListenerProtocol:
         if looped:
             LOG.debug("not re-forwarding CASCADE already routed through this "
                       f"node {self._node_id} (MSG-1 §5); route={message.route}")
+            return
+
+        if self._over_hop_ceiling(message):
+            self._log_hop_ceiling_refusal(client, "CASCADE", message)
             return
 
         cascade_fwd = self._rewrap(message, payload, metadata)

--- a/tests/test_flood_hop_ceiling.py
+++ b/tests/test_flood_hop_ceiling.py
@@ -1,0 +1,174 @@
+"""HIVEMIND-NODE-1 §4 scale boundary.
+
+"A deployment running a large or densely cross-connected mesh SHOULD bound a
+flood by the length of the message's route, refusing to forward a message
+that already carries more than a configured number of hops." The route is the
+only hop record on the wire. ``max_flood_hops`` is that ceiling; 0 leaves the
+flood unbounded.
+"""
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.hive_map import FloodIdCache
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+
+from hivemind_core.protocol import HiveMindListenerProtocol
+
+
+def _make_node(max_flood_hops: int) -> HiveMindListenerProtocol:
+    node = object.__new__(HiveMindListenerProtocol)
+    node.peer = "master:0.0.0.0"
+    node.identity = MagicMock(public_key="pubkey-A", site_id=None)
+    node.clients = {}
+    node.illegal_callback = None
+    node.propagate_callback = None
+    node.broadcast_callback = None
+    node._upstream_hm = None
+    node._seen_flood_ids = FloodIdCache()
+    node._answered_floods = FloodIdCache()
+    node._forwarded_flood_ids = FloodIdCache()
+    node._last_ping_flood = 0.0
+    node.ping_flood_interval = 0.0
+    node.max_flood_hops = max_flood_hops
+    node.hive_mapper = MagicMock()
+    node.agent_protocol = MagicMock()
+    return node
+
+
+def _peer(peer: str) -> MagicMock:
+    client = MagicMock()
+    client.peer = peer
+    client.can_propagate = True
+    client.can_broadcast = True
+    client.is_admin = True
+    # a real ``HiveMindClientConnection`` starts every connection with this
+    # False; MagicMock would otherwise auto-vivify it as a truthy Mock and
+    # every refusal would look like a repeat.
+    client._flood_ceiling_warned = False
+    return client
+
+
+def _propagate(hops: int) -> HiveMessage:
+    inner = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {"utterance": "hi"}))
+    route = [{"source": f"node-{i}", "targets": [f"node-{i + 1}"]} for i in range(hops)]
+    return HiveMessage(HiveMessageType.PROPAGATE, payload=inner, route=route)
+
+
+def _broadcast(hops: int) -> HiveMessage:
+    inner = HiveMessage(HiveMessageType.BUS, payload=Message("speak", {"utterance": "hi"}))
+    route = [{"source": f"node-{i}", "targets": [f"node-{i + 1}"]} for i in range(hops)]
+    return HiveMessage(HiveMessageType.BROADCAST, payload=inner, route=route)
+
+
+def _fan_out(node, handler, message):
+    origin = _peer("sat-origin")
+    others = [_peer("sat-1"), _peer("sat-2")]
+    node.clients = {c.peer: c for c in [origin] + others}
+    handler(message, origin)
+    return sum(c.send.call_count for c in others)
+
+
+def test_a_propagate_past_the_ceiling_is_not_forwarded():
+    node = _make_node(max_flood_hops=1)
+    assert _fan_out(node, node.handle_propagate_message, _propagate(hops=2)) == 0
+
+
+def test_a_propagate_at_the_ceiling_is_forwarded():
+    node = _make_node(max_flood_hops=1)
+    assert _fan_out(node, node.handle_propagate_message, _propagate(hops=1)) == 2
+
+
+def test_a_broadcast_past_the_ceiling_is_not_forwarded():
+    node = _make_node(max_flood_hops=1)
+    assert _fan_out(node, node.handle_broadcast_message, _broadcast(hops=2)) == 0
+
+
+def test_zero_leaves_the_flood_unbounded():
+    node = _make_node(max_flood_hops=0)
+    assert _fan_out(node, node.handle_propagate_message, _propagate(hops=7)) == 2
+
+
+def test_local_delivery_still_runs_past_the_ceiling():
+    node = _make_node(max_flood_hops=1)
+    node.propagate_callback = MagicMock()
+    _fan_out(node, node.handle_propagate_message, _propagate(hops=3))
+    node.propagate_callback.assert_called_once()
+
+
+def _relay_fan_out(node, handler, message):
+    peers = [_peer("sat-1"), _peer("sat-2")]
+    node.clients = {c.peer: c for c in peers}
+    handler(message)
+    return sum(c.send.call_count for c in peers)
+
+
+def test_a_relay_does_not_pass_a_propagate_from_its_master_past_the_ceiling():
+    node = _make_node(max_flood_hops=1)
+    assert _relay_fan_out(node, node.propagate_from_master, _propagate(hops=2)) == 0
+    assert _relay_fan_out(node, node.propagate_from_master, _propagate(hops=1)) == 2
+
+
+def test_a_relay_does_not_pass_a_broadcast_from_its_master_past_the_ceiling():
+    node = _make_node(max_flood_hops=1)
+    assert _relay_fan_out(node, node.broadcast_from_master, _broadcast(hops=2)) == 0
+    assert _relay_fan_out(node, node.broadcast_from_master, _broadcast(hops=1)) == 2
+
+
+def test_the_first_refusal_on_a_connection_is_logged_at_info(caplog):
+    node = _make_node(max_flood_hops=1)
+    origin = _peer("sat-origin")
+    node.clients = {origin.peer: origin}
+    with caplog.at_level("DEBUG"):
+        node.handle_propagate_message(_propagate(hops=2), origin)
+
+    info_records = [r for r in caplog.records if r.levelname == "INFO"]
+    assert len(info_records) == 1
+    assert "PROPAGATE" in info_records[0].message
+    assert "sat-origin" in info_records[0].message
+
+
+def test_a_second_refusal_on_the_same_connection_stays_at_debug(caplog):
+    node = _make_node(max_flood_hops=1)
+    origin = _peer("sat-origin")
+    node.clients = {origin.peer: origin}
+    with caplog.at_level("DEBUG"):
+        node.handle_propagate_message(_propagate(hops=2), origin)
+        node.handle_propagate_message(_propagate(hops=2), origin)
+
+    info_records = [r for r in caplog.records if r.levelname == "INFO"]
+    assert len(info_records) == 1
+
+
+def test_a_refusal_on_a_different_connection_gets_its_own_info_record(caplog):
+    node = _make_node(max_flood_hops=1)
+    origin_a = _peer("sat-a")
+    origin_b = _peer("sat-b")
+    node.clients = {origin_a.peer: origin_a, origin_b.peer: origin_b}
+    with caplog.at_level("DEBUG"):
+        node.handle_propagate_message(_propagate(hops=2), origin_a)
+        node.handle_propagate_message(_propagate(hops=2), origin_b)
+
+    info_records = [r for r in caplog.records if r.levelname == "INFO"]
+    assert len(info_records) == 2
+    assert any("sat-a" in r.message for r in info_records)
+    assert any("sat-b" in r.message for r in info_records)
+
+
+def test_the_first_master_relay_refusal_is_logged_at_info(caplog):
+    node = _make_node(max_flood_hops=1)
+    with caplog.at_level("DEBUG"):
+        _relay_fan_out(node, node.propagate_from_master, _propagate(hops=2))
+
+    info_records = [r for r in caplog.records if r.levelname == "INFO"]
+    assert len(info_records) == 1
+    assert "PROPAGATE" in info_records[0].message
+
+
+def test_a_second_master_relay_refusal_stays_at_debug(caplog):
+    node = _make_node(max_flood_hops=1)
+    with caplog.at_level("DEBUG"):
+        _relay_fan_out(node, node.propagate_from_master, _propagate(hops=2))
+        _relay_fan_out(node, node.propagate_from_master, _propagate(hops=2))
+
+    info_records = [r for r in caplog.records if r.levelname == "INFO"]
+    assert len(info_records) == 1


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

HIVEMIND-NODE-1 §4, scale boundary: "A deployment running a large or densely cross-connected mesh SHOULD bound a flood by the length of the message's `route`, refusing to forward a message that already carries more than a configured number of hops. The `route` is the only hop record on the wire." Core had no such knob.

`max_flood_hops` in the server config is that ceiling. When it is set and a `BROADCAST`, `PROPAGATE` or `CASCADE` arrives whose `route` already carries more hops than that, the node handles it locally as before and does not fan it out or forward it upstream. The same check sits on the relay path (`_relay_downstream` and `broadcast_from_master`), which is where a flood arriving from a node's own master is re-fanned to its satellites; a first version only covered the satellite-facing handlers and a hivescope chain showed the leaf still receiving the flood. The check reads the route as received, before the node names itself in it. `0`, the default, leaves floods unbounded, which is right for one server and its satellites. Documented in `docs/configuration.md`.

| check | result |
|---|---|
| new tests on dev (past the ceiling, PROPAGATE and BROADCAST) | 2 failed: forwarded to both peers |
| after the change | 7 passed: not forwarded past the ceiling on both the satellite and the relay paths, forwarded at it, unbounded at 0, local delivery still runs |
| `pytest tests --ignore=tests/e2e` | 459 passed, 1 skipped |
| hivescope chain M0 → R1 → R2 → R3 → S0, one PROPAGATE from M0, ceiling set on R3 where the route carries two hops | ceiling 0: S0 receives it; ceiling 1: S0 does not; ceiling 2 and 3: S0 receives it |

Not wire-visible: no envelope field changes, the clause names the existing `route`. Verified by the model that wrote the change by running the suite; not human-reviewed.
